### PR TITLE
255 - Don't start emitters before observer is started

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -3,6 +3,14 @@
 API changes
 -----------
 
+
+0.8.1 - unreleased
+~~~~~~~~~~~~~~~~~~
+
+- ``EventEmitter.start()`` no waits for emitter to start.
+- Don't start the emitter unless the main observer is not started.
+
+
 0.8.0
 ~~~~~
 

--- a/src/watchdog/observers/api.py
+++ b/src/watchdog/observers/api.py
@@ -51,6 +51,7 @@ Classes
 
 from __future__ import with_statement
 import threading
+import time
 from watchdog.utils import DaemonThread
 from watchdog.utils.compat import queue
 from watchdog.utils.bricks import SkipRepeatsQueue
@@ -153,6 +154,21 @@ class EventEmitter(DaemonThread):
         """
         return self._watch
 
+    @property
+    def ready(self):
+        """
+        True when emitter is active and ready to listen for events.
+        """
+        return True
+
+    def start(self):
+        """
+        Start emitter in blocking mode waiting for it to be ready.
+        """
+        super(EventEmitter, self).start()
+        while not self.ready:
+            time.sleep(0.01)
+
     def queue_event(self, event):
         """
         Queues a single event.
@@ -250,6 +266,7 @@ class BaseObserver(EventDispatcher):
         self._handlers = dict()
         self._emitters = set()
         self._emitter_for_watch = dict()
+        self._ready = False
 
     def _add_emitter(self, emitter):
         self._emitter_for_watch[emitter.watch] = emitter
@@ -258,19 +275,19 @@ class BaseObserver(EventDispatcher):
     def _remove_emitter(self, emitter):
         del self._emitter_for_watch[emitter.watch]
         self._emitters.remove(emitter)
-        emitter.stop()
-        emitter.join()
+
+        # We might remove an emitter, before starting it, so there is no
+        # need to join the thread
+        if emitter.isAlive():
+            emitter.stop()
+            emitter.join()
 
     def _get_emitter_for_watch(self, watch):
         return self._emitter_for_watch[watch]
 
     def _clear_emitters(self):
-        for emitter in self._emitters:
-            emitter.stop()
-        for emitter in self._emitters:
-            emitter.join()
-        self._emitters.clear()
-        self._emitter_for_watch.clear()
+        for emitter in self._emitters.copy():
+            self._remove_emitter(emitter)
 
     def _add_handler_for_watch(self, event_handler, watch):
         try:
@@ -287,6 +304,16 @@ class BaseObserver(EventDispatcher):
     def _remove_handler_for_watch(self, handler, watch):
         handlers = self._get_handlers_for_watch(watch)
         handlers.remove(handler)
+
+    def _start_emitter(self, emitter):
+        """
+        Start emitter and wait for it to become ready.
+        """
+        # Don't start when it was already started.
+        if emitter.isAlive():
+            return
+
+        emitter.start()
 
     def schedule(self, event_handler, path, recursive=False):
         """
@@ -326,8 +353,12 @@ class BaseObserver(EventDispatcher):
                                               watch=watch,
                                               timeout=self.timeout)
                 self._add_emitter(emitter)
+                # We only start the emitter if main thread is already
+                # running.
                 if self.isAlive():
-                    emitter.start()
+                    self._start_emitter(emitter)
+            # Here to help with testing.
+            watch._emitter = emitter
             self._watches.add(watch)
         return watch
 
@@ -412,8 +443,24 @@ class BaseObserver(EventDispatcher):
             pass
         event_queue.task_done()
 
+    @property
+    def ready(self):
+        """
+        True when observer is active and listening for events.
+        """
+        return self._ready
+
+    def start_blocking(self):
+        """
+        Start observer and wait for it to start listening for changes.
+        """
+        self.start()
+        while not self.ready:
+            time.sleep(0.01)
+
     def run(self):
-        for emitter in self._emitters:
-            if not emitter.isAlive():
-                emitter.start()
+        with self._lock:
+            for emitter in self._emitters:
+                self._start_emitter(emitter)
+        self._ready = True
         return EventDispatcher.run(self)

--- a/src/watchdog/observers/inotify.py
+++ b/src/watchdog/observers/inotify.py
@@ -127,6 +127,10 @@ class InotifyEmitter(EventEmitter):
         self._inotify.start()
         return EventEmitter.run(self)
 
+    @property
+    def ready(self):
+        return self._inotify.ready
+
     def on_thread_stop(self):
         self._inotify.close()
 

--- a/src/watchdog/observers/polling.py
+++ b/src/watchdog/observers/polling.py
@@ -71,7 +71,25 @@ class PollingEmitter(EventEmitter):
         self._snapshot = None
         self._lock = threading.Lock()
         self._take_snapshot = lambda: DirectorySnapshot(
-            self.watch.path, self.watch.is_recursive, stat=stat, listdir=listdir)
+            self.watch.path,
+            self.watch.is_recursive,
+            stat=stat,
+            listdir=listdir,
+            )
+
+    def run(self):
+        """
+        Start the looking for changes.
+        """
+        self._snapshot = self._take_snapshot()
+        return EventEmitter.run(self)
+
+    @property
+    def ready(self):
+        """
+        We are ready after first snapshot was taken.
+        """
+        return self._snapshot is not None
 
     def queue_events(self, timeout):
         if not self._snapshot:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -16,6 +16,8 @@
 # limitations under the License.
 
 import os
+import threading
+import unittest
 import pytest
 from . import shell
 from sys import version_info
@@ -50,3 +52,15 @@ def p(tmpdir, *args):
     with the provided arguments.
     """
     return partial(os.path.join, tmpdir)
+
+
+class WatchdogTestCase(unittest.TestCase):
+    """
+    Test case for watchdog tests.
+    """
+
+    def tearDown(self):
+        # Check that we don't have unstopped threads.
+        active_thread = threading.enumerate()
+        self.assertEqual([threading.currentThread()], active_thread)
+        super(WatchdogTestCase, self).tearDown()

--- a/tests/legacy/test_watchdog_observers_api.py
+++ b/tests/legacy/test_watchdog_observers_api.py
@@ -103,6 +103,6 @@ class TestBaseObserver(unittest.TestCase):
         watch = observer.schedule(handler, '/foobar', True)
         observer.event_queue.put((FileModifiedEvent('/foobar'), watch))
         observer.start()
-        time.sleep(1)
+
         observer.unschedule_all()
         observer.stop()

--- a/tests/legacy/test_watchdog_observers_polling.py
+++ b/tests/legacy/test_watchdog_observers_polling.py
@@ -66,13 +66,13 @@ class TestPollingEmitter(unittest.TestCase):
     def setUp(self):
         self.event_queue = queue.Queue()
         self.watch = ObservedWatch(temp_dir, True)
-        self.emitter = Emitter(self.event_queue, self.watch, timeout=0.2)
+        self.emitter = Emitter(self.event_queue, self.watch, timeout=0.01)
 
     def teardown(self):
         pass
 
     def test___init__(self):
-        SLEEP_TIME = 0.4
+        SLEEP_TIME = 0.02
         self.emitter.start()
         sleep(SLEEP_TIME)
         mkdir(p('project'))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2011 Yesudeep Mangalapilly <yesudeep@gmail.com>
+# Copyright 2012 Google, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Tests for generic observer, generic emitter, generic event dispatcher...etc
+"""
+import tempfile
+import threading
+
+from watchdog.observers.api import BaseObserver, EventEmitter, ObservedWatch
+
+from tests import WatchdogTestCase
+
+
+class DummyEventEmitter(EventEmitter):
+    """
+    Simple event emitter implementation to help with testing generic
+    event emitters.
+    """
+
+    _ready = None
+
+    @property
+    def ready(self):
+        """
+        Delay `ready` for the next call.
+        """
+        if self._ready is None:
+            self._ready = object()
+            return False
+        return True
+
+
+
+class TestEventEmitter(WatchdogTestCase):
+    """
+    Unit test for EventEmitter.
+    """
+
+    def setUp(self):
+        super(TestEventEmitter, self).setUp()
+        self.queue = []
+        watch = ObservedWatch(path=tempfile.tempdir, recursive=False)
+        self.sut = DummyEventEmitter(self.queue, watch, timeout=0)
+
+    def tearDown(self):
+        if self.sut.isAlive():
+            self.sut.stop()
+            self.sut.join()
+        super(TestEventEmitter, self).setUp()
+
+    def test_start_blocking(self):
+        """
+        It will start the emitter and for it to finish the start.
+        """
+        self.sut.start()
+
+        self.assertTrue(self.sut.ready)
+
+
+class DummyObserver(BaseObserver):
+    """
+    Dummy implementation to help with testing the TestBaseObserver.
+    """
+
+
+class TestBaseObserver(WatchdogTestCase):
+    """
+    Unit tests for BaseObserver.
+    """
+
+    def setUp(self):
+        super(TestBaseObserver, self).setUp()
+        self.sut = DummyObserver(DummyEventEmitter, timeout=0)
+
+    def tearDown(self):
+        if self.sut.isAlive():
+            self.sut.stop()
+            self.sut.join()
+        super(TestBaseObserver, self).tearDown()
+
+    def test_schedule_not_started(self):
+        """
+        It does not start the emitter when observer is not started yet.
+        """
+        handler = self.sut.schedule('handler', tempfile.tempdir)
+
+        emitter = handler._emitter
+
+        self.assertFalse(emitter.isAlive())
+
+    def test_schedule_started(self):
+        """
+        When observer is already started, it starts the emitter when
+        it is scheduled.
+        """
+        self.sut.start()
+
+        handler = self.sut.schedule('handler', tempfile.tempdir)
+        emitter = handler._emitter
+
+        self.assertTrue(emitter.isAlive())
+        self.assertTrue(emitter.ready)
+
+    def test_start(self):
+        """
+        It starts the attached emitters.
+        """
+        handler = self.sut.schedule('handler', tempfile.tempdir)
+        emitter = handler._emitter
+        self.assertFalse(emitter.isAlive())
+
+        self.sut.start_blocking()
+
+        self.assertTrue(emitter.isAlive())
+        self.assertTrue(emitter.ready)
+
+    def test_unschedule_not_started(self):
+        """
+        Removes the scheduled emitter.
+        """
+        handler = self.sut.schedule('handler', tempfile.tempdir)
+
+        self.sut.unschedule(handler)
+
+    def test_unschedule_all_not_started(self):
+        """
+        Removes all scheduled emitters.
+        """
+        handler = self.sut.schedule('handler', tempfile.tempdir)
+
+        self.sut.unschedule_all()

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -43,10 +43,19 @@ def setup_function(function):
     event_queue = Queue()
 
 
-def start_watching(path=None):
+def make_emitter(path=None):
+    """
+    Create the default emitter, return it and set it as global to be
+    available in teardown_function.
+    """
     path = p('') if path is None else path
     global emitter
     emitter = Emitter(event_queue, ObservedWatch(path, recursive=True))
+    return emitter
+
+
+def start_watching(path=None):
+    emitter = make_emitter(path)
     if platform.is_darwin():
         # FSEvents will report old evens (like create for mkdtemp in test
         # setup. Waiting for a considerable time seems to 'flush' the events.
@@ -186,3 +195,21 @@ def test_passing_bytes_should_give_bytes():
     touch(p('a'))
     event = event_queue.get(timeout=5)[0]
     assert isinstance(event.src_path, bytes)
+
+
+def test_ignore_events_before_start():
+    """
+    It will ignore events occurring on the FS before start is called.
+    """
+    emitter = make_emitter(p(''))
+    touch(p('a'))
+
+    assert event_queue.empty()
+
+    # Now we start the emitter and after this we should see events.
+    emitter.start()
+    touch(p('b'))
+
+    event = event_queue.get(timeout=5)[0]
+    assert isinstance(event, FileCreatedEvent)
+    assert event.src_path == p('b')

--- a/tests/test_inotify_buffer.py
+++ b/tests/test_inotify_buffer.py
@@ -17,6 +17,7 @@
 from __future__ import unicode_literals
 import os
 import random
+import time
 import pytest
 from tests import tmpdir, p  # pytest magic
 from .shell import mkdir, touch, mv
@@ -36,13 +37,23 @@ def wait_for_move_event(read_event):
             return event
 
 
+def make_inotify_buffer(path, recursive=False, delay=0.5):
+    return InotifyBuffer(path.encode(), recursive=recursive, delay=delay)
+
+
+def start_inotify_buffer(path, recursive=False):
+    inotify = make_inotify_buffer(path, recursive=recursive)
+    inotify.start()
+    return inotify
+
+
 @pytest.mark.timeout(5)
 def test_move_from(p):
     mkdir(p('dir1'))
     mkdir(p('dir2'))
     touch(p('dir1', 'a'))
 
-    inotify = InotifyBuffer(p('dir1').encode())
+    inotify = start_inotify_buffer(p('dir1'))
     mv(p('dir1', 'a'), p('dir2', 'b'))
     event = wait_for_move_event(inotify.read_event)
     assert event.is_moved_from
@@ -56,7 +67,7 @@ def test_move_to(p):
     mkdir(p('dir2'))
     touch(p('dir1', 'a'))
 
-    inotify = InotifyBuffer(p('dir2').encode())
+    inotify = start_inotify_buffer(p('dir2'))
     mv(p('dir1', 'a'), p('dir2', 'b'))
     event = wait_for_move_event(inotify.read_event)
     assert event.is_moved_to
@@ -70,13 +81,13 @@ def test_move_internal(p):
     mkdir(p('dir2'))
     touch(p('dir1', 'a'))
 
-    inotify = InotifyBuffer(p('').encode(), recursive=True)
+    inotify = start_inotify_buffer(p(''), recursive=True)
     mv(p('dir1', 'a'), p('dir2', 'b'))
     frm, to = wait_for_move_event(inotify.read_event)
     assert frm.src_path == p('dir1', 'a').encode()
     assert to.src_path == p('dir2', 'b').encode()
     inotify.close()
-    
+
 
 @pytest.mark.timeout(10)
 def test_move_internal_batch(p):
@@ -87,7 +98,7 @@ def test_move_internal_batch(p):
     for f in files:
         touch(p('dir1', f))
 
-    inotify = InotifyBuffer(p('').encode(), recursive=True)
+    inotify = start_inotify_buffer(p(''), recursive=True)
 
     random.shuffle(files)
     for f in files:
@@ -102,6 +113,18 @@ def test_move_internal_batch(p):
         assert frm.name == to.name
         i += 1
     inotify.close()
+
+
+@pytest.mark.timeout(5)
+def test_ignore_before_start(p):
+    """
+    It will ignore events created before start.
+    """
+    inotify = make_inotify_buffer(p(''), delay=0)
+
+    touch(p('a'))
+
+    assert 0 == len(inotify._queue)
 
 
 def test_close_clean(tmpdir):


### PR DESCRIPTION
# Problem

This is the code from #255
# Changes

please not that it is not working and has no tests and it needs to be extended to the other emitters / observers as this is just for inotify...

so the currrent code is just an example to show what is my problemI have added a 'ready' state for emitter to signal what it is really ready
to be used... as isAlive() is not reliable, since it is set before calling
run.

On BaseObserver, I have also added an explicit start_blocking() method... not sure if we
should have this separate method or make default start() method blocking.

On BaseEmitter start is blocking, as I have another patch witch handles
exceptions during start #259

With the new code, in `tests/legacy/test_watchdog_observers_api.py`  there
is no need to do a dumb sleep(1)

I have also reduced the sleep in test_watchdog_observers_polling.py as 0.4 seconds is a lot

Now that we don't always start an emitter after we subscribe, the emitter stop code
need an update since we can stop/clean the emitter before starting it.

While the functional/system tests are great, they are very slow.
I think that we should also have unit tests to check for all kind of corner
cases which are much harder to setup/reproduce with functional tests.

This is why I start writing unit tests for the code that I have changed.
It was much easier to create race-conditions and overlap thread calls.

I have refactored clear_emitter to make use of _remove_emitter so that  we
have less code duplication or less code doing similar things in different
ways

Changes were only tested on Ubuntu 12.04 with Python 2.7
