### PR TITLE
Don't Walk Directories Without Read Permissions

### DIFF
--- a/src/watchdog/utils/dirsnapshot.py
+++ b/src/watchdog/utils/dirsnapshot.py
@@ -229,7 +229,7 @@ class DirectorySnapshot(object):
                 yield _
             if recursive:
                 for path, st in entries:
-                    if S_ISDIR(st.st_mode):
+                    if S_ISDIR(st.st_mode) and os.access(path, os.R_OK):
                         for _ in walk(path):
                             yield _
 


### PR DESCRIPTION
Fixing an issue I noticed on macOS if the watched directory has subdirectories that do not have read permissions (specifically ```.Trashes```).