### PR TITLE
A change to add try/catch block

### DIFF
--- a/src/watchdog/observers/inotify.py
+++ b/src/watchdog/observers/inotify.py
@@ -582,21 +582,24 @@ if platform.is_linux():
             # IN_MOVED_TO events which don't pair up with
             # IN_MOVED_FROM events should be marked IN_CREATE
             # instead relative to this directory.
-            self._add_watch(src_path, self._event_mask)
-            for root, dirnames, filenames in os.walk(src_path):
-              for dirname in dirnames:
-                full_path = absolute_path(
-                  os.path.join(root, dirname))
-                wd_dir = self._add_watch(full_path, self._event_mask)
-                event_list.append(InotifyEvent(wd_dir,
-                    InotifyConstants.IN_CREATE | InotifyConstants.IN_ISDIR,
-                    0, dirname, full_path))
-              for filename in filenames:
-                full_path = absolute_path(
-                  os.path.join(root, filename))
-                wd_parent_dir = self._wd_for_path[absolute_path(os.path.dirname(full_path))]
-                event_list.append(InotifyEvent(wd_parent_dir,
-                    InotifyConstants.IN_CREATE, 0, filename, full_path))
+            try:
+                self._add_watch(src_path, self._event_mask)
+                for root, dirnames, filenames in os.walk(src_path):
+                  for dirname in dirnames:
+                    full_path = absolute_path(
+                      os.path.join(root, dirname))
+                    wd_dir = self._add_watch(full_path, self._event_mask)
+                    event_list.append(InotifyEvent(wd_dir,
+                        InotifyConstants.IN_CREATE | InotifyConstants.IN_ISDIR,
+                        0, dirname, full_path))
+                  for filename in filenames:
+                    full_path = absolute_path(
+                      os.path.join(root, filename))
+                    wd_parent_dir = self._wd_for_path[absolute_path(os.path.dirname(full_path))]
+                    event_list.append(InotifyEvent(wd_parent_dir,
+                        InotifyConstants.IN_CREATE, 0, filename, full_path))
+            except OSError:
+                pass
       return event_list
 
 


### PR DESCRIPTION
I added this try/catch block in order to get watchdog working with dexy, which creates, moves and deletes temporary directories in a watched directory and so causes exceptions in watchdog. This try/catch fixes this issue for me.
