### PR TITLE
Added explicit WATCHDOG_OBSERVER env variable

### DIFF
--- a/src/watchdog/observers/__init__.py
+++ b/src/watchdog/observers/__init__.py
@@ -54,11 +54,24 @@ Class          Platforms                        Note
 
 """
 
+import os
 import warnings
 from watchdog.utils import platform
 from watchdog.utils import UnsupportedLibc
 
-if platform.is_linux():
+OBSERVER = os.environ.get('WATCHDOG_OBSERVER')
+
+# an observer can explicitly be configured with the WATCHDOG_OBSERVER
+# environment variable in dotted path form, just like an import, e.g.
+# watchdog.observers.polling.PollingObserver
+if OBSERVER:
+    import importlib
+
+    module_path, class_name = OBSERVER.rsplit('.', 1)
+    module = importlib.import_module(module_path)
+
+    Observer = getattr(module, class_name)
+elif platform.is_linux():
     try:
         from .inotify import InotifyObserver as Observer
     except UnsupportedLibc:


### PR DESCRIPTION
This allows the observer to be explicitly set.  The need for this is
when trying to detect changes on a virtual filesystem on VirtualBox that
is mounting a volume on a Mac.  In this scenario inotify does not detect
the changes, so polling is desired.