### PR TITLE
Improve *BSD detection in watchdog.observers.platform

### DIFF
--- a/src/watchdog/utils/platform.py
+++ b/src/watchdog/utils/platform.py
@@ -33,7 +33,7 @@ def get_platform_name():
         return PLATFORM_DARWIN
     elif sys.platform.startswith('linux'):
         return PLATFORM_LINUX
-    elif sys.platform.startswith('bsd'):
+	elif sys.platform.startswith(('dragonfly', 'freebsd', 'netbsd', 'openbsd', )):
         return PLATFORM_BSD
     else:
         return PLATFORM_UNKNOWN

--- a/src/watchdog/utils/platform.py
+++ b/src/watchdog/utils/platform.py
@@ -33,7 +33,7 @@ def get_platform_name():
         return PLATFORM_DARWIN
     elif sys.platform.startswith('linux'):
         return PLATFORM_LINUX
-	elif sys.platform.startswith(('dragonfly', 'freebsd', 'netbsd', 'openbsd', )):
+    elif sys.platform.startswith(('dragonfly', 'freebsd', 'netbsd', 'openbsd', )):
         return PLATFORM_BSD
     else:
         return PLATFORM_UNKNOWN


### PR DESCRIPTION
KqueueObeserver is never selected implicitly, since `sys.platform` is incorrectly tested to start with `'bsd'`, which it does on none of the BSDs actually implementing kqueue.