### PR TITLE
Windows: more graceful handling external deletion of watched folders

### DIFF
--- a/src/watchdog/observers/read_directory_changes.py
+++ b/src/watchdog/observers/read_directory_changes.py
@@ -134,6 +134,18 @@ class WindowsApiEmitter(EventEmitter):
                     else:
                         self.queue_event(FILE_ACTION_EVENT_MAP[action](src_path))
 
+    def run(self):
+        try:
+            while self.should_keep_running():
+                self.queue_events(self.timeout)
+        except WindowsError as error:
+            # Just exit quietly on 'Access denied' errors, which, incidentally,
+            # also might mean the watched folder was deleted externally.
+            if error.winerror == 5:
+                pass
+            else:
+                raise
+
 
 class WindowsApiObserver(BaseObserver):
 

--- a/src/watchdog/observers/winapi_common.py
+++ b/src/watchdog/observers/winapi_common.py
@@ -134,7 +134,11 @@ def read_directory_changes(handle, event_buffer, recursive):
                               ctypes.byref(nbytes),
                               None,
                               None)
-    except WindowsError:
+    except WindowsError as error:
+        # If the watched directory is deleted by an external process, the call
+        # fails with an 'Access denied' and it is pointless to continue watching.
+        if error.winerror == 5:
+            raise
         return [], 0
     # get_FILE_NOTIFY_INFORMATION expects nBytes to be long.
 


### PR DESCRIPTION
In case a watched folder is deleted ReadDirectoryChangesW() fails with an 'Access denied' (error code 5). In case of that error, it is better to let the event emitter thread die. Otherwise it goes into a busy-loop, polling the non-existant folder, eating 100% CPU.

Also in this patch, the error mentioned above is silenced in the main loop to avoid the tracebacks which can not be handled by the application anyway.

Though this pull request fixes the most important problem, in the future these kind of situations could be turned into events that the application could handle itself.
