### PR TITLE
Generate sub created events only if recursive=True

### DIFF
--- a/src/watchdog/observers/read_directory_changes.py
+++ b/src/watchdog/observers/read_directory_changes.py
@@ -113,7 +113,7 @@ class WindowsApiEmitter(EventEmitter):
                     isdir = os.path.isdir(src_path)
                     cls = DirCreatedEvent if isdir else FileCreatedEvent
                     self.queue_event(cls(src_path))
-                    if isdir:
+                    if isdir and self.watch.is_recursive:
                         # If a directory is moved from outside the watched folder to inside it
                         # we only get a created directory event out of it, not any events for its children
                         # so use the same hack as for file moves to get the child events

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -17,8 +17,8 @@
 import unittest
 
 try:
-    from Queue import Queue  # Python 2
+    from Queue import Queue, Empty  # Python 2
 except ImportError:
-    from queue import Queue  # Python 3
+    from queue import Queue, Empty  # Python 3
 
-__all__ = ["unittest", "Queue"]
+__all__ = ["unittest", "Queue", "Empty"]


### PR DESCRIPTION
When directory with some files will be copied in to observed directory, watchdog emits events about that files created, even if recursive switched off.