### PR TITLE
Hotfix for Thread Safety

### DIFF
--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -140,7 +140,7 @@ if platform.is_darwin():
                             callback,
                             self.pathnames)
         _fsevents.read_events(self)
-      except Exception as e:
+      except Exception, e:
         pass
       finally:
         self.on_thread_exit()


### PR DESCRIPTION
This is a hotfix where someone forgot to add an except after a try, causing threading issues. My particular issue came from watchdog throwing thread safe errors while using Django's test suite.
