### PR TITLE
one-filesystem option, follow symlink option, improved dirsnapshot.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ htmlcov/
 include/
 lib/
 /bootstrap.py
+
+# tags
+tags

--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,4 @@ lib/
 /bootstrap.py
 
 # tags
-tags
+*tags

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the License is distributed on an "AS IS" BASIS, 
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.

--- a/src/watchdog/events.py
+++ b/src/watchdog/events.py
@@ -413,9 +413,8 @@ class PatternMatchingEventHandler(FileSystemEventHandler):
     """
 
     def __init__(self, patterns=None, ignore_patterns=None,
-                 ignore_directories=False, case_sensitive=False):
+            ignore_directories=False, case_sensitive=False):
         super(PatternMatchingEventHandler, self).__init__()
-
         self._patterns = patterns
         self._ignore_patterns = ignore_patterns
         self._ignore_directories = ignore_directories

--- a/src/watchdog/observers/api.py
+++ b/src/watchdog/observers/api.py
@@ -85,7 +85,9 @@ class ObservedWatch(object):
         ``True`` if watch is recursive; ``False`` otherwise.
     """
 
-    def __init__(self, path, **kw):
+    def __init__(self, path, *args, **kw):
+        if args:
+            kw["recursive"] = args[0]
         self._path = path
         self._is_recursive = kw.get("recursive", False)
         self._follow_symlinks = kw.get("recursive", True)
@@ -302,7 +304,7 @@ class BaseObserver(EventDispatcher):
         handlers = self._get_handlers_for_watch(watch)
         handlers.remove(handler)
 
-    def schedule(self, event_handler, path, **kw):
+    def schedule(self, event_handler, path, *args, **kw):
         """
         Schedules watching a path and calls appropriate methods specified
         in the given event handler in response to file system events.
@@ -327,7 +329,7 @@ class BaseObserver(EventDispatcher):
             a watch.
         """
         with self._lock:
-            watch = ObservedWatch(path, **kw)
+            watch = ObservedWatch(path, *args, **kw)
             self._add_handler_for_watch(event_handler, watch)
             try:
                 # If we have an emitter for this watch already, we don't create a

--- a/src/watchdog/observers/api.py
+++ b/src/watchdog/observers/api.py
@@ -90,7 +90,7 @@ class ObservedWatch(object):
             kw["recursive"] = args[0]
         self._path = path
         self._is_recursive = kw.get("recursive", False)
-        self._follow_symlinks = kw.get("recursive", True)
+        self._follow_symlinks = kw.get("follow_symlinks", True)
         self._dev_id = kw.get("dev_id", None)
 
     @property
@@ -112,6 +112,11 @@ class ObservedWatch(object):
     def dev_id(self):
         """return the dev_id we should only watch"""
         return self._dev_id
+
+    @property
+    def config_kw(self):
+        """return the dev_id we should only watch"""
+        return {"recursive": self._is_recursive, "follow_symlinks": self._follow_symlinks, "dev_id": self._dev_id}
 
     @property
     def key(self):

--- a/src/watchdog/observers/api.py
+++ b/src/watchdog/observers/api.py
@@ -85,9 +85,11 @@ class ObservedWatch(object):
         ``True`` if watch is recursive; ``False`` otherwise.
     """
 
-    def __init__(self, path, recursive):
+    def __init__(self, path, **kw):
         self._path = path
-        self._is_recursive = recursive
+        self._is_recursive = kw.get("recursive", False)
+        self._follow_symlinks = kw.get("recursive", True)
+        self._dev_id = kw.get("dev_id", None)
 
     @property
     def path(self):
@@ -98,6 +100,16 @@ class ObservedWatch(object):
     def is_recursive(self):
         """Determines whether subdirectories are watched for the path."""
         return self._is_recursive
+
+    @property
+    def follow_symlinks(self):
+        """Determines whether to follow symlinks"""
+        return self._follow_symlinks
+
+    @property
+    def dev_id(self):
+        """return the dev_id we should only watch"""
+        return self._dev_id
 
     @property
     def key(self):
@@ -290,7 +302,7 @@ class BaseObserver(EventDispatcher):
         handlers = self._get_handlers_for_watch(watch)
         handlers.remove(handler)
 
-    def schedule(self, event_handler, path, recursive=False):
+    def schedule(self, event_handler, path, **kw):
         """
         Schedules watching a path and calls appropriate methods specified
         in the given event handler in response to file system events.
@@ -315,7 +327,7 @@ class BaseObserver(EventDispatcher):
             a watch.
         """
         with self._lock:
-            watch = ObservedWatch(path, recursive)
+            watch = ObservedWatch(path, **kw)
             self._add_handler_for_watch(event_handler, watch)
             try:
                 # If we have an emitter for this watch already, we don't create a

--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -147,7 +147,7 @@ class FSEventsObserver(BaseObserver):
         BaseObserver.__init__(self, emitter_class=FSEventsEmitter,
                               timeout=timeout)
 
-    def schedule(self, event_handler, path, recursive=False):
+    def schedule(self, event_handler, path, **kwargs):
         # Python 2/3 compat
         try:
             str_class = unicode
@@ -169,4 +169,4 @@ class FSEventsObserver(BaseObserver):
             # compatibility.
             if sys.version_info < (3,):
                 path = path.encode('utf-8')
-        return BaseObserver.schedule(self, event_handler, path, recursive)
+        return BaseObserver.schedule(self, event_handler, path, **kwargs)

--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -70,7 +70,7 @@ class FSEventsEmitter(EventEmitter):
     def __init__(self, event_queue, watch, timeout=DEFAULT_EMITTER_TIMEOUT):
         EventEmitter.__init__(self, event_queue, watch, timeout)
         self._lock = threading.Lock()
-        self.snapshot = DirectorySnapshot(watch.path, watch.is_recursive)
+        self.snapshot = DirectorySnapshot(watch.path, **watch.config_kw)
 
     def on_thread_stop(self):
         _fsevents.remove_watch(self.watch)
@@ -81,8 +81,7 @@ class FSEventsEmitter(EventEmitter):
             if not self.watch.is_recursive\
                 and self.watch.path not in self.pathnames:
                 return
-            new_snapshot = DirectorySnapshot(self.watch.path,
-                                             self.watch.is_recursive)
+            new_snapshot = self.snapshot.copy()
             events = new_snapshot - self.snapshot
             self.snapshot = new_snapshot
 

--- a/src/watchdog/observers/kqueue.py
+++ b/src/watchdog/observers/kqueue.py
@@ -457,11 +457,10 @@ class KqueueEmitter(EventEmitter):
             self._register_kevent(path, stat.S_ISDIR(stat_info.st_mode))
 
         self._snapshot = DirectorySnapshot(watch.path,
-                                           watch.is_recursive,
-                                           walker_callback,
+                                           walker_callback=walker_callback,
+                                           recursive=watch.is_recursive,
                                            dev_id=watch.dev_id,
-                                           follow_symlinks=watch.follow_symlinks,
-                                           )
+                                           follow_symlinks=watch.follow_symlinks)
 
     def _register_kevent(self, path, is_directory):
         """
@@ -685,10 +684,8 @@ class KqueueEmitter(EventEmitter):
 
                 # Take a fresh snapshot of the directory and update the
                 # saved snapshot.
-                new_snapshot = DirectorySnapshot(self.watch.path,
-                                                 self.watch.is_recursive)
                 ref_snapshot = self._snapshot
-                self._snapshot = new_snapshot
+                self._snapshot = self._snapshot.copy()
 
                 if files_renamed or dirs_renamed or dirs_modified:
                     for src_path in files_renamed:

--- a/src/watchdog/observers/kqueue.py
+++ b/src/watchdog/observers/kqueue.py
@@ -458,9 +458,7 @@ class KqueueEmitter(EventEmitter):
 
         self._snapshot = DirectorySnapshot(watch.path,
                                            walker_callback=walker_callback,
-                                           recursive=watch.is_recursive,
-                                           dev_id=watch.dev_id,
-                                           follow_symlinks=watch.follow_symlinks)
+                                           **watch.config_kw)
 
     def _register_kevent(self, path, is_directory):
         """

--- a/src/watchdog/observers/kqueue.py
+++ b/src/watchdog/observers/kqueue.py
@@ -458,7 +458,10 @@ class KqueueEmitter(EventEmitter):
 
         self._snapshot = DirectorySnapshot(watch.path,
                                            watch.is_recursive,
-                                           walker_callback)
+                                           walker_callback,
+                                           dev_id=watch.dev_id,
+                                           follow_symlinks=watch.follow_symlinks,
+                                           )
 
     def _register_kevent(self, path, is_directory):
         """

--- a/src/watchdog/observers/polling.py
+++ b/src/watchdog/observers/polling.py
@@ -71,7 +71,7 @@ class PollingEmitter(EventEmitter):
         self._snapshot = None
         self._lock = threading.Lock()
         self._take_snapshot = lambda: DirectorySnapshot(
-            self.watch.path, self.watch.is_recursive, stat=stat, listdir=listdir)
+            self.watch.path, stat=stat, listdir=listdir, **self.watch.config_kw)
 
     def queue_events(self, timeout):
         if not self._snapshot:

--- a/src/watchdog/utils/dirsnapshot.py
+++ b/src/watchdog/utils/dirsnapshot.py
@@ -182,7 +182,6 @@ class DirectorySnapshot(object):
         self._init_kw["_follow_symlinks"] = follow_symlinks
         self._init_kw["_dev_id"] = dev_id
         self._init_kw["_listdir"] = listdir
-        print "init", self._init_kw
         self.__dict__.update(self._init_kw)
         self._stat_info = {}
         self._inode_to_path = {}

--- a/src/watchdog/utils/dirsnapshot.py
+++ b/src/watchdog/utils/dirsnapshot.py
@@ -170,7 +170,7 @@ class DirectorySnapshot(object):
     
     def __init__(self, path, recursive=True,
                  walker_callback=(lambda p, s: None),
-                 stat=os.stat,
+                 stat=default_stat,
                  dev_id=None,
                  follow_symlinks=True,
                  listdir=os.listdir):

--- a/src/watchdog/utils/dirsnapshot.py
+++ b/src/watchdog/utils/dirsnapshot.py
@@ -45,7 +45,7 @@ Classes
 """
 
 import os
-from stat import S_ISDIR
+import stat as is_stat
 from watchdog.utils import platform
 from watchdog.utils import stat as default_stat
 
@@ -210,6 +210,7 @@ class DirectorySnapshot(object):
         self._inode_to_path[stat_info.st_ino] = self.path
 
         def walk(root):
+            print '__walk__', root
             paths = [os.path.join(root, name) for name in listdir(root)]
             entries = []
             for p in paths:
@@ -221,12 +222,12 @@ class DirectorySnapshot(object):
                 yield _
             if recursive:
                 for path, st in entries:
-                    is_dir = S_ISDIR(st.st_mode)
-                    is_symlink = S_ISLNK(st.st_mode)
-                    is_same_dev = st.ST_DEV == dev_id
-                    if is_dir \
-                        and not is_symlink or follow_symlinks \
-                        and not dev_id or is_same_dev:
+                    is_dir = is_stat.S_ISDIR(st.st_mode)
+                    is_symlink = is_stat.S_ISLNK(st.st_mode)
+                    is_same_dev = (st.st_dev == dev_id)
+                    if is_dir and \
+                        (not is_symlink or follow_symlinks) and \
+                        (not dev_id or is_same_dev):
                             for _ in walk(path):
                                 yield _
 
@@ -255,7 +256,7 @@ class DirectorySnapshot(object):
         return (st.st_ino, st.st_dev)
     
     def isdir(self, path):
-        return S_ISDIR(self._stat_info[path].st_mode)
+        return is_stat.S_ISDIR(self._stat_info[path].st_mode)
     
     def mtime(self, path):
         return self._stat_info[path].st_mtime

--- a/src/watchdog/utils/dirsnapshot.py
+++ b/src/watchdog/utils/dirsnapshot.py
@@ -210,7 +210,6 @@ class DirectorySnapshot(object):
         self._inode_to_path[stat_info.st_ino] = self.path
 
         def walk(root):
-            print '__walk__', root
             paths = [os.path.join(root, name) for name in listdir(root)]
             entries = []
             for p in paths:

--- a/src/watchdog/utils/dirsnapshot.py
+++ b/src/watchdog/utils/dirsnapshot.py
@@ -182,6 +182,7 @@ class DirectorySnapshot(object):
         self._init_kw["_follow_symlinks"] = follow_symlinks
         self._init_kw["_dev_id"] = dev_id
         self._init_kw["_listdir"] = listdir
+        print "init", self._init_kw
         self.__dict__.update(self._init_kw)
         self._stat_info = {}
         self._inode_to_path = {}

--- a/src/watchdog/watchmedo.py
+++ b/src/watchdog/watchmedo.py
@@ -119,7 +119,6 @@ def observe_with(observer, event_handler, pathnames, observe_kw_args):
     :param recursive:
         ``True`` if recursive; ``False`` otherwise.
     """
-    print observe_kw_args
     for pathname in set(pathnames):
         observer.schedule(event_handler, pathname, **observe_kw_args)
     observer.start()

--- a/src/watchdog/watchmedo.py
+++ b/src/watchdog/watchmedo.py
@@ -119,6 +119,7 @@ def observe_with(observer, event_handler, pathnames, observe_kw_args):
     :param recursive:
         ``True`` if recursive; ``False`` otherwise.
     """
+    print observe_kw_args
     for pathname in set(pathnames):
         observer.schedule(event_handler, pathname, **observe_kw_args)
     observer.start()

--- a/tests/shell.py
+++ b/tests/shell.py
@@ -76,7 +76,6 @@ def rm(path, recursive=False):
     else:
         os.remove(path)
 
-
 def touch(path, times=None):
     """Updates the modified timestamp of a file or directory."""
     if os.path.isdir(path):
@@ -85,12 +84,19 @@ def touch(path, times=None):
         with open(path, 'ab'):
             os.utime(path, times)
 
-
 def truncate(path):
     """Truncates a file."""
     with open(path, 'wb'):
         os.utime(path, None)
 
+def symlink(src_path, dest_path):
+    """symlink files or directories."""
+    try:
+        os.symlink(src_path, dest_path)
+    except OSError:
+        # this will happen on windows
+        os.remove(dest_path)
+        os.symlink(src_path, dest_path)
 
 def mv(src_path, dest_path):
     """Moves files or directories."""

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2014 Thomas Amland <thomas.amland@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import time
+import pytest
+from functools import partial
+from .shell import mkdtemp, mkdir, touch, mv, symlink
+from watchdog.utils.dirsnapshot import DirectorySnapshot
+from watchdog.utils.dirsnapshot import DirectorySnapshotDiff
+
+def sync():
+    os.system("sync")
+def wait():
+    sync()
+    time.sleep(1)
+
+@pytest.fixture()
+def tmpdir():
+    return mkdtemp()
+
+
+@pytest.fixture()
+def p(tmpdir, *args):
+    """
+    Convenience function to join the temporary directory path
+    with the provided arguments.
+    """
+    return partial(os.path.join, tmpdir)
+
+def test_follow_symlink(p):
+    mkdir(p('root'))
+    mkdir(p('root', 'real'))
+    symlink(p('root', 'real'), p('root', 'symlink'))
+    touch(p('root', 'real', 'a'))
+    ref = DirectorySnapshot(p(''), follow_symlinks=True)
+    assert p('root', 'symlink', 'a') in ref.stat_snapshot
+    ref = DirectorySnapshot(p(''), follow_symlinks=False)
+    assert p('root', 'symlink', 'a') not in ref.stat_snapshot
+
+def test_one_filesystem(p):
+    mkdir(p('root'))
+    target = p('root', 'a')
+    touch(target)
+    dev_id = os.stat(target).st_dev
+    ref = DirectorySnapshot(p(''), dev_id=dev_id)
+    assert target in ref.stat_snapshot
+    ref = DirectorySnapshot(p(''), dev_id=(dev_id + 1))
+    assert target not in ref.stat_snapshot

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -47,16 +47,18 @@ def test_follow_symlink(p):
     symlink(p('root', 'real'), p('root', 'symlink'))
     touch(p('root', 'real', 'a'))
     ref = DirectorySnapshot(p(''), follow_symlinks=True)
-    assert p('root', 'symlink', 'a') in ref.stat_snapshot
+    assert p('root', 'symlink', 'a') in ref.paths
     ref = DirectorySnapshot(p(''), follow_symlinks=False)
-    assert p('root', 'symlink', 'a') not in ref.stat_snapshot
+    assert p('root', 'symlink', 'a') not in ref.paths
 
 def test_one_filesystem(p):
     mkdir(p('root'))
     target = p('root', 'a')
     touch(target)
     dev_id = os.stat(target).st_dev
+    ref = DirectorySnapshot(p(''))
+    assert target in ref.paths
     ref = DirectorySnapshot(p(''), dev_id=dev_id)
-    assert target in ref.stat_snapshot
+    assert target in ref.paths
     ref = DirectorySnapshot(p(''), dev_id=(dev_id + 1))
-    assert target not in ref.stat_snapshot
+    assert target not in ref.paths

--- a/tests/test_snapshot_diff.py
+++ b/tests/test_snapshot_diff.py
@@ -110,6 +110,5 @@ def test_detect_modify_for_moved_files(p):
     touch(p('a'))
     mv(p('a'), p('b'))
     diff = DirectorySnapshotDiff(ref, DirectorySnapshot(p('')))
-    print diff
     assert diff.files_moved == [(p('a'), p('b'))]
     assert diff.files_modified == [p('a')]

--- a/tests/test_snapshot_diff.py
+++ b/tests/test_snapshot_diff.py
@@ -112,6 +112,7 @@ def test_detect_modify_for_moved_files(p):
     wait()
     touch(p('a'))
     mv(p('a'), p('b'))
+    wait()
     diff = DirectorySnapshotDiff(ref, DirectorySnapshot(p('')))
     assert diff.files_moved == [(p('a'), p('b'))]
     assert diff.files_modified == [p('a')]

--- a/tests/test_snapshot_diff.py
+++ b/tests/test_snapshot_diff.py
@@ -115,13 +115,3 @@ def test_detect_modify_for_moved_files(p):
     diff = DirectorySnapshotDiff(ref, DirectorySnapshot(p('')))
     assert diff.files_moved == [(p('a'), p('b'))]
     assert diff.files_modified == [p('a')]
-
-def test_follow_symlink(p):
-    mkdir(p('root'))
-    mkdir(p('root', 'real'))
-    symlink(p('root', 'real'), p('root', 'symlink'))
-    touch(p('root', 'real', 'a'))
-    ref = DirectorySnapshot(p(''), follow_symlinks=True)
-    assert p('root', 'symlink', 'a') in ref.stat_snapshot
-    ref = DirectorySnapshot(p(''), follow_symlinks=False)
-    assert p('root', 'symlink', 'a') not in ref.stat_snapshot

--- a/tests/test_snapshot_diff.py
+++ b/tests/test_snapshot_diff.py
@@ -24,7 +24,7 @@ from watchdog.utils.dirsnapshot import DirectorySnapshotDiff
 
 
 def wait():
-    time.sleep(0.5)
+    time.sleep(1.0)
 
 @pytest.fixture()
 def tmpdir():
@@ -110,5 +110,6 @@ def test_detect_modify_for_moved_files(p):
     touch(p('a'))
     mv(p('a'), p('b'))
     diff = DirectorySnapshotDiff(ref, DirectorySnapshot(p('')))
+    print diff
     assert diff.files_moved == [(p('a'), p('b'))]
     assert diff.files_modified == [p('a')]

--- a/tests/test_snapshot_diff.py
+++ b/tests/test_snapshot_diff.py
@@ -22,10 +22,7 @@ from .shell import mkdtemp, mkdir, touch, mv, symlink
 from watchdog.utils.dirsnapshot import DirectorySnapshot
 from watchdog.utils.dirsnapshot import DirectorySnapshotDiff
 
-def sync():
-    os.system("sync")
 def wait():
-    sync()
     time.sleep(1)
 
 @pytest.fixture()
@@ -112,7 +109,6 @@ def test_detect_modify_for_moved_files(p):
     wait()
     touch(p('a'))
     mv(p('a'), p('b'))
-    wait()
     diff = DirectorySnapshotDiff(ref, DirectorySnapshot(p('')))
     assert diff.files_moved == [(p('a'), p('b'))]
     assert diff.files_modified == [p('a')]


### PR DESCRIPTION
this patch will enable flags for:
* scan / do not scan files that are on the same file system
* follow / do not follow symlinks