### PR TITLE
Import InotifyFullEmitter only on Linux

### DIFF
--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -38,9 +38,9 @@ from watchdog.observers.api import ObservedWatch
 pytestmark = pytest.mark.skipif(not platform.is_linux() and not platform.is_darwin(), reason="")
 if platform.is_linux():
     from watchdog.observers.inotify import InotifyEmitter as Emitter
+    from watchdog.observers.inotify import InotifyFullEmitter
 elif platform.is_darwin():
     from watchdog.observers.fsevents2 import FSEventsEmitter as Emitter
-from watchdog.observers.inotify import InotifyFullEmitter
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
@@ -145,6 +145,7 @@ def test_move_to():
     assert isinstance(event, FileCreatedEvent)
     assert event.src_path == p('dir2', 'b')
 
+
 def test_move_to_full():
     mkdir(p('dir1'))
     mkdir(p('dir2'))
@@ -156,6 +157,7 @@ def test_move_to_full():
     assert event.dest_path == p('dir2', 'b')
     assert event.src_path == None #Should equal none since the path was not watched
 
+
 def test_move_from():
     mkdir(p('dir1'))
     mkdir(p('dir2'))
@@ -166,7 +168,8 @@ def test_move_from():
     event = event_queue.get(timeout=5)[0]
     assert isinstance(event, FileDeletedEvent)
     assert event.src_path == p('dir1', 'a')
- 
+
+
 def test_move_from_full():
     mkdir(p('dir1'))
     mkdir(p('dir2'))
@@ -177,6 +180,7 @@ def test_move_from_full():
     assert isinstance(event, FileMovedEvent)
     assert event.src_path == p('dir1', 'a')
     assert event.dest_path == None #Should equal None since path not watched
+
 
 def test_separate_consecutive_moves():
     mkdir(p('dir1'))


### PR DESCRIPTION
Fix errors while run tests on Windows like this:
```
=================================== ERRORS ====================================  
___________________ ERROR collecting tests/test_emitter.py ____________________  
tests\test_emitter.py:43: in <module>                                            
    from watchdog.observers.inotify import InotifyFullEmitter                    
.tox\py37\lib\site-packages\watchdog\observers\inotify.py:74: in <module>        
    from .inotify_buffer import InotifyBuffer                                    
.tox\py37\lib\site-packages\watchdog\observers\inotify_buffer.py:20: in <module> 
    from watchdog.observers.inotify_c import Inotify                             
.tox\py37\lib\site-packages\watchdog\observers\inotify_c.py:62: in <module>      
    libc = _load_libc()                                                          
.tox\py37\lib\site-packages\watchdog\observers\inotify_c.py:59: in _load_libc    
    raise err                                                                    
.tox\py37\lib\site-packages\watchdog\observers\inotify_c.py:57: in _load_libc    
    return ctypes.CDLL('libc.so.0')                                              
c:\python37\Lib\ctypes\__init__.py:356: in __init__                              
    self._handle = _dlopen(self._name, mode)                                     
E   OSError: [WinError 126] Не найден указанный модуль         
```

                  