### PR TITLE
Minor update to hacking.rst: scripts/autobuild.sh moved

### DIFF
--- a/docs/source/hacking.rst
+++ b/docs/source/hacking.rst
@@ -59,7 +59,7 @@ nose_, and generate coverage_ reports.
 Start it by issuing this command in the ``watchdog`` directory
 checked out earlier::
 
-    $ scripts/autobuild.sh
+    $ tools/autobuild.sh
     ...
 
 Happy hacking!


### PR DESCRIPTION
scripts/autobuild.sh moved to tools/autobuild.sh. Update hacking.rst to reflect this.
