### PR TITLE
Use regex not strings.

### DIFF
--- a/src/watchdog/events.py
+++ b/src/watchdog/events.py
@@ -522,10 +522,10 @@ class RegexMatchingEventHandler(FileSystemEventHandler):
         if event.src_path:
             paths.append(unicode_paths.decode(event.src_path))
 
-        if any(r.match(p) for r in self.ignore_regexes for p in paths):
+        if any(r.match(p) for r in self._ignore_regexes for p in paths):
             return
 
-        if any(r.match(p) for r in self.regexes for p in paths):
+        if any(r.match(p) for r in self._regexes for p in paths):
             self.on_any_event(event)
             _method_map = {
                 EVENT_TYPE_MODIFIED: self.on_modified,


### PR DESCRIPTION
This PR fixes the issue of using the Regex handler. The current version only uses the strings, failing all the time. With this PR it uses the created regex.
