### PR TITLE
Use setsid function from Python's os module

### DIFF
--- a/src/watchdog/tricks/__init__.py
+++ b/src/watchdog/tricks/__init__.py
@@ -138,13 +138,14 @@ class AutoRestartTrick(Trick):
                  kill_after=10):
         super(AutoRestartTrick, self).__init__(
             patterns, ignore_patterns, ignore_directories)
-        self.command = ['setsid'] + command
+        self.command = command
         self.stop_signal = stop_signal
         self.kill_after = kill_after
         self.process = None
 
     def start(self):
-        self.process = subprocess.Popen(self.command)
+
+        self.process = subprocess.Popen(self.command, preexec_fn=os.setsid)
 
     def stop(self):
         if self.process is None:

--- a/src/watchdog/tricks/__init__.py
+++ b/src/watchdog/tricks/__init__.py
@@ -144,7 +144,6 @@ class AutoRestartTrick(Trick):
         self.process = None
 
     def start(self):
-
         self.process = subprocess.Popen(self.command, preexec_fn=os.setsid)
 
     def stop(self):


### PR DESCRIPTION
Prevents errors on a Unix-like OS which does not have `setsid` included.