### PR TITLE
fixed some tests for windows, fixed directory move event for windows

### DIFF
--- a/src/watchdog/observers/read_directory_changes.py
+++ b/src/watchdog/observers/read_directory_changes.py
@@ -85,7 +85,7 @@ if platform.is_windows():
             dest_path = src_path
             src_path = last_renamed_src_path
 
-            if os.path.isdir(src_path):
+            if os.path.isdir(dest_path):
               event = DirMovedEvent(src_path, dest_path)
               if self.watch.is_recursive:
                 # HACK: We introduce a forced delay before

--- a/tests/test_watch_observers_winapi.py
+++ b/tests/test_watch_observers_winapi.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2011 Yesudeep Mangalapilly <yesudeep@gmail.com>
+# Copyright 2012 Google, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+import unittest2
+
+try:
+  import queue  # IGNORE:F0401
+except ImportError:
+  import Queue as queue  # IGNORE:F0401
+
+from time import sleep
+from tests.shell import\
+  mkdir,\
+  mkdtemp,\
+  touch,\
+  rm,\
+  mv
+
+from watchdog.events import DirModifiedEvent, DirCreatedEvent,\
+  FileCreatedEvent,\
+  FileMovedEvent, FileModifiedEvent, DirMovedEvent, FileDeletedEvent,\
+  DirDeletedEvent
+
+from watchdog.observers.api import ObservedWatch
+from watchdog.utils import platform
+
+if platform.is_windows():
+  from watchdog.observers.read_directory_changes import WindowsApiEmitter as Emitter
+
+  temp_dir = mkdtemp()
+
+  def p(*args):
+    """
+    Convenience function to join the temporary directory path
+    with the provided arguments.
+    """
+    return os.path.join(temp_dir, *args)
+
+  class TestWindowsApiEmitter(unittest2.TestCase):
+    def setUp(self):
+      self.event_queue = queue.Queue()
+      self.watch = ObservedWatch(temp_dir, True)
+      self.emitter = Emitter(self.event_queue, self.watch, timeout=0.2)
+
+    def teardown(self):
+      pass
+
+    def test___init__(self):
+      SLEEP_TIME = 1
+      self.emitter.start()
+      sleep(SLEEP_TIME)
+      mkdir(p('fromdir'))
+      sleep(SLEEP_TIME)
+      mv(p('fromdir'), p('todir'))
+      sleep(SLEEP_TIME)
+      self.emitter.stop()
+
+      # What we need here for the tests to pass is a collection type
+      # that is:
+      #   * unordered
+      #   * non-unique
+      # A multiset! Python's collections.Counter class seems appropriate.
+      expected = set([
+        DirCreatedEvent(p('fromdir')),
+        DirMovedEvent(p('fromdir'),p('todir')),
+        ])
+      got = set()
+
+      while True:
+        try:
+          event, _ = self.event_queue.get_nowait()
+          got.add(event)
+        except queue.Empty:
+          break
+
+      print got
+      self.assertEqual(expected, got)

--- a/tests/test_watchdog_events.py
+++ b/tests/test_watchdog_events.py
@@ -17,11 +17,13 @@
 # limitations under the License.
 
 
+import os
 import unittest2
 import re
 
 from tests.utils import list_attributes
 from watchdog.utils import has_attribute
+from pathtools.path import absolute_path
 from pathtools.patterns import filter_paths
 from watchdog.events import\
   FileSystemEvent,\
@@ -287,30 +289,30 @@ class TestDirMovedEvent(unittest2.TestCase):
 
   def test_sub_moved_events(self):
     mock_walker_path = [
-      ('/path',
+      (absolute_path('/path'),
        ['ad', 'bd'],
        ['af', 'bf', 'cf']),
-      ('/path/ad',
+      (absolute_path('/path/ad'),
        [],
        ['af', 'bf', 'cf']),
-      ('/path/bd',
+      (absolute_path('/path/bd'),
        [],
        ['af', 'bf', 'cf']),
     ]
-    dest_path = '/path'
-    src_path = '/foobar'
+    dest_path = absolute_path('/path')
+    src_path = absolute_path('/foobar')
     expected_events = set([
-      DirMovedEvent('/foobar/ad', '/path/ad'),
-      DirMovedEvent('/foobar/bd', '/path/bd'),
-      FileMovedEvent('/foobar/af', '/path/af'),
-      FileMovedEvent('/foobar/bf', '/path/bf'),
-      FileMovedEvent('/foobar/cf', '/path/cf'),
-      FileMovedEvent('/foobar/ad/af', '/path/ad/af'),
-      FileMovedEvent('/foobar/ad/bf', '/path/ad/bf'),
-      FileMovedEvent('/foobar/ad/cf', '/path/ad/cf'),
-      FileMovedEvent('/foobar/bd/af', '/path/bd/af'),
-      FileMovedEvent('/foobar/bd/bf', '/path/bd/bf'),
-      FileMovedEvent('/foobar/bd/cf', '/path/bd/cf'),
+      DirMovedEvent(absolute_path('/foobar/ad'), absolute_path('/path/ad')),
+      DirMovedEvent(absolute_path('/foobar/bd'), absolute_path('/path/bd')),
+      FileMovedEvent(absolute_path('/foobar/af'), absolute_path('/path/af')),
+      FileMovedEvent(absolute_path('/foobar/bf'), absolute_path('/path/bf')),
+      FileMovedEvent(absolute_path('/foobar/cf'), absolute_path('/path/cf')),
+      FileMovedEvent(absolute_path('/foobar/ad/af'), absolute_path('/path/ad/af')),
+      FileMovedEvent(absolute_path('/foobar/ad/bf'), absolute_path('/path/ad/bf')),
+      FileMovedEvent(absolute_path('/foobar/ad/cf'), absolute_path('/path/ad/cf')),
+      FileMovedEvent(absolute_path('/foobar/bd/af'), absolute_path('/path/bd/af')),
+      FileMovedEvent(absolute_path('/foobar/bd/bf'), absolute_path('/path/bd/bf')),
+      FileMovedEvent(absolute_path('/foobar/bd/cf'), absolute_path('/path/bd/cf')),
       ])
     dir_moved_event = DirMovedEvent(src_path, dest_path)
 
@@ -728,30 +730,30 @@ class TestLoggingEventHandler(unittest2.TestCase):
 class TestGenerateSubMovedEventsFor(unittest2.TestCase):
   def test_generate_sub_moved_events_for(self):
     mock_walker_path = [
-      ('/path',
+      (absolute_path('/path'),
        ['ad', 'bd'],
        ['af', 'bf', 'cf']),
-      ('/path/ad',
+      (absolute_path('/path/ad'),
        [],
        ['af', 'bf', 'cf']),
-      ('/path/bd',
+      (absolute_path('/path/bd'),
        [],
        ['af', 'bf', 'cf']),
     ]
-    dest_path = '/path'
-    src_path = '/foobar'
+    dest_path = absolute_path('/path')
+    src_path = absolute_path('/foobar')
     expected_events = set([
-      DirMovedEvent('/foobar/ad', '/path/ad'),
-      DirMovedEvent('/foobar/bd', '/path/bd'),
-      FileMovedEvent('/foobar/af', '/path/af'),
-      FileMovedEvent('/foobar/bf', '/path/bf'),
-      FileMovedEvent('/foobar/cf', '/path/cf'),
-      FileMovedEvent('/foobar/ad/af', '/path/ad/af'),
-      FileMovedEvent('/foobar/ad/bf', '/path/ad/bf'),
-      FileMovedEvent('/foobar/ad/cf', '/path/ad/cf'),
-      FileMovedEvent('/foobar/bd/af', '/path/bd/af'),
-      FileMovedEvent('/foobar/bd/bf', '/path/bd/bf'),
-      FileMovedEvent('/foobar/bd/cf', '/path/bd/cf'),
+      DirMovedEvent(absolute_path('/foobar/ad'), absolute_path('/path/ad')),
+      DirMovedEvent(absolute_path('/foobar/bd'), absolute_path('/path/bd')),
+      FileMovedEvent(absolute_path('/foobar/af'), absolute_path('/path/af')),
+      FileMovedEvent(absolute_path('/foobar/bf'), absolute_path('/path/bf')),
+      FileMovedEvent(absolute_path('/foobar/cf'), absolute_path('/path/cf')),
+      FileMovedEvent(absolute_path('/foobar/ad/af'), absolute_path('/path/ad/af')),
+      FileMovedEvent(absolute_path('/foobar/ad/bf'), absolute_path('/path/ad/bf')),
+      FileMovedEvent(absolute_path('/foobar/ad/cf'), absolute_path('/path/ad/cf')),
+      FileMovedEvent(absolute_path('/foobar/bd/af'), absolute_path('/path/bd/af')),
+      FileMovedEvent(absolute_path('/foobar/bd/bf'), absolute_path('/path/bd/bf')),
+      FileMovedEvent(absolute_path('/foobar/bd/cf'), absolute_path('/path/bd/cf')),
       ])
 
     def _mock_os_walker(path):

--- a/tests/test_watchdog_observers_api.py
+++ b/tests/test_watchdog_observers_api.py
@@ -19,6 +19,8 @@
 import time
 import unittest2
 
+from pathtools.path import absolute_path
+
 from watchdog.observers.api import\
   BaseObserver,\
   EventEmitter,\
@@ -51,7 +53,7 @@ class TestObservedWatch(unittest2.TestCase):
 
   def test___repr__(self):
     observed_watch = ObservedWatch('/foobar', True)
-    self.assertEqual('<ObservedWatch: path=/foobar, is_recursive=True>',
+    self.assertEqual('<ObservedWatch: path=' + absolute_path('/foobar') + ', is_recursive=True>',
                      observed_watch.__repr__())
 
 


### PR DESCRIPTION
The directory move using the Windows Api checks if the action is a directory action by using src_path. But src_path doesn't exist anymore, so it should check dest_path instead.

I have a Windows 7 64-bit machine, running Python 2.7.2 x32

Also, several tests fail on windows because they expect forward slashes and Windows not to prepend C:/ or whatever drive letter in front of the path. Solved by feeding absolute paths to the tests.
