### PR TITLE
to prevent user code kill the consumer thread of watchdog

### DIFF
--- a/src/watchdog/observers/api.py
+++ b/src/watchdog/observers/api.py
@@ -365,5 +365,12 @@ class BaseObserver(EventDispatcher):
             # registered after every dispatch.
             for handler in list(self._handlers.get(watch, [])):
                 if handler in self._handlers.get(watch, []):
-                    handler.dispatch(event)
+                    try:
+                        # to prevent user code kill the consumer thread of watchdog
+                        handler.dispatch(event)
+                    except Exception as e:
+                        import traceback
+                        print(e)
+                        traceback.print_exc()
+
         event_queue.task_done()


### PR DESCRIPTION
while user code raise a not cached exception, watchdog's consumer thread will be killed.and not reborn.that will make tasks in queue accumulated, and user have no way to save the watchdog but restart the process.
my modification tried to handler the "event handler's invocation" excepted the root "Exception" to avoid consumer thread's killing.
