### PR TITLE
WindowsApiEmitter made easier to subclass.

### DIFF
--- a/src/watchdog/observers/read_directory_changes.py
+++ b/src/watchdog/observers/read_directory_changes.py
@@ -73,13 +73,16 @@ class WindowsApiEmitter(EventEmitter):
         if self._handle:
             close_directory_handle(self._handle)
 
+    def _read_events(self):
+        return read_events(self._handle, self.watch.is_recursive)
+
     def queue_events(self, timeout):
-        winapi_events = read_events(self._handle, self.watch.is_recursive)
+        winapi_events = self._read_events()
         with self._lock:
             last_renamed_src_path = ""
             for winapi_event in winapi_events:
                 src_path = os.path.join(self.watch.path, winapi_event.src_path)
-                
+
                 if winapi_event.is_renamed_old:
                     last_renamed_src_path = src_path
                 elif winapi_event.is_renamed_new:


### PR DESCRIPTION
queue_events now does not call read_events directly. The call
was put into a member function _read_events instead, to make
it easier to replace the read_events functionality while keeping
the rest of the class going.

I need to make the WindowsApiObserver reconnect on the network
failure. I achieve it by catching certain errors in get_directory_handle
and read_events, but with the way the code has been organized 
I had to "copy/paste" whole read_directory_changes file. If I take the 
read_events out of the queue_events, I can just override on_thread_start,
on_thread_stop and the new _read_events to achieve this.
