### PR TITLE
Fix issue 129

### DIFF
--- a/src/watchdog/utils/__init__.py
+++ b/src/watchdog/utils/__init__.py
@@ -45,17 +45,13 @@ Classes
 import sys
 import threading
 
-try:
-  import ctypes.util
-  ctypes_available = True
-except ImportError:
-  ctypes_available = False
-
 
 def ctypes_find_library(name, default):
   """Finds a dynamic library."""
-  if not ctypes_available:
-    raise RuntimeError
+  try:
+    import ctypes.util
+  except ImportError:
+    raise RuntimeError('ctypes not available on this system')
   module_path = None
   try:
     module_path = ctypes.util.find_library(name)


### PR DESCRIPTION
If the ctypes module isn't available, the directory snapshot code should still work. Ticket following this issue is at https://github.com/gorakhargosh/watchdog/issues/129.
