### PR TITLE
250 - Fix inotify stop dead lock.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -162,6 +162,13 @@ Fork the `repository`_ on GitHub and send a pull request, or file an issue
 ticket at the `issue tracker`_. For general help and questions use the official
 `mailing list`_ or ask on `stackoverflow`_ with tag `python-watchdog`.
 
+Create and activate your virtual environment, then::
+
+    pip install pytest
+    pip install -e .
+    py.tests tests
+
+
 Supported Platforms
 -------------------
 * Linux 2.6 (inotify)

--- a/src/watchdog/observers/inotify.py
+++ b/src/watchdog/observers/inotify.py
@@ -71,7 +71,7 @@ from __future__ import with_statement
 
 import os
 import threading
-from .inotify_buffer import InotifyBuffer
+from .inotify_buffer import InotifyBuffer, STOP_EVENT
 
 from watchdog.observers.api import (
     EventEmitter,
@@ -129,6 +129,9 @@ class InotifyEmitter(EventEmitter):
     def queue_events(self, timeout):
         with self._lock:
             event = self._inotify.read_event()
+
+            if event is STOP_EVENT:
+                return
 
             if isinstance(event, tuple):
                 move_from, move_to = event

--- a/src/watchdog/observers/inotify_buffer.py
+++ b/src/watchdog/observers/inotify_buffer.py
@@ -21,6 +21,8 @@ from collections import deque
 from watchdog.utils import DaemonThread
 from .inotify_c import Inotify
 
+STOP_EVENT = object()
+
 
 class _Worker(DaemonThread):
     """
@@ -94,6 +96,9 @@ class InotifyBuffer(object):
         self._worker.stop()
         self._inotify.close()
         self._worker.join()
+        # Add the stop event to unblock the read_event which waits for
+        # events in the queue... even after inotify buffer is closed.
+        self._put(STOP_EVENT)
 
     def _put(self, elem):
         self._lock.acquire()


### PR DESCRIPTION
# Problem

See description from #250

inotify.stop() thread never ends since it continue to wait for inotify_buffer, but the buffer is closed and will never emit a new event.
# Changes

I have fixed this my emitting a one last special event to signal that inotify_buffer was closed.

py.test magic with tmpdir and p is strange ... this reminds me of AngularJS ... and pyflakes is not happy with it. :(

I have updated the README as it was not obvious that py.test is used.
# How to test

You can try this code https://gist.github.com/adiroiban/064b3a5e07d404ea7109 

or use the provided automated test
