### PR TITLE
tests: Fix failing unittest test_watchdog_observers_polling.TestPollingE...

### DIFF
--- a/tests/test_watchdog_observers_polling.py
+++ b/tests/test_watchdog_observers_polling.py
@@ -112,7 +112,7 @@ class TestPollingEmitter(unittest2.TestCase):
       DirMovedEvent(p('project', 'blah'), p('project', 'boo')),
 
       DirModifiedEvent(p()),
-      FileDeletedEvent(p('project', 'boo')),
+      FileDeletedEvent(p('project', 'tofile')),
       DirDeletedEvent(p('project', 'boo')),
       DirDeletedEvent(p('project')),
 


### PR DESCRIPTION
...mitter

There was both a FileDeletedEvent and a DirDeletedEvent for the entry, just
keep the latter. Also add missing to_file entry.

This makes the test work on OS X (tested on 10.8.3) and Linux (tested on Ubuntu 12.10)
