### PR TITLE
Fix regression on Mac

### DIFF
--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -142,8 +142,6 @@ if platform.is_darwin():
         _fsevents.read_events(self)
       except Exception, e:
         pass
-      finally:
-        self.on_thread_exit()
 
 
   class FSEventsObserver(BaseObserver):


### PR DESCRIPTION
This reverts commit fe451b757e0864639752605c163ebb0d11efe492.

Great to see people are finally working on this repo and keeping up to date! Commit fe451b757e0864639752605c163ebb0d11efe492 resulted in the following error messages after calling `observer.stop()` in my code:

```
python[11364] (CarbonCore.framework) FSEventStreamStop(): failed assertion 'streamRef != NULL'
python[11364] (CarbonCore.framework) FSEventStreamInvalidate(): failed assertion 'streamRef != NULL'
python[11364] (CarbonCore.framework) FSEventStreamRelease(): failed assertion 'streamRef != NULL'
/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py:604: RuntimeWarning: tp_compare didn't return -1 or -2 for exception
  del _active[_get_ident()]
```

I'm using Mac OS X 10.8.4. Reverting the commit fixes the problem. I'm too tired right now to figure out exactly why the commit was causing problems. :)
