### PR TITLE
Fixed FreeBSD 10 detection issue

### DIFF
--- a/src/watchdog/utils/platform.py
+++ b/src/watchdog/utils/platform.py
@@ -25,15 +25,14 @@ PLATFORM_BSD = 'bsd'
 PLATFORM_DARWIN = 'darwin'
 PLATFORM_UNKNOWN = 'unknown'
 
-
 def get_platform_name():
-    if sys.platform.startswith("win"):
+    if 'win' in sys.platform:
         return PLATFORM_WINDOWS
-    elif sys.platform.startswith('darwin'):
+    elif 'darwin' in sys.platform:
         return PLATFORM_DARWIN
-    elif sys.platform.startswith('linux'):
+    elif 'linux' in sys.platform:
         return PLATFORM_LINUX
-    elif sys.platform.startswith('bsd'):
+    elif 'bsd' in sys.platform:
         return PLATFORM_BSD
     else:
         return PLATFORM_UNKNOWN

--- a/src/watchdog/utils/platform.py
+++ b/src/watchdog/utils/platform.py
@@ -24,15 +24,14 @@ PLATFORM_LINUX = 'linux'
 PLATFORM_BSD = 'bsd'
 PLATFORM_DARWIN = 'darwin'
 PLATFORM_UNKNOWN = 'unknown'
-
 def get_platform_name():
-    if 'win' in sys.platform:
+    if sys.platform.startswith("win"):
         return PLATFORM_WINDOWS
-    elif 'darwin' in sys.platform:
+    elif sys.platform.startswith('darwin'):
         return PLATFORM_DARWIN
-    elif 'linux' in sys.platform:
+    elif sys.platform.startswith('linux'):
         return PLATFORM_LINUX
-    elif 'bsd' in sys.platform:
+    elif 'bsd' in sys.platform: 
         return PLATFORM_BSD
     else:
         return PLATFORM_UNKNOWN

--- a/src/watchdog/utils/platform.py
+++ b/src/watchdog/utils/platform.py
@@ -24,6 +24,8 @@ PLATFORM_LINUX = 'linux'
 PLATFORM_BSD = 'bsd'
 PLATFORM_DARWIN = 'darwin'
 PLATFORM_UNKNOWN = 'unknown'
+
+
 def get_platform_name():
     if sys.platform.startswith("win"):
         return PLATFORM_WINDOWS
@@ -31,7 +33,7 @@ def get_platform_name():
         return PLATFORM_DARWIN
     elif sys.platform.startswith('linux'):
         return PLATFORM_LINUX
-    elif 'bsd' in sys.platform: 
+    elif sys.platform.startswith('bsd') or sys.platform.startswith('freebsd'):
         return PLATFORM_BSD
     else:
         return PLATFORM_UNKNOWN


### PR DESCRIPTION
I looked into [#312](https://github.com/gorakhargosh/watchdog/issues/312) and [#320](https://github.com/gorakhargosh/watchdog/issues/320). I addressed the problem by  replacing

``` python
def get_platform_name():
    if sys.platform.startswith("win"):
        return PLATFORM_WINDOWS
    elif sys.platform.startswith('darwin'):
        return PLATFORM_DARWIN
    elif sys.platform.startswith('linux'):
        return PLATFORM_LINUX
    elif sys.platform.startswith('bsd'):
        return PLATFORM_BSD
    else:
        return PLATFORM_UNKNOWN
```

with

``` python
def get_platform_name():
    if sys.platform.startswith("win"):
        return PLATFORM_WINDOWS
    elif sys.platform.startswith('darwin'):
        return PLATFORM_DARWIN
    elif sys.platform.startswith('linux'):
        return PLATFORM_LINUX
    elif sys.platform.startswith('bsd') or sys.platform.startswith('freebsd'):
        return PLATFORM_BSD
    else:
        return PLATFORM_UNKNOWN
```

Let me know what you guys think
