### PR TITLE
Avoid race condition crash when a directory is swapped for a file

### DIFF
--- a/src/watchdog/utils/dirsnapshot.py
+++ b/src/watchdog/utils/dirsnapshot.py
@@ -44,7 +44,6 @@ Classes
 
 """
 
-import errno
 import os
 from stat import S_ISDIR
 from watchdog.utils import platform
@@ -211,14 +210,12 @@ class DirectorySnapshot(object):
         def walk(root):
             try:
                 paths = [os.path.join(root, name) for name in listdir(root)]
-            except OSError as e:
+            except (FileNotFoundError, NotADirectoryError):
                 # Directory may have been deleted between finding it in the directory
                 # list of its parent and trying to delete its contents. If this
-                # happens we treat it as empty.
-                if e.errno == errno.ENOENT:
-                    return
-                else:
-                    raise
+                # happens we treat it as empty. Likewise if the directory was replaced
+                # with a file of the same name (less likely, but possible).
+                return
             entries = []
             for p in paths:
                 try:


### PR DESCRIPTION
This commit builds off the race condition checking introduced in
2e8319992, but also correctly handles the case where a directory is
replaced with a file before it can be walked.

For example:
1. [external] create `/a/b/c.txt`
2. [watchdog] walk `/a` (contains directory `/a/b/` at this point)
3. [external] `rm -rf /a/b/`
4. [external] `touch /a/b`
5. [watchdog] walk `/a/b/` (raises `NotADirectoryError`)