### PR TITLE
Count permission change events as a file modification

### DIFF
--- a/src/watchdog/utils/dirsnapshot.py
+++ b/src/watchdog/utils/dirsnapshot.py
@@ -46,7 +46,7 @@ Classes
 
 import errno
 import os
-from stat import S_ISDIR
+from stat import S_ISDIR, S_IMODE
 from watchdog.utils import platform
 from watchdog.utils import stat as default_stat
 
@@ -99,7 +99,8 @@ class DirectorySnapshotDiff(object):
         modified = set()
         for path in ref.paths & snapshot.paths:
             if ref.inode(path) == snapshot.inode(path):
-                if ref.mtime(path) != snapshot.mtime(path):
+                if ref.mtime(path) != snapshot.mtime(path) or \
+                   ref.mode(path) != snapshot.mode(path):
                     modified.add(path)
         
         for (old_path, new_path) in moved:
@@ -262,6 +263,9 @@ class DirectorySnapshot(object):
     
     def mtime(self, path):
         return self._stat_info[path].st_mtime
+
+    def mode(self, path):
+        return S_IMODE(self._stat_info[path].st_mode)
     
     def stat_info(self, path):
         """


### PR DESCRIPTION
Thanks for making watchdog -- it's been really useful.

Currently, watchdog does not catch changes in file permissions. I'm not sure if this is intentional, or an oversight. If it was an oversight, this PR introduces a fix.

For a minimal example:

```py
from watchdog.utils.dirsnapshot import DirectorySnapshot
import subprocess

BASE_PATH = '/Users/pascal/test/tmp-92'
FILE_PATH = f'{BASE_PATH}/large-file-37.txt'

res = subprocess.run(f'chmod u-x {FILE_PATH}', shell=True)
s = DirectorySnapshot(BASE_PATH)
print(s.mode(FILE_PATH))
res = subprocess.run(f'chmod u+x {FILE_PATH}', shell=True)
s2 = DirectorySnapshot(BASE_PATH)
print(s2.mode(FILE_PATH))

print((s - s2).files_modified)
```