### PR TITLE
Terminate all subprocesses

### DIFF
--- a/src/watchdog/tricks/__init__.py
+++ b/src/watchdog/tricks/__init__.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 
+import os
 import signal
 import subprocess
 import time
@@ -131,7 +132,7 @@ class AutoRestartTrick(Trick):
                  kill_after=10):
         super(AutoRestartTrick, self).__init__(
             patterns, ignore_patterns, ignore_directories)
-        self.command = command
+        self.command = ['setsid'] + command
         self.stop_signal = stop_signal
         self.kill_after = kill_after
         self.process = None
@@ -143,7 +144,7 @@ class AutoRestartTrick(Trick):
         if self.process is None:
             return
         try:
-            self.process.send_signal(self.stop_signal)
+            os.killpg(os.getpgid(self.process.pid), self.stop_signal)
         except OSError:
             # Process is already gone
             pass
@@ -155,7 +156,7 @@ class AutoRestartTrick(Trick):
                 time.sleep(0.25)
             else:
                 try:
-                    self.process.kill()
+                    os.killpg(os.getpgid(self.process.pid), 9)
                 except OSError:
                     # Process is already gone
                     pass


### PR DESCRIPTION
`auto-restart` won't terminate all children processes

```
 1e39bb6da6cffe8b  dario@macbook /tmp> cat file.py
from subprocess import call
call('python3 -m http.server'.split())
1e39bb6da6cffe8b  dario@macbook /tmp> 
watchmedo auto-restart -p /tmp/file.py python file.py
Serving HTTP on 0.0.0.0 port 8000 ...
on_any_event(self=<watchdog.tricks.AutoRestartTrick object at 0x2c7f450>, event=<FileModifiedEvent: src_path=/tmp/file.py>)
Traceback (most recent call last):
[SNIP]
OSError: [Errno 98] Address already in use
```

(I stumbled upon this problem with a [Warp](http://hackage.haskell.org/package/warp) server run through the `runhaskell` program, that spawns a `runghc` and a `ghc` process, the dummy file.py is only for your ease to reproduce it)

I'm not storing the result of `os.getpgid(self.process.pid)` because it could change during the execution
