### PR TITLE
Fix anon_inode descriptors leakage

### DIFF
--- a/src/watchdog/observers/inotify_c.py
+++ b/src/watchdog/observers/inotify_c.py
@@ -248,6 +248,7 @@ class Inotify(object):
         with self._lock:
             wd = self._wd_for_path[self._path]
             inotify_rm_watch(self._inotify_fd, wd)
+            os.close(self._inotify_fd)
 
     def read_events(self, event_buffer_size=DEFAULT_EVENT_BUFFER_SIZE):
         """


### PR DESCRIPTION
There is inode descriptor leakage in a current version.

Steps to reproduce:
1. Create any observer.
2. Close the observer.
3. Check ls /proc/$pid/fd

There is: anon_inode:inotify present, which was opened by watchdog (checked with strace). 
This pull request contains fix for that problem.
