### PR TITLE
My fix for: https://github.com/gorakhargosh/watchdog/issues/77

### DIFF
--- a/src/watchdog/observers/api.py
+++ b/src/watchdog/observers/api.py
@@ -247,7 +247,11 @@ class EventDispatcher(DaemonThread):
             :class:`queue.Empty`
         """
         event, watch = event_queue.get(block=True, timeout=timeout)
-        self.dispatch_event(event, watch)
+        try:
+            self.dispatch_event(event, watch)
+        except KeyError:
+            # Watch was removed by another thread before we could emit the events.
+            pass
         event_queue.task_done()
 
     def on_thread_exit(self):


### PR DESCRIPTION
Handle the case where a watch could be deleted before the events were emitted.

I'm not sure what the implications of this are (i.e. if there is other cleanup that needs to occur in such a case), but this seems to work quite well for me.
