### PR TITLE
Add a workaround to support uClibc library

### DIFF
--- a/src/watchdog/observers/inotify_c.py
+++ b/src/watchdog/observers/inotify_c.py
@@ -45,7 +45,19 @@ def _load_libc():
     try:
         return ctypes.CDLL('libc.so')
     except (OSError, IOError):
+        pass
+
+    try:
         return ctypes.CDLL('libc.so.6')
+    except (OSError, IOError):
+        pass
+
+    # uClibc
+    try:
+        return ctypes.CDLL('libc.so.0')
+    except (OSError, IOError) as err:
+        raise err
+
 
 libc = _load_libc()
 


### PR DESCRIPTION
uClibc based systems provide only libc.so.0 and libc.so.1
symlinks.

So try to find libc.so.0 if neither libc.so nor libc.so.6
could be found.

Signed-off-by: Yegor Yefremov <yegorslists@googlemail.com>