### PR TITLE
read_directory_changes: On directory create check if it's actually a mov...

### DIFF
--- a/src/watchdog/observers/read_directory_changes.py
+++ b/src/watchdog/observers/read_directory_changes.py
@@ -46,7 +46,9 @@ if platform.is_windows():
     DEFAULT_OBSERVER_TIMEOUT,\
     DEFAULT_EMITTER_TIMEOUT
   from watchdog.events import\
+    DirCreatedEvent, \
     DirMovedEvent,\
+    FileCreatedEvent,\
     FileMovedEvent
 
 
@@ -104,14 +106,21 @@ if platform.is_windows():
                   self.queue_event(sub_moved_event)
               self.queue_event(event)
             else:
-              self.queue_event(FileMovedEvent(src_path,
-                                              dest_path))
+              self.queue_event(FileMovedEvent(src_path, dest_path))
           else:
             if os.path.isdir(src_path):
-              action_event_map = DIR_ACTION_EVENT_MAP
+              event = DIR_ACTION_EVENT_MAP[action](src_path)
+              if isinstance(event, DirCreatedEvent):
+                # If a directory is moved from outside the watched folder to inside it
+                # we only get a created directory event out of it, not any events for its children
+                # so use the same hack as for file moves to get the child events
+                time.sleep(WATCHDOG_TRAVERSE_MOVED_DIR_DELAY)
+                sub_events = _generate_sub_created_events_for(src_path)
+                for sub_created_event in sub_events:
+                  self.queue_event(sub_created_event)
+              self.queue_event(event)
             else:
-              action_event_map = FILE_ACTION_EVENT_MAP
-            self.queue_event(action_event_map[action](src_path))
+              self.queue_event(FILE_ACTION_EVENT_MAP[action](src_path))
 
 
   class WindowsApiObserver(BaseObserver):
@@ -124,3 +133,20 @@ if platform.is_windows():
       BaseObserver.__init__(self,
                             emitter_class=WindowsApiEmitter,
                             timeout=timeout)
+
+def _generate_sub_created_events_for(src_dir_path):
+  """Generates an event list of :class:`DirCreatedEvent` and :class:`FileCreatedEvent`
+  objects for all the files and directories within the given moved directory
+  that were moved along with the directory.
+
+  :param src_dir_path:
+      The source path of the created directory.
+  :returns:
+      An iterable of file system events of type :class:`DirCreatedEvent` and
+      :class:`FileCreatedEvent`.
+  """
+  for root, directories, filenames in os.walk(src_dir_path):
+    for directory in directories:
+      yield DirCreatedEvent(os.path.join(root, directory))
+    for filename in filenames:
+      yield FileCreatedEvent(os.path.join(root, filename))


### PR DESCRIPTION
...e

On Windows if a folder is moved from outside the watched folder to inside it. We only get a Directory Create from ReadDirectoryChangesW, no events for the directory's children. Create those events like we do for the directory rename case.
