### PR TITLE
Add a tox.ini that doesn't depend on setup.py test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,27 @@ python:
   - 3.2
   - 3.3
   - 3.4
+  - 3.5
+  - nightly
   - pypy
+  - pypy3
+
+before_install:
+  - SED_GET_PY='s/[^0-9]//g;s/.//3g;2s/.*/py/;1!G;h;$!d;s/y.2./y/;s/y.3./y3/'
+  - PY=$(python -V 2>&1 | sed "$SED_GET_PY")
+  - test $PY == 32 && TOX='virtualenv<14 tox' || TOX=tox
+  - export TOXENV=py$PY
 
 install:
-  - python setup.py install
+  - pip install $TOX
+  - tox --notest
 
 script:
-  - python setup.py test
+  - tox
 
 notifications:
     email: false
+
+matrix:
+    allow_failures:
+      - python: nightly

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,14 @@
 [tox]
-envlist = py26,py27,py34,pypy
+envlist = py{36,35,34,33,32,27,26,py3,py}
 
 [testenv]
-commands = python setup.py test
+deps = pytest-cov
+       pytest-timeout
+       py26: unittest2
+       py32: coverage<4
+       py32: pytest<3
+commands = py.test {posargs}
+
+[pytest]
+addopts = --cov=watchdog
+          --cov-report=term-missing


### PR DESCRIPTION
# Abstract

- Update tox.ini to avoid the setup.py test command that installs pytest-timeout twice instead of pytest
- Include more CPython versions: 3.2, 3.3, 3.5 and 3.6
- Include PyPy3
- Add `{posargs}` so one can test selected environments passing parameters to py.test (arguments after `--`), e.g.

  ```
  tox -e py35,py34 -- -k test_inotify
  ```

# Description

I wasn't able to run the watchdog test suite before due to the fact that pytest was installing pytest-timeout twice. This used to be the `tox -e py27` result:

```
[...]
py27 installed: argh==0.26.2,pathtools==0.1.2,PyYAML==3.11,watchdog==0.8.3
py27 runtests: PYTHONHASHSEED='3431958763'
py27 runtests: commands[0] | python setup.py test
[...]
```

It installs pytest-timeout:

```
[...]
Searching for pytest-timeout>=0.3
Reading https://pypi.python.org/simple/pytest-timeout/
Downloading https://pypi.python.org/packages/cf/92/ab29b9baa54d47dfd50e43be35577de9af4e7ebf27d29f546ddeb6c3b6f5/pytest-timeout-1.0.0.tar.gz#md5=f9f162bd079689980b5614673ddfdae4
Best match: pytest-timeout 1.0.0
Processing pytest-timeout-1.0.0.tar.gz
Writing /tmp/easy_install-jssqbJ/pytest-timeout-1.0.0/setup.cfg
Running pytest-timeout-1.0.0/setup.py -q bdist_egg --dist-dir /tmp/easy_install-jssqbJ/pytest-timeout-1.0.0/egg-dist-tmp-fIEa1U
zip_safe flag not set; analyzing archive contents...
Moving pytest_timeout-1.0.0-py2.7.egg to /home/danilo/code/watchdog/.eggs

Installed /home/danilo/code/watchdog/.eggs/pytest_timeout-1.0.0-py2.7.egg
[...]
```

But when installing pytest, it installs pytest-timeout again:

```
[...]
Searching for pytest
Downloading https://pypi.python.org/packages/cf/92/ab29b9baa54d47dfd50e43be35577de9af4e7ebf27d29f546ddeb6c3b6f5/pytest-timeout-1.0.0.tar.gz#md5=f9f162bd079689980b5614673ddfdae4
Best match: pytest timeout-1.0.0
Processing pytest-timeout-1.0.0.tar.gz
Writing /tmp/easy_install-lViTvF/pytest-timeout-1.0.0/setup.cfg
Running pytest-timeout-1.0.0/setup.py -q bdist_egg --dist-dir /tmp/easy_install-lViTvF/pytest-timeout-1.0.0/egg-dist-tmp-8MRQkx
zip_safe flag not set; analyzing archive contents...
Removing /home/danilo/code/watchdog/.eggs/pytest_timeout-1.0.0-py2.7.egg
Moving pytest_timeout-1.0.0-py2.7.egg to /home/danilo/code/watchdog/.eggs

Installed /home/danilo/code/watchdog/.eggs/pytest_timeout-1.0.0-py2.7.egg
[...]
```

Next, the tests doesn't run because pytest wasn't installed:

```
[...]
Traceback (most recent call last):
  File "setup.py", line 154, in <module>
    zip_safe=False
  File "/usr/lib64/python2.7/distutils/core.py", line 151, in setup
    dist.run_commands()
  File "/usr/lib64/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/usr/lib64/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/home/danilo/code/watchdog/.tox/py27/lib/python2.7/site-packages/setuptools/command/test.py", line 163, in run
    self.distribution.fetch_build_eggs(self.distribution.tests_require)
  File "/home/danilo/code/watchdog/.tox/py27/lib/python2.7/site-packages/setuptools/dist.py", line 394, in fetch_build_eggs
    replace_conflicting=True,
  File "/home/danilo/code/watchdog/.tox/py27/lib/python2.7/site-packages/pkg_resources/__init__.py", line 829, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'pytest' distribution was not found and is required by the application
[...]
```

The same happened in a virtualenv with Python 3, that has nothing to do with tox:

```
$ pip list
pip (8.1.2)
setuptools (25.1.6)
wheel (0.29.0)
$ python -V
Python 3.5.2
$ python setup.py test
[...]
Traceback (most recent call last):
  File "setup.py", line 154, in <module>
    zip_safe=False
  File "/usr/lib64/python3.5/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/usr/lib64/python3.5/distutils/dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "/usr/lib64/python3.5/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "/home/danilo/venv35/lib/python3.5/site-packages/setuptools/command/test.py", line 163, in run
    self.distribution.fetch_build_eggs(self.distribution.tests_require)
  File "/home/danilo/venv35/lib/python3.5/site-packages/setuptools/dist.py", line 394, in fetch_build_eggs
    replace_conflicting=True,
  File "/home/danilo/venv35/lib/python3.5/site-packages/pkg_resources/__init__.py", line 829, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'pytest' distribution was not found and is required by the application
```

And I don't see anything buggy in the setup.py either, it actually runs in my Python 3.2 environment:

```
$ pip list
coverage (3.7.1)
ipython (1.2.1)
pip (7.1.2)
pluggy (0.3.1)
py (1.4.31)
pytest (2.9.2)
setuptools (25.1.0)
tox (2.3.1)
virtualenv (13.1.2)
wheel (0.29.0)
$ python -V
Python 3.2.6
$ python setup.py test
[...]
==================== 61 passed, 1 skipped in 17.86 seconds =====================
```

I wanted to test on every environment without manually creating dozens of environments trying pip/setuptools versions (actually, that's why tox exist), and Python 3.2 is hard to test/use nowadays, since pip doesn't support it anymore.

I've changed the tox.ini to make it independent from the setup.py test command, and also to include Python 3.5, 3.6 and PyPy3. To test in Python 3.2, the environment that calls tox must have `virtualenv<14` (and `pip<8`). For the remaining ones, that's not required.

Tox caches downloads and virtualenvs. It allows passing parameters directly to py.test to call. For example,

```
tox -e py35,py34,pypy3 -- -k test_inotify
```

Runs the tests on CPython 3.5, CPython 3.4 and PyPy3, always calling `py.test -k test_inotify`, i.e., only the 5 tests that matches with that name, deselecting the remaining ones.

With this tox.ini I managed to run the entire test suite in every environment:

```
$ tox
[...]
___________________________________ summary ____________________________________
  py36: commands succeeded
  py35: commands succeeded
  py34: commands succeeded
  py33: commands succeeded
  py32: commands succeeded
  py27: commands succeeded
  py26: commands succeeded
  pypy3: commands succeeded
  pypy: commands succeeded
  congratulations :)
```