### PR TITLE
polling observer: deleting observed directory now emits DirDeletedEvent

### DIFF
--- a/src/watchdog/observers/polling.py
+++ b/src/watchdog/observers/polling.py
@@ -88,7 +88,15 @@ class PollingEmitter(EventEmitter):
 
             # Get event diff between fresh snapshot and previous snapshot.
             # Update snapshot.
-            new_snapshot = self._take_snapshot()
+            try:
+                new_snapshot = self._take_snapshot()
+            except OSError as e:
+                self.queue_event(DirDeletedEvent(self.watch.path))
+                self.stop()
+                return
+            except Exception as e:
+                raise e
+
             events = DirectorySnapshotDiff(self._snapshot, new_snapshot)
             self._snapshot = new_snapshot
 

--- a/tests/legacy/test_watchdog_observers_polling.py
+++ b/tests/legacy/test_watchdog_observers_polling.py
@@ -141,3 +141,32 @@ class TestPollingEmitter(unittest.TestCase):
                 break
 
         self.assertEqual(expected, got)
+
+    def test_delete_watched_dir(self):
+        SLEEP_TIME = 0.4
+        self.emitter.start()
+        rm(p(''), recursive=True)
+        sleep(SLEEP_TIME)
+        self.emitter.stop()
+
+        # What we need here for the tests to pass is a collection type
+        # that is:
+        #   * unordered
+        #   * non-unique
+        # A multiset! Python's collections.Counter class seems appropriate.
+        expected = set(
+            [
+
+                DirDeletedEvent(os.path.dirname(p(''))),
+            ]
+        )
+
+        got = set()
+        while True:
+            try:
+                event, _ = self.event_queue.get_nowait()
+                got.add(event)
+            except queue.Empty:
+                break
+
+        self.assertEqual(expected, got)


### PR DESCRIPTION
This fixes an issue with the polling observer when the observed directory itself gets deleted.

Previously this resulted in a "DirNotFound" error and caused an exception.

Now the exception is handled and a `DirDeletedEvent` is raised plus stoping the polling observer appropriately.