### PR TITLE
Added 'follow' keyword to trigger following of symbolic links, on linux-inotify.

### DIFF
--- a/src/watchdog/observers/inotify.py
+++ b/src/watchdog/observers/inotify.py
@@ -118,7 +118,7 @@ class InotifyEmitter(EventEmitter):
 
     def on_thread_start(self):
         path = unicode_paths.encode(self.watch.path)
-        self._inotify = InotifyBuffer(path, self.watch.is_recursive)
+        self._inotify = InotifyBuffer(path, self.watch.is_recursive, self.watch.does_follow_links)
 
     def on_thread_stop(self):
         if self._inotify:

--- a/src/watchdog/observers/inotify_buffer.py
+++ b/src/watchdog/observers/inotify_buffer.py
@@ -29,10 +29,10 @@ class InotifyBuffer(BaseThread):
 
     delay = 0.5
 
-    def __init__(self, path, recursive=False):
+    def __init__(self, path, recursive=False, follow=False):
         BaseThread.__init__(self)
         self._queue = DelayedQueue(self.delay)
-        self._inotify = Inotify(path, recursive)
+        self._inotify = Inotify(path, recursive, follow)
         self.start()
 
     def read_event(self):

--- a/src/watchdog/observers/inotify_c.py
+++ b/src/watchdog/observers/inotify_c.py
@@ -167,9 +167,11 @@ class Inotify(object):
         :class:`bytes`
     :param recursive:
         ``True`` if subdirectories should be monitored; ``False`` otherwise.
+    :param follow:
+        ``True`` if symbolic links should be traversed; ``False`` otherwise.
     """
 
-    def __init__(self, path, recursive=False, event_mask=WATCHDOG_ALL_EVENTS):
+    def __init__(self, path, recursive=False, follow=False, event_mask=WATCHDOG_ALL_EVENTS):
         # The file descriptor associated with the inotify instance.
         inotify_fd = inotify_init()
         if inotify_fd == -1:
@@ -184,7 +186,8 @@ class Inotify(object):
         self._path = path
         self._event_mask = event_mask
         self._is_recursive = recursive
-        self._add_dir_watch(path, recursive, event_mask)
+        self._follow_links = follow
+        self._add_dir_watch(path, recursive, follow, event_mask)
         self._moved_from_events = dict()
 
     @property
@@ -351,7 +354,7 @@ class Inotify(object):
         return event_list
 
     # Non-synchronized methods.
-    def _add_dir_watch(self, path, recursive, mask):
+    def _add_dir_watch(self, path, recursive, follow, mask):
         """
         Adds a watch (optionally recursively) for the given directory path
         to monitor events specified by the mask.
@@ -360,19 +363,31 @@ class Inotify(object):
             Path to monitor
         :param recursive:
             ``True`` to monitor recursively.
+        :param follow:
+            ``True`` to traverse symbolic links
         :param mask:
             Event bit mask.
         """
         if not os.path.isdir(path):
             raise OSError('Path is not a directory')
-        self._add_watch(path, mask)
+
+        if os.path.islink(path):
+            if follow:
+                self._add_watch( path + bytearray( (os.sep + '.').encode('ascii')) , mask)
+            else:
+                raise OSError('monitoring a symlinked directory does not work.  Try \'follow\' option')
+        else:
+            self._add_watch(path, mask)
+
         if recursive:
             for root, dirnames, _ in os.walk(path):
                 for dirname in dirnames:
                     full_path = os.path.join(root, dirname)
                     if os.path.islink(full_path):
-                        continue
-                    self._add_watch(full_path, mask)
+                        if follow:
+                            self._add_watch( full_path + bytearray( (os.sep + '.').encode('ascii')) , mask)
+                    else:
+                        self._add_watch(full_path, mask)
 
     def _add_watch(self, path, mask):
         """

--- a/tests/legacy/test_watchdog_observers_api.py
+++ b/tests/legacy/test_watchdog_observers_api.py
@@ -33,28 +33,28 @@ from watchdog.events import LoggingEventHandler, FileModifiedEvent
 class TestObservedWatch(unittest.TestCase):
 
     def test___eq__(self):
-        watch1 = ObservedWatch('/foobar', True)
-        watch2 = ObservedWatch('/foobar', True)
-        watch_ne1 = ObservedWatch('/foo', True)
-        watch_ne2 = ObservedWatch('/foobar', False)
+        watch1 = ObservedWatch('/foobar', True, False)
+        watch2 = ObservedWatch('/foobar', True, False)
+        watch_ne1 = ObservedWatch('/foo', True, False)
+        watch_ne2 = ObservedWatch('/foobar', False, False)
 
         self.assertTrue(watch1.__eq__(watch2))
         self.assertFalse(watch1.__eq__(watch_ne1))
         self.assertFalse(watch1.__eq__(watch_ne2))
 
     def test___ne__(self):
-        watch1 = ObservedWatch('/foobar', True)
-        watch2 = ObservedWatch('/foobar', True)
-        watch_ne1 = ObservedWatch('/foo', True)
-        watch_ne2 = ObservedWatch('/foobar', False)
+        watch1 = ObservedWatch('/foobar', True, False)
+        watch2 = ObservedWatch('/foobar', True, False)
+        watch_ne1 = ObservedWatch('/foo', True, False)
+        watch_ne2 = ObservedWatch('/foobar', False, False)
 
         self.assertFalse(watch1.__ne__(watch2))
         self.assertTrue(watch1.__ne__(watch_ne1))
         self.assertTrue(watch1.__ne__(watch_ne2))
 
     def test___repr__(self):
-        observed_watch = ObservedWatch('/foobar', True)
-        self.assertEqual('<ObservedWatch: path=' + '/foobar' + ', is_recursive=True>',
+        observed_watch = ObservedWatch('/foobar', True, False)
+        self.assertEqual('<ObservedWatch: path=' + '/foobar' + ', is_recursive=True' + ', does_follow_links=False>',
                          observed_watch.__repr__())
 
 
@@ -62,7 +62,7 @@ class TestEventEmitter(unittest.TestCase):
 
     def test___init__(self):
         event_queue = EventQueue()
-        watch = ObservedWatch('/foobar', True)
+        watch = ObservedWatch('/foobar', True, False)
         event_emitter = EventEmitter(event_queue, watch, timeout=1)
         event_emitter.queue_event(FileModifiedEvent('/foobar/blah'))
 
@@ -71,7 +71,7 @@ class TestEventDispatcher(unittest.TestCase):
 
     def test_dispatch_event(self):
         event = FileModifiedEvent('/foobar')
-        watch = ObservedWatch('/path', True)
+        watch = ObservedWatch('/path', True, False)
 
         class TestableEventDispatcher(EventDispatcher):
 

--- a/tests/legacy/test_watchdog_observers_polling.py
+++ b/tests/legacy/test_watchdog_observers_polling.py
@@ -65,7 +65,7 @@ class TestPollingEmitter(unittest.TestCase):
 
     def setUp(self):
         self.event_queue = queue.Queue()
-        self.watch = ObservedWatch(temp_dir, True)
+        self.watch = ObservedWatch(temp_dir, True, False)
         self.emitter = Emitter(self.event_queue, self.watch, timeout=0.2)
 
     def teardown(self):

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -49,9 +49,9 @@ def start_watching(path=None, use_full_emitter=False):
     path = p('') if path is None else path
     global emitter
     if platform.is_linux() and use_full_emitter:
-        emitter = InotifyFullEmitter(event_queue, ObservedWatch(path, recursive=True))
+        emitter = InotifyFullEmitter(event_queue, ObservedWatch(path, recursive=True, follow=False))
     else:
-        emitter = Emitter(event_queue, ObservedWatch(path, recursive=True))
+        emitter = Emitter(event_queue, ObservedWatch(path, recursive=True, follow=False))
 
     if platform.is_darwin():
         # FSEvents will report old evens (like create for mkdtemp in test

--- a/tests/test_inotify_c.py
+++ b/tests/test_inotify_c.py
@@ -30,7 +30,7 @@ def watching(path=None, use_full_emitter=False):
     path = p('') if path is None else path
     global emitter
     Emitter = InotifyFullEmitter if use_full_emitter else InotifyEmitter
-    emitter = Emitter(event_queue, ObservedWatch(path, recursive=True))
+    emitter = Emitter(event_queue, ObservedWatch(path, recursive=True, follow=False))
     emitter.start()
     yield
     emitter.stop()


### PR DESCRIPTION
Added support for 'follow' keyword to inotify implementation (Linux.)
dev done with python3, passes all tests on python2 and python3.
Platforms other than linux not tested.

A lot of people seem to complain about this, and it bit me also.
Would need someone else to add support on Mac & windows, I only use Linux.