### PR TITLE
Fix crash on shutdown

### DIFF
--- a/src/watchdog/observers/inotify_c.py
+++ b/src/watchdog/observers/inotify_c.py
@@ -257,8 +257,9 @@ class Inotify(object):
         Closes the inotify instance and removes all associated watches.
         """
         with self._lock:
-            wd = self._wd_for_path[self._path]
-            inotify_rm_watch(self._inotify_fd, wd)
+            if self._path in self._wd_for_path:
+                wd = self._wd_for_path[self._path]
+                inotify_rm_watch(self._inotify_fd, wd)
             os.close(self._inotify_fd)
 
     def read_events(self, event_buffer_size=DEFAULT_EVENT_BUFFER_SIZE):

--- a/tests/test_inotify_buffer.py
+++ b/tests/test_inotify_buffer.py
@@ -19,7 +19,7 @@ import os
 import random
 import pytest
 from tests import tmpdir, p  # pytest magic
-from .shell import mkdir, touch, mv
+from .shell import mkdir, touch, mv, rm
 from watchdog.observers.api import ObservedWatch
 from watchdog.utils import platform
 
@@ -101,6 +101,19 @@ def test_move_internal_batch(p):
         assert os.path.dirname(to.src_path).endswith(b'/dir2')
         assert frm.name == to.name
         i += 1
+    inotify.close()
+
+
+@pytest.mark.timeout(5)
+def test_delete_watched_directory(p):
+    mkdir(p('dir'))
+    inotify = InotifyBuffer(p('dir').encode())
+    rm(p('dir'), recursive=True)
+
+    # Wait for the event to be picked up
+    inotify.read_event()
+
+    # Ensure InotifyBuffer shuts down cleanly without raising an exception
     inotify.close()
 
 


### PR DESCRIPTION
When the root directory being watched by inotify was deleted, watchdog
would crash with a KeyError when shutting down.

This commit stops watching the deleted directory for events once it's
been deleted, as well as adds a guard for the crash.