### PR TITLE
Queue event handlers rather than watches.

### DIFF
--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -67,8 +67,8 @@ class FSEventsEmitter(EventEmitter):
         ``float``
     """
 
-    def __init__(self, event_queue, watch, timeout=DEFAULT_EMITTER_TIMEOUT):
-        EventEmitter.__init__(self, event_queue, watch, timeout)
+    def __init__(self, observer, watch, timeout=DEFAULT_EMITTER_TIMEOUT):
+        EventEmitter.__init__(self, observer, watch, timeout)
         self._lock = threading.Lock()
         self.snapshot = DirectorySnapshot(watch.path, watch.is_recursive)
 

--- a/src/watchdog/observers/fsevents2.py
+++ b/src/watchdog/observers/fsevents2.py
@@ -174,8 +174,8 @@ class FSEventsEmitter(EventEmitter):
     FSEvents based event emitter. Handles conversion of native events.
     """
 
-    def __init__(self, event_queue, watch, timeout=DEFAULT_EMITTER_TIMEOUT):
-        EventEmitter.__init__(self, event_queue, watch, timeout)
+    def __init__(self, observer, watch, timeout=DEFAULT_EMITTER_TIMEOUT):
+        EventEmitter.__init__(self, observer, watch, timeout)
         self._fsevents = FSEventsQueue(watch.path)
         self._fsevents.start()
 

--- a/src/watchdog/observers/inotify.py
+++ b/src/watchdog/observers/inotify.py
@@ -111,8 +111,8 @@ class InotifyEmitter(EventEmitter):
         ``float``
     """
 
-    def __init__(self, event_queue, watch, timeout=DEFAULT_EMITTER_TIMEOUT):
-        EventEmitter.__init__(self, event_queue, watch, timeout)
+    def __init__(self, observer, watch, timeout=DEFAULT_EMITTER_TIMEOUT):
+        EventEmitter.__init__(self, observer, watch, timeout)
         self._lock = threading.Lock()
         self._inotify = None
 

--- a/src/watchdog/observers/polling.py
+++ b/src/watchdog/observers/polling.py
@@ -65,9 +65,9 @@ class PollingEmitter(EventEmitter):
     system changes.
     """
 
-    def __init__(self, event_queue, watch, timeout=DEFAULT_EMITTER_TIMEOUT,
+    def __init__(self, observer, watch, timeout=DEFAULT_EMITTER_TIMEOUT,
                  stat=default_stat, listdir=os.listdir):
-        EventEmitter.__init__(self, event_queue, watch, timeout)
+        EventEmitter.__init__(self, observer, watch, timeout)
         self._snapshot = None
         self._lock = threading.Lock()
         self._take_snapshot = lambda: DirectorySnapshot(

--- a/tests/legacy/test_watchdog_observers_api.py
+++ b/tests/legacy/test_watchdog_observers_api.py
@@ -24,10 +24,13 @@ from watchdog.observers.api import (
     EventEmitter,
     ObservedWatch,
     EventDispatcher,
-    EventQueue
 )
 
-from watchdog.events import LoggingEventHandler, FileModifiedEvent
+from watchdog.events import (
+    LoggingEventHandler,
+    FileModifiedEvent,
+    FileSystemEventHandler
+)
 
 
 class TestObservedWatch(unittest.TestCase):
@@ -61,9 +64,10 @@ class TestObservedWatch(unittest.TestCase):
 class TestEventEmitter(unittest.TestCase):
 
     def test___init__(self):
-        event_queue = EventQueue()
-        watch = ObservedWatch('/foobar', True)
-        event_emitter = EventEmitter(event_queue, watch, timeout=1)
+        observer = BaseObserver(emitter_class=EventEmitter)
+        watch = observer.schedule(FileSystemEventHandler, '/foobar', True)
+
+        event_emitter = EventEmitter(observer, watch, timeout=1)
         event_emitter.queue_event(FileModifiedEvent('/foobar/blah'))
 
 

--- a/tests/legacy/test_watchdog_observers_polling.py
+++ b/tests/legacy/test_watchdog_observers_polling.py
@@ -18,7 +18,6 @@
 
 
 import os
-import sys
 from tests import unittest
 
 try:
@@ -46,7 +45,8 @@ from watchdog.events import (
     DirDeletedEvent
 )
 
-from watchdog.observers.api import ObservedWatch
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers.api import BaseObserver
 from watchdog.observers.polling import PollingEmitter as Emitter
 
 
@@ -64,9 +64,10 @@ def p(*args):
 class TestPollingEmitter(unittest.TestCase):
 
     def setUp(self):
-        self.event_queue = queue.Queue()
-        self.watch = ObservedWatch(temp_dir, True)
-        self.emitter = Emitter(self.event_queue, self.watch, timeout=0.2)
+        self.observer = BaseObserver(emitter_class=Emitter)
+        self.watch = self.observer.schedule(
+            FileSystemEventHandler, temp_dir, True)
+        self.emitter = Emitter(self.observer, self.watch, timeout=0.2)
 
     def teardown(self):
         pass
@@ -135,7 +136,7 @@ class TestPollingEmitter(unittest.TestCase):
         got = set()
         while True:
             try:
-                event, _ = self.event_queue.get_nowait()
+                event, _ = self.observer.event_queue.get_nowait()
                 got.add(event)
             except queue.Empty:
                 break


### PR DESCRIPTION
Fix for #229. Queue handlers rather than watches so `observer._dispatch_event()` won't need the lock.

This does couple emitters and observers, but I think that can be fixed if the solution is otherwise sound.
