### PR TITLE
Require pathtools>=0.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ extra_args = dict(
 
 install_requires = ['PyYAML >=3.09',
                     'argh >=0.8.1',
-                    'pathtools']
+                    'pathtools >=0.1.1']
 if sys.version_info < (2, 7, 0):
 # argparse is merged into Python 2.7 in the Python 2x series
 # and Python 3.2 in the Python 3x series.


### PR DESCRIPTION
Hi,

The function `match_any_paths` is introduced in `pathtools 0.1.1`. I somehow managed to install `pathtools 0.1.0` and `watchmedo tricks` failed with an import error. 

This should ensure a compatible `pathtools` version.
