### PR TITLE
Use separate ctypes DLL instances

### DIFF
--- a/src/watchdog/observers/read_directory_changes.py
+++ b/src/watchdog/observers/read_directory_changes.py
@@ -19,7 +19,6 @@
 
 from __future__ import with_statement
 
-import ctypes
 import threading
 import os.path
 import time
@@ -79,7 +78,7 @@ class WindowsApiEmitter(EventEmitter):
             last_renamed_src_path = ""
             for winapi_event in winapi_events:
                 src_path = os.path.join(self.watch.path, winapi_event.src_path)
-                
+
                 if winapi_event.is_renamed_old:
                     last_renamed_src_path = src_path
                 elif winapi_event.is_renamed_new:

--- a/src/watchdog/observers/winapi.py
+++ b/src/watchdog/observers/winapi.py
@@ -123,7 +123,9 @@ def _errcheck_dword(value, func, args):
     return args
 
 
-ReadDirectoryChangesW = ctypes.windll.kernel32.ReadDirectoryChangesW
+kernel32 = ctypes.WinDLL("kernel32")
+
+ReadDirectoryChangesW = kernel32.ReadDirectoryChangesW
 ReadDirectoryChangesW.restype = ctypes.wintypes.BOOL
 ReadDirectoryChangesW.errcheck = _errcheck_bool
 ReadDirectoryChangesW.argtypes = (
@@ -137,7 +139,7 @@ ReadDirectoryChangesW.argtypes = (
     LPVOID  # FileIOCompletionRoutine # lpCompletionRoutine
 )
 
-CreateFileW = ctypes.windll.kernel32.CreateFileW
+CreateFileW = kernel32.CreateFileW
 CreateFileW.restype = ctypes.wintypes.HANDLE
 CreateFileW.errcheck = _errcheck_handle
 CreateFileW.argtypes = (
@@ -150,13 +152,13 @@ CreateFileW.argtypes = (
     ctypes.wintypes.HANDLE  # hTemplateFile
 )
 
-CloseHandle = ctypes.windll.kernel32.CloseHandle
+CloseHandle = kernel32.CloseHandle
 CloseHandle.restype = ctypes.wintypes.BOOL
 CloseHandle.argtypes = (
     ctypes.wintypes.HANDLE,  # hObject
 )
 
-CancelIoEx = ctypes.windll.kernel32.CancelIoEx
+CancelIoEx = kernel32.CancelIoEx
 CancelIoEx.restype = ctypes.wintypes.BOOL
 CancelIoEx.errcheck = _errcheck_bool
 CancelIoEx.argtypes = (
@@ -164,7 +166,7 @@ CancelIoEx.argtypes = (
     ctypes.POINTER(OVERLAPPED)  # lpOverlapped
 )
 
-CreateEvent = ctypes.windll.kernel32.CreateEventW
+CreateEvent = kernel32.CreateEventW
 CreateEvent.restype = ctypes.wintypes.HANDLE
 CreateEvent.errcheck = _errcheck_handle
 CreateEvent.argtypes = (
@@ -174,14 +176,14 @@ CreateEvent.argtypes = (
     ctypes.wintypes.LPCWSTR,  # lpName
 )
 
-SetEvent = ctypes.windll.kernel32.SetEvent
+SetEvent = kernel32.SetEvent
 SetEvent.restype = ctypes.wintypes.BOOL
 SetEvent.errcheck = _errcheck_bool
 SetEvent.argtypes = (
     ctypes.wintypes.HANDLE,  # hEvent
 )
 
-WaitForSingleObjectEx = ctypes.windll.kernel32.WaitForSingleObjectEx
+WaitForSingleObjectEx = kernel32.WaitForSingleObjectEx
 WaitForSingleObjectEx.restype = ctypes.wintypes.DWORD
 WaitForSingleObjectEx.errcheck = _errcheck_dword
 WaitForSingleObjectEx.argtypes = (
@@ -190,7 +192,7 @@ WaitForSingleObjectEx.argtypes = (
     ctypes.wintypes.BOOL,  # bAlertable
 )
 
-CreateIoCompletionPort = ctypes.windll.kernel32.CreateIoCompletionPort
+CreateIoCompletionPort = kernel32.CreateIoCompletionPort
 CreateIoCompletionPort.restype = ctypes.wintypes.HANDLE
 CreateIoCompletionPort.errcheck = _errcheck_handle
 CreateIoCompletionPort.argtypes = (
@@ -200,7 +202,7 @@ CreateIoCompletionPort.argtypes = (
     ctypes.wintypes.DWORD,  # NumberOfConcurrentThreads
 )
 
-GetQueuedCompletionStatus = ctypes.windll.kernel32.GetQueuedCompletionStatus
+GetQueuedCompletionStatus = kernel32.GetQueuedCompletionStatus
 GetQueuedCompletionStatus.restype = ctypes.wintypes.BOOL
 GetQueuedCompletionStatus.errcheck = _errcheck_bool
 GetQueuedCompletionStatus.argtypes = (
@@ -211,7 +213,7 @@ GetQueuedCompletionStatus.argtypes = (
     ctypes.wintypes.DWORD,  # dwMilliseconds
 )
 
-PostQueuedCompletionStatus = ctypes.windll.kernel32.PostQueuedCompletionStatus
+PostQueuedCompletionStatus = kernel32.PostQueuedCompletionStatus
 PostQueuedCompletionStatus.restype = ctypes.wintypes.BOOL
 PostQueuedCompletionStatus.errcheck = _errcheck_bool
 PostQueuedCompletionStatus.argtypes = (
@@ -255,7 +257,7 @@ WATCHDOG_FILE_NOTIFY_FLAGS = reduce(
 
 BUFFER_SIZE = 2048
 
-    
+
 def _parse_event_buffer(readBuffer, nBytes):
     results = []
     while nBytes > 0:
@@ -318,27 +320,27 @@ class WinAPINativeEvent(object):
     def __init__(self, action, src_path):
         self.action = action
         self.src_path = src_path
-    
+
     @property
     def is_added(self):
         return self.action == FILE_ACTION_CREATED
-    
+
     @property
     def is_removed(self):
         return self.action == FILE_ACTION_REMOVED
-    
+
     @property
     def is_modified(self):
         return self.action == FILE_ACTION_MODIFIED
-    
+
     @property
     def is_renamed_old(self):
         return self.action == FILE_ACTION_RENAMED_OLD_NAME
-    
+
     @property
     def is_renamed_new(self):
         return self.action == FILE_ACTION_RENAMED_NEW_NAME
-    
+
     def __repr__(self):
         return ("<WinAPINativeEvent: action=%d, src_path=%r>" % (self.action, self.src_path))
 

--- a/src/watchdog/utils/win32stat.py
+++ b/src/watchdog/utils/win32stat.py
@@ -59,7 +59,9 @@ class BY_HANDLE_FILE_INFORMATION(ctypes.Structure):
                 ('nFileIndexLow', ctypes.wintypes.DWORD)]
 
 
-CreateFile = ctypes.windll.kernel32.CreateFileW
+kernel32 = ctypes.WinDLL("kernel32")
+
+CreateFile = kernel32.CreateFileW
 CreateFile.restype = ctypes.wintypes.HANDLE
 CreateFile.argtypes = (
     ctypes.c_wchar_p,
@@ -71,14 +73,14 @@ CreateFile.argtypes = (
     ctypes.wintypes.HANDLE,
 )
 
-GetFileInformationByHandle = ctypes.windll.kernel32.GetFileInformationByHandle
+GetFileInformationByHandle = kernel32.GetFileInformationByHandle
 GetFileInformationByHandle.restype = ctypes.wintypes.BOOL
 GetFileInformationByHandle.argtypes = (
     ctypes.wintypes.HANDLE,
     ctypes.wintypes.POINTER(BY_HANDLE_FILE_INFORMATION),
 )
 
-CloseHandle = ctypes.windll.kernel32.CloseHandle
+CloseHandle = kernel32.CloseHandle
 CloseHandle.restype = ctypes.wintypes.BOOL
 CloseHandle.argtypes = (ctypes.wintypes.HANDLE,)
 


### PR DESCRIPTION
This prevents us being affected or affecting other code that might use ctypes. Also trimmed some trailing whitespace and an unused import.