### PR TITLE
Allow quickstart code to run without arguments

### DIFF
--- a/README
+++ b/README
@@ -18,9 +18,10 @@ as command-line arguments and logs events generated::
         logging.basicConfig(level=logging.INFO,
                             format='%(asctime)s - %(message)s',
                             datefmt='%Y-%m-%d %H:%M:%S')
+        path = sys.argv[1] if len(sys.argv) > 1 else '.'
         event_handler = LoggingEventHandler()
         observer = Observer()
-        observer.schedule(event_handler, path=sys.argv[1], recursive=True)
+        observer.schedule(event_handler, path, recursive=True)
         observer.start()
         try:
             while True:

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -41,7 +41,7 @@ file system changes and simply log them to the console::
         logging.basicConfig(level=logging.INFO,
                             format='%(asctime)s - %(message)s',
                             datefmt='%Y-%m-%d %H:%M:%S')
-        path = sys.argv[1]
+        path = sys.argv[1] if len(sys.argv) > 1 else '.'
         event_handler = LoggingEventHandler()
         observer = Observer()
         observer.schedule(event_handler, path, recursive=True)


### PR DESCRIPTION
The path argument now overrides the default value of '.'
