### PR TITLE
fix the issue: watch & unwatch the same folder on Windows 

### DIFF
--- a/src/watchdog/observers/winapi.py
+++ b/src/watchdog/observers/winapi.py
@@ -281,8 +281,12 @@ def get_directory_handle(path):
 def close_directory_handle(handle):
     try:
         CancelIoEx(handle, None)  # force ReadDirectoryChangesW to return
+        CloseHandle(handle)       # close directory handle
     except WindowsError:
-        return
+        try:
+            CloseHandle(handle)   # close directory handle
+        except:
+            return
 
 
 def read_directory_changes(handle, recursive):


### PR DESCRIPTION
fix the issue : watch & unwatch the same folder on Windows may cause exception "Access Denied"
should close the dir handle

testing code

```
import os
import sys
import time
import shutil
import logging
import tempfile
import threading
from os.path import join, dirname, abspath
from watchdog.observers import Observer
from watchdog.events import LoggingEventHandler

class ObserverThread(threading.Thread):
    def __init__(self, folder):
        threading.Thread.__init__(self)
        self.folder = folder
        self.stop_evt = threading.Event()
    def stop(self):
        self.stop_evt.set()
    def run(self):
        event_handler = LoggingEventHandler()
        observer = Observer()
        observer.schedule(event_handler, self.folder, recursive=True)
        observer.start()
        self.stop_evt.wait()
        observer.stop()
        observer.join()

def main():
    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
    folder = tempfile.mkdtemp()    # watch & unwatch the same folder 10 times
    for i in range(10):
        if not os.path.exists(folder):
            os.mkdir(folder)
        tmp_file = join(folder, 'tmp.txt')
        print 'process %d temp_file=%s' % (i, tmp_file)

        t = ObserverThread(folder)
        t.start()
        with open(tmp_file, 'w') as f:
            f.write('abc')
        os.remove(tmp_file)
        t.stop()
        t.join()

        shutil.rmtree(folder)

if __name__ == "__main__":
    main()
```
