### PR TITLE
Fix deprecated imp module usage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@
 # limitations under the License.
 
 import sys
-import importlib.util
 import os.path
 from setuptools import setup, find_packages
 from setuptools.extension import Extension
@@ -28,10 +27,15 @@ from distutils.util import get_platform
 SRC_DIR = 'src'
 WATCHDOG_PKG_DIR = os.path.join(SRC_DIR, 'watchdog')
 
-spec = importlib.util.spec_from_file_location(
-    'version', os.path.join(WATCHDOG_PKG_DIR, 'version.py'))
-version = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(version)
+if sys.version_info >= (3, 5):
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        'version', os.path.join(WATCHDOG_PKG_DIR, 'version.py'))
+    version = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(version)
+else:
+    import imp
+    version = imp.load_source('version', os.path.join(WATCHDOG_PKG_DIR, 'version.py'))
 
 ext_modules = []
 if get_platform().startswith('macosx'):

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@
 # limitations under the License.
 
 import sys
-import imp
+import importlib.util
 import os.path
 from setuptools import setup, find_packages
 from setuptools.extension import Extension
@@ -28,7 +28,10 @@ from distutils.util import get_platform
 SRC_DIR = 'src'
 WATCHDOG_PKG_DIR = os.path.join(SRC_DIR, 'watchdog')
 
-version = imp.load_source('version', os.path.join(WATCHDOG_PKG_DIR, 'version.py'))
+spec = importlib.util.spec_from_file_location(
+    'version', os.path.join(WATCHDOG_PKG_DIR, 'version.py'))
+version = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(version)
 
 ext_modules = []
 if get_platform().startswith('macosx'):

--- a/tools/bootstrap.py
+++ b/tools/bootstrap.py
@@ -67,7 +67,6 @@ if not has_broken_dash_S and 'site' in sys.modules:
 # out any namespace packages from site-packages that might have been
 # loaded by .pth files.
 clean_path = sys.path[:]
-import site
 sys.path[:] = clean_path
 for k, v in list(sys.modules.items()):
     if k in ('setuptools', 'pkg_resources') or (
@@ -190,8 +189,8 @@ except ImportError:
     ez['use_setuptools'](**setup_args)
     if 'pkg_resources' in sys.modules:
         if sys.version_info[0] >= 3:
-            import imp
-            reload_ = imp.reload
+            import importlib
+            reload_ = importlib.reload
         else:
             reload_ = reload
 


### PR DESCRIPTION
It is recommended to use `importlib` instead of the deprecated `imp`.