### PR TITLE
Enable possibility to enforce PollingObserver by setting the environment variable WATCHMEDO_FORCE_POLLING

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,12 @@ response to events:
         --command='echo "${watch_src_path}"' \
         .
 
+You can enforce usage of the PollingObserver by setting the environment
+variable WATCHMEDO_FORCE_POLLING to an non empty value. This is for example usable
+if you are in an environment where the default observer will not work. For example
+when you are monitoring files on a shared folder inside a virtual machine where
+the host file change events doesn't propagate to the guest.
+
 Please see the help information for these commands by typing:
 
 .. code-block:: bash

--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ response to events:
         .
 
 You can enforce usage of the PollingObserver by setting the environment
-variable WATCHMEDO_FORCE_POLLING to an non empty value. This is for example usable
+variable WATCHDOG_FORCE_POLLING to an non empty value. This is for example usable
 if you are in an environment where the default observer will not work. For example
 when you are monitoring files on a shared folder inside a virtual machine where
 the host file change events doesn't propagate to the guest.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -163,4 +163,6 @@ Windows Vista and later
 OS Independent Polling
     |project_name| also includes a fallback-implementation that polls
     watched directories for changes by periodically comparing snapshots
-    of the directory tree.
+    of the directory tree. You can enforce this behavior for ``watchmedo``
+    by setting the environment variable WATCHMEDO_FORCE_POLLING to a non
+    empty value.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -163,6 +163,5 @@ Windows Vista and later
 OS Independent Polling
     |project_name| also includes a fallback-implementation that polls
     watched directories for changes by periodically comparing snapshots
-    of the directory tree. You can enforce this behavior for ``watchmedo``
-    by setting the environment variable WATCHMEDO_FORCE_POLLING to a non
-    empty value.
+    of the directory tree. You can enforce this behavior by setting the
+    environment variable WATCHMEDO_FORCE_POLLING to a non empty value.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -164,4 +164,4 @@ OS Independent Polling
     |project_name| also includes a fallback-implementation that polls
     watched directories for changes by periodically comparing snapshots
     of the directory tree. You can enforce this behavior by setting the
-    environment variable WATCHMEDO_FORCE_POLLING to a non empty value.
+    environment variable WATCHDOG_FORCE_POLLING to a non empty value.

--- a/src/watchdog/observers/__init__.py
+++ b/src/watchdog/observers/__init__.py
@@ -55,9 +55,12 @@ Class          Platforms                        Note
 """
 
 import warnings
+import os
 from watchdog.utils import platform
 from watchdog.utils import UnsupportedLibc
 
+if os.environ.get('WATCHMEDO_FORCE_POLLING', False):
+    from .polling import PollingObserver as Observer
 if platform.is_linux():
     try:
         from .inotify import InotifyObserver as Observer

--- a/src/watchdog/observers/__init__.py
+++ b/src/watchdog/observers/__init__.py
@@ -59,7 +59,7 @@ import os
 from watchdog.utils import platform
 from watchdog.utils import UnsupportedLibc
 
-if os.environ.get('WATCHMEDO_FORCE_POLLING', False):
+if os.environ.get('WATCHDOG_FORCE_POLLING', False):
     from .polling import PollingObserver as Observer
 
 elif platform.is_linux():

--- a/src/watchdog/observers/__init__.py
+++ b/src/watchdog/observers/__init__.py
@@ -61,7 +61,8 @@ from watchdog.utils import UnsupportedLibc
 
 if os.environ.get('WATCHMEDO_FORCE_POLLING', False):
     from .polling import PollingObserver as Observer
-if platform.is_linux():
+
+elif platform.is_linux():
     try:
         from .inotify import InotifyObserver as Observer
     except UnsupportedLibc:

--- a/src/watchdog/watchmedo.py
+++ b/src/watchdog/watchmedo.py
@@ -39,7 +39,7 @@ except ImportError:
 from argh import arg, aliases, ArghParser, expects_obj
 from watchdog.version import VERSION_STRING
 from watchdog.utils import load_class
-
+import os
 
 logging.basicConfig(level=logging.INFO)
 
@@ -418,6 +418,11 @@ Example option usage::
      default=False,
      help="Ignore events that occur while command is still being executed " \
           "to avoid multiple simultaneous instances")
+@arg('--polling',
+     dest='polling',
+     default=os.environ.get('WATCHDOG_POLLING', False),
+     help='force usage of PollingObserver, can also be set using a none empty'
+          'value for environment variable WATCHDOG_POLLING')
 @expects_obj
 def shell_command(args):
     """
@@ -426,7 +431,11 @@ def shell_command(args):
     :param args:
         Command line argument options.
     """
-    from watchdog.observers import Observer
+    if args.polling:
+        from watchdog.observers.polling import PollingObserver as Observer
+    else:
+        from watchdog.observers import Observer
+
     from watchdog.tricks import ShellCommandTrick
 
     if not args.command:

--- a/src/watchdog/watchmedo.py
+++ b/src/watchdog/watchmedo.py
@@ -39,7 +39,6 @@ except ImportError:
 from argh import arg, aliases, ArghParser, expects_obj
 from watchdog.version import VERSION_STRING
 from watchdog.utils import load_class
-import os
 
 
 logging.basicConfig(level=logging.INFO)
@@ -47,7 +46,6 @@ logging.basicConfig(level=logging.INFO)
 CONFIG_KEY_TRICKS = 'tricks'
 CONFIG_KEY_PYTHON_PATH = 'python-path'
 
-FORCE_POLLING = True if os.environ.get('WATCHMEDO_FORCE_POLLING', False) else False
 
 def path_split(pathname_spec, separator=os.path.sep):
     """
@@ -116,10 +114,6 @@ def observe_with(observer, event_handler, pathnames, recursive):
     :param recursive:
         ``True`` if recursive; ``False`` otherwise.
     """
-    if FORCE_POLLING:
-        from watchdog.observers.polling import PollingObserver
-        observer = PollingObserver
-
     for pathname in set(pathnames):
         observer.schedule(event_handler, pathname, recursive)
     observer.start()
@@ -176,17 +170,12 @@ def tricks_from(args):
     :param args:
         Command line argument options.
     """
-    if FORCE_POLLING:
-        from watchdog.observers.polling import PollingObserver
-        observer_class = PollingObserver
-    else:
-        from watchdog.observers import Observer
-        observer_class = Observer
+    from watchdog.observers import Observer
 
     add_to_sys_path(path_split(args.python_path))
     observers = []
     for tricks_file in args.files:
-        observer = observer_class(timeout=args.timeout)
+        observer = Observer(timeout=args.timeout)
 
         if not os.path.exists(tricks_file):
             raise IOError("cannot find tricks file: %s" % tricks_file)


### PR DESCRIPTION
This enables possibility to enforce the usage of PollingObserver by setting the environment variable WATCHMEDO_FORCE_POLLING.