### PR TITLE
Pass WATCH_* variables as environment to subprocess

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ response to events:
     watchmedo shell-command \
         --patterns="*.py;*.txt" \
         --recursive \
-        --command='echo "${watch_src_path}"' \
+        --command='echo "$WATCH_SRC_PATH"' \
         .
 
 Please see the help information for these commands by typing:


### PR DESCRIPTION
Passing WATCH_* variables as environment variables enable us to use any
shell command including for example executing a script, which extend the
way users can use the ShellCommandTrick and 'watchmedo shell-command ..'.

This change is backward incompatible because it change the way user
access variable passed to their shell command, instead of using python
template substitue (i.e. ${path}), they should use normal shell variable
refering (i.e. $path), this change also make the variable upper case to
make them fit with the norm of environment variables.