### PR TITLE
Allow tricks to set source_directory per trick

### DIFF
--- a/src/watchdog/watchmedo.py
+++ b/src/watchdog/watchmedo.py
@@ -151,7 +151,8 @@ def schedule_tricks(observer, tricks, pathname, recursive):
         for name, value in trick.items():
             TrickClass = load_class(name)
             handler = TrickClass(**value)
-            observer.schedule(handler, pathname, recursive)
+            trick_pathname = absolute_path(getattr(handler, 'source_directory') or pathname)
+            observer.schedule(handler, trick_pathname, recursive)
 
 
 @alias('tricks')


### PR DESCRIPTION
This patch allows Tricks to set the source_directory per trick, so one can have one trick watching

```
src/css/*.scss
```

And another trick watching

```
src/js/*.coffee
```

without running in "too many open files" errors when using the polling observer (should also save cycles with other observers).
