### PR TITLE
Fix unused arg treated as error with clang

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,9 @@ if get_platform().startswith('macosx'):
                 '-Wall',
                 '-Wextra',
                 '-fPIC',
+
+                # required w/Xcode 5.1+ and above because of '-mno-fused-madd'
+                '-Wno-error=unused-command-line-argument-hard-error-in-future'
             ]
         ),
     ]


### PR DESCRIPTION
Tested on MacOS 10.8.5, Xcode 5.1.1.
