### PR TITLE
Ignore -1 watch descriptor value.

### DIFF
--- a/src/watchdog/observers/inotify.py
+++ b/src/watchdog/observers/inotify.py
@@ -536,6 +536,8 @@ if platform.is_linux():
         event_list = []
         for wd, mask, cookie, name in Inotify._parse_event_buffer(
           event_buffer):
+          if wd == -1:
+              continue
           wd_path = self._path_for_wd[wd]
           src_path = absolute_path(os.path.join(wd_path, name))
           inotify_event = InotifyEvent(wd, mask, cookie, name,


### PR DESCRIPTION
If wd == -1 this code throws exception, so just ignore this value

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.6/dist-packages/watchdog/observers/api.py", line 196, in run
    self.queue_events(self.timeout)
  File "/usr/local/lib/python2.6/dist-packages/watchdog/observers/inotify.py", line 751, in queue_events
    inotify_events = self._inotify.read_events()
  File "/usr/local/lib/python2.6/dist-packages/watchdog/observers/inotify.py", line 541, in read_events
    wd_path = self._path_for_wd[wd]
KeyError: -1
```
