### PR TITLE
Fixed import error on windows xp

### DIFF
--- a/src/watchdog/observers/__init__.py
+++ b/src/watchdog/observers/__init__.py
@@ -50,7 +50,7 @@ except ImportError: # pragma: no cover
       except ImportError: # pragma: no cover
         try: # pragma: no cover
           from watchdog.observers.read_directory_changes import WindowsApiObserver as _Observer
-        except ImportError: # pragma: no cover
+        except (ImportError, AttributeError): # pragma: no cover
           from watchdog.observers.polling import PollingObserver as _Observer
 
 


### PR DESCRIPTION
Importing Observer on windows xp will throw AttributeError (because the CancelIoEx function isn't available in xp) instead of falling back to PollingObserver.
