### PR TITLE
OrderedSetQueue.put is broken

### DIFF
--- a/src/watchdog/utils/bricks.py
+++ b/src/watchdog/utils/bricks.py
@@ -95,7 +95,7 @@ class OrderedSetQueue(queue.Queue):
         if item not in self._set_of_items:
             queue.Queue._put(self, item)
             self._set_of_items.add(item)
-         else:
+        else:
             # `put` increments `unfinished_tasks` even if we did not put
             # anything into the queue here
             self.unfinished_tasks -= 1


### PR DESCRIPTION
The implementation of OrderedSetQueue is broken. `Queue.put` will increase `unfinished_tasks` by 1, whether `_put` actually puts an item in the queue or not. This causes `join` to lock on an empty queue. Test case:

``` python
>>> from watchdog.utils.bricks import OrderedSetQueue as Queue
>>> q=Queue()
>>> q.put(1)
>>> q.put(1)
>>> q.get()
1
>>> q.qsize()
0
>>> q.join()
[blocks …]
```

The fix here is a bit hacky. Maybe someone has one that is more pythonic.
