### PR TITLE
utils: fix import statements

### DIFF
--- a/src/watchdog/utils/__init__.py
+++ b/src/watchdog/utils/__init__.py
@@ -35,7 +35,6 @@ import sys
 import threading
 from watchdog.utils import platform
 from watchdog.utils.compat import Event
-from collections import namedtuple
 
 
 if sys.version_info[0] == 2 and platform.is_windows():

--- a/src/watchdog/utils/__init__.py
+++ b/src/watchdog/utils/__init__.py
@@ -33,7 +33,7 @@ Classes
 import os
 import sys
 import threading
-import watchdog.utils.platform
+from watchdog.utils import platform
 from watchdog.utils.compat import Event
 from collections import namedtuple
 


### PR DESCRIPTION
Hello,

The name `platform` in the `utils` module is undefined, as the import reads `import watchdog.utils.platform`. I guess you meant `from watchdog.utils import platform`?

BTW, thanks for the very useful package!
