### PR TITLE
Add "-w/--wait" option to shell-command to wait for the shell command to finish

### DIFF
--- a/src/watchdog/tricks/__init__.py
+++ b/src/watchdog/tricks/__init__.py
@@ -67,9 +67,10 @@ class LoggerTrick(Trick):
 
 class ShellCommandTrick(Trick):
     """Execeutes shell commands in response to matched events."""
-    def __init__(self, shell_command=None, patterns=None, ignore_patterns=None, ignore_directories=False):
+    def __init__(self, shell_command=None, patterns=None, ignore_patterns=None, ignore_directories=False, wait_for_process=False):
         super(ShellCommandTrick, self).__init__(patterns, ignore_patterns, ignore_directories)
         self.shell_command = shell_command
+        self.wait_for_process = wait_for_process
 
     def on_any_event(self, event):
         from string import Template
@@ -97,4 +98,7 @@ class ShellCommandTrick(Trick):
             command = self.shell_command
 
         command = Template(command).safe_substitute(**context)
-        subprocess.Popen(command, shell=True)
+        process = subprocess.Popen(command, shell=True)
+        if self.wait_for_process:
+            process.wait()
+

--- a/src/watchdog/watchmedo.py
+++ b/src/watchdog/watchmedo.py
@@ -403,6 +403,10 @@ Example option usage::
      dest='timeout',
      default=1.0,
      help='use this as the polling interval/blocking timeout')
+@arg('-w', '--wait',
+     dest='wait_for_process',
+     action='store_true',
+     default=False)
 def shell_command(args):
     """
     Subcommand to execute shell commands in response to file system events.
@@ -421,7 +425,8 @@ def shell_command(args):
     handler = ShellCommandTrick(shell_command=args.command,
                                 patterns=patterns,
                                 ignore_patterns=ignore_patterns,
-                                ignore_directories=args.ignore_directories)
+                                ignore_directories=args.ignore_directories,
+                                wait_for_process=args.wait_for_process)
     observer = Observer(timeout=args.timeout)
     observe_with(observer, handler, args.directories, args.recursive)
 


### PR DESCRIPTION
This prevents multiple executions of the same tool concurrently for consecutive events, which can mess up the output
