### PR TITLE
Renaming "scripts" to "tools"

### DIFF
--- a/tools/autobuild.sh
+++ b/tools/autobuild.sh
@@ -5,7 +5,7 @@
 # Public domain.
 #
 
-bin/python scripts/nosy.py .
+bin/python tools/nosy.py .
 
 
 

--- a/tools/nosy.py
+++ b/tools/nosy.py
@@ -114,7 +114,7 @@ if __name__ == "__main__":
             # with the source code, we erase all coverage information
             # before regenerating reports or running `nosetests`.
             "bin/coverage erase",
-            "bin/python-tests tests/run_tests.py",
+            "bin/python-tests ./run_tests.py",
             "bin/coverage html",
         ]
         command = '; '.join(commands)


### PR DESCRIPTION
Looks like a couple files still have references to the old directories. This commit updates autobuild.sh and nosy.py to address this.
