### PR TITLE
inotify: recover from interrupted system call

### DIFF
--- a/src/watchdog/observers/inotify.py
+++ b/src/watchdog/observers/inotify.py
@@ -72,6 +72,7 @@ from watchdog.utils import platform
 
 if platform.is_linux():
   import os
+  import errno
   import struct
   import threading
   import ctypes
@@ -531,7 +532,14 @@ if platform.is_linux():
       """
       Reads events from inotify and yields them.
       """
-      event_buffer = os.read(self._inotify_fd, event_buffer_size)
+      while True:
+        try:
+          event_buffer = os.read(self._inotify_fd, event_buffer_size)
+        except OSError as e:
+          if e.errno == errno.EINTR:
+            continue
+        break
+      
       with self._lock:
         event_list = []
         for wd, mask, cookie, name in Inotify._parse_event_buffer(


### PR DESCRIPTION
When the thread is paused, e.g. when entering sleep mode, os.read will be interrupted first. Currently the script is not able to recover from that.
