### PR TITLE
Include the unit-tests with the sources released

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,6 +8,7 @@ include docs/*.xml
 include docs/Makefile
 include docs/make.bat
 recursive-include docs/source *
+recursive-include tests *
 #global-exclude .DS_Store
 #global-exclude Thumbs.db
 #global-exclude Desktop.ini


### PR DESCRIPTION
This way downstream packagers can run the check when packaging the
application.

Signed-off-by: Pierre-Yves Chibon pingou@pingoured.fr
