### PR TITLE
Linux - issue with symlinks

### DIFF
--- a/src/watchdog/observers/inotify.py
+++ b/src/watchdog/observers/inotify.py
@@ -238,6 +238,7 @@ if platform.is_linux():
     InotifyConstants.IN_CREATE,
     InotifyConstants.IN_DELETE,
     InotifyConstants.IN_DELETE_SELF,
+    InotifyConstants.IN_DONT_FOLLOW,
     ])
 
   class InotifyEvent(object):
@@ -627,6 +628,8 @@ if platform.is_linux():
         for root, dirnames, _ in os.walk(path):
           for dirname in dirnames:
             full_path = absolute_path(os.path.join(root, dirname))
+            if os.path.islink(full_path):
+              continue
             self._add_watch(full_path, mask)
 
     def _add_watch(self, path, mask):


### PR DESCRIPTION
Under linux with inotify, Watchdog currently sees symlinks to directories as traversable and can report changes on either the link or the original. It should work like rsync and most other utilities, where the normal behaviour is to treat the link as just a symlink file - changes should only be reported on them if something changes about the symlink itself (e.g. it is deleted or changes target) rather than changes to the linked files.
