### PR TITLE
make 'watchmedo tricks' accept a positional argument to watch other dir

### DIFF
--- a/src/watchdog/watchmedo.py
+++ b/src/watchdog/watchmedo.py
@@ -152,8 +152,12 @@ def schedule_tricks(observer, tricks, pathname, recursive):
 
 @alias('tricks')
 @arg('files',
-     nargs='*',
+     nargs=1,
      help='perform tricks from given file')
+@arg('directory',
+     nargs='?',
+     default=None,
+     help='directory to watch (instead of the location of tricks.yaml)')
 @arg('--python-path',
      default='.',
      help='paths separated by %s to add to the python path' % os.path.sep)
@@ -193,7 +197,7 @@ def tricks_from(args):
     if CONFIG_KEY_PYTHON_PATH in config:
       add_to_sys_path(config[CONFIG_KEY_PYTHON_PATH])
 
-    dir_path = parent_dir_path(tricks_file)
+    dir_path = args.directory or parent_dir_path(tricks_file)
     schedule_tricks(observer, tricks, dir_path, args.recursive)
     observer.start()
     observers.append(observer)


### PR DESCRIPTION
This provides an alternate mechanism for specifying what directory
should be watched for tricks.

tricks.yaml is a very valuable, user-friendly feature. However, many users
will want to keep it somewhere outside the project root, to keep it clean.
In addition, log and shell-command accept directory arguments and
specifying it is more explicit.

If an additional argument is not provided, you get the default behavior
of watching the directory containing the yaml file.
