### PR TITLE
Readability, enable pygments highlighting in README.rst

### DIFF
--- a/README
+++ b/README
@@ -6,7 +6,9 @@ Python API and shell utilities to monitor file system events.
 Example API Usage
 -----------------
 A simple program that uses watchdog to monitor directories specified
-as command-line arguments and logs events generated::
+as command-line arguments and logs events generated:
+    
+.. code-block:: python
 
     import sys
     import time
@@ -39,7 +41,9 @@ know more about this tool.
 
 Here is how you can log the current directory recursively
 for events related only to ``*.py`` and ``*.txt`` files while
-ignoring all directory events::
+ignoring all directory events:
+    
+.. code-block:: bash
 
     watchmedo log \
         --patterns="*.py;*.txt" \
@@ -48,7 +52,9 @@ ignoring all directory events::
         .
 
 You can use the ``shell-command`` subcommand to execute shell commands in
-response to events::
+response to events:
+    
+.. code-block:: bash
 
     watchmedo shell-command \
         --patterns="*.py;*.txt" \
@@ -56,7 +62,9 @@ response to events::
         --command='echo "${watch_src_path}"' \
         .
 
-Please see the help information for these commands by typing::
+Please see the help information for these commands by typing:
+
+.. code-block:: bash
 
     watchmedo [command] --help
 
@@ -69,7 +77,9 @@ subclass ``watchdog.tricks.Trick`` and are written by plugin authors. Trick
 classes are augmented with a few additional features that regular event handlers
 don't need.
 
-An example ``tricks.yaml`` file::
+An example ``tricks.yaml`` file:
+    
+.. code-block:: yaml
 
     tricks:
     - watchdog.tricks.LoggerTrick:
@@ -103,17 +113,23 @@ Please file enhancement requests at the `issue tracker`_.
 
 Installation
 ------------
-Installing from PyPI using ``pip``::
+Installing from PyPI using ``pip``:
+    
+.. code-block:: bash
 
-    pip install watchdog
+    $ pip install watchdog
 
-Installing from PyPI using ``easy_install``::
+Installing from PyPI using ``easy_install``:
+    
+.. code-block:: bash
 
-    easy_install watchdog
+    $ easy_install watchdog
 
-Installing from source::
+Installing from source:
+    
+.. code-block:: bash
 
-    python setup.py install
+    $ python setup.py install
 
 
 Installation Caveats
@@ -121,14 +137,18 @@ Installation Caveats
 The ``watchmedo`` script depends on PyYAML_ which links with LibYAML_,
 which brings a performance boost to the PyYAML parser. However, installing
 LibYAML_ is optional but recommended. On Mac OS X, you can use homebrew_
-to install LibYAML::
+to install LibYAML:
 
-    brew install libyaml
+.. code-block:: bash
+
+    $ brew install libyaml
 
 On Linux, use your favorite package manager to install LibYAML. Here's how you
-do it on Ubuntu::
+do it on Ubuntu:
+    
+.. code-block:: bash
 
-    sudo aptitude install libyaml-dev
+    $ sudo aptitude install libyaml-dev
 
 On Windows, please install PyYAML_ using the binaries they provide.
 


### PR DESCRIPTION
Use the full `code` directive with the language option passed in to highlight code for python, bash and yaml.

See highlighting on https://github.com/tony/watchdog/tree/patch-1 for preview.
