### PR TITLE
Document implemented observer classes

### DIFF
--- a/src/watchdog/observers/__init__.py
+++ b/src/watchdog/observers/__init__.py
@@ -29,6 +29,26 @@ Classes
    :show-inheritance:
    :inherited-members:
 
+You can also import platform specific classes directly and use it instead
+of :class:`Observer`.  Here is a list of implemented observer classes.:
+
+============== ================================ ==============================
+Class          Platforms                        Note
+============== ================================ ==============================
+|Inotify|      Linux 2.6.13+                    ``inotify(7)`` based observer
+|FSEvents|     Mac OS X                         FSEvents based observer
+|Kqueue|       Mac OS X and BSD with kqueue(2)  ``kqueue(2)`` based observer
+|WinApi|       MS Windows                       Windows API-based observer
+|Polling|      Any                              fallback implementation
+============== ================================ ==============================
+
+.. |Inotify|     replace:: :class:`.inotify.InotifyObserver`
+.. |FSEvents|    replace:: :class:`.fsevents.FSEventsObserver`
+.. |Kqueue|      replace:: :class:`.kqueue.KqueueObserver`
+.. |WinApi|      replace:: :class:`.read_directory_changes.WindowsApiObserver`
+.. |WinApiAsync| replace:: :class:`.read_directory_changes_async.WindowsApiAsyncObserver`
+.. |Polling|     replace:: :class:`.polling.PollingObserver`
+
 """
 
 from watchdog.observers.api import BaseObserver, DEFAULT_OBSERVER_TIMEOUT


### PR DESCRIPTION
Sometimes it is useful to manually choose observer backend.  So I documented how to do that.

For example, when you are on NFS you'd want to use polling observer because it seems that inotify does not detect non-local changes.
