### PR TITLE
Add terminate cli argument for shell-command.

### DIFF
--- a/src/watchdog/tricks/__init__.py
+++ b/src/watchdog/tricks/__init__.py
@@ -79,19 +79,24 @@ class ShellCommandTrick(Trick):
 
     def __init__(self, shell_command=None, patterns=None, ignore_patterns=None,
                  ignore_directories=False, wait_for_process=False,
-                 drop_during_process=False):
+                 drop_during_process=False, terminate_on_event=False):
         super(ShellCommandTrick, self).__init__(patterns, ignore_patterns,
                                                 ignore_directories)
         self.shell_command = shell_command
         self.wait_for_process = wait_for_process
         self.drop_during_process = drop_during_process
         self.process = None
+        self.terminate_on_event = terminate_on_event
 
     def on_any_event(self, event):
         from string import Template
 
         if self.drop_during_process and self.process and self.process.poll() is None:
             return
+
+        if self.process and self.terminate_on_event:
+            # TODO hit this with more of a sledge hammer, like autorestarttrick.stop
+            self.process.terminate()
 
         if event.is_directory:
             object_type = 'directory'

--- a/src/watchdog/watchmedo.py
+++ b/src/watchdog/watchmedo.py
@@ -418,6 +418,11 @@ Example option usage::
      default=False,
      help="Ignore events that occur while command is still being executed " \
           "to avoid multiple simultaneous instances")
+@arg('-t', '--terminate',
+     dest='terminate_on_event',
+     action='store_true',
+     default=False,
+     help="Kill currently running commands upon new event.")
 @expects_obj
 def shell_command(args):
     """
@@ -439,6 +444,7 @@ def shell_command(args):
                                 ignore_patterns=ignore_patterns,
                                 ignore_directories=args.ignore_directories,
                                 wait_for_process=args.wait_for_process,
+                                terminate_on_event=args.terminate_on_event,
                                 drop_during_process=args.drop_during_process)
     observer = Observer(timeout=args.timeout)
     observe_with(observer, handler, args.directories, args.recursive)


### PR DESCRIPTION
If a new event occurs whilst the current one is still in progress, it
terminates the Popen and runs the command anew.