### PR TITLE
Add Appveyor CI for Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,44 @@
+build: off
+
+cache:
+  - '%LOCALAPPDATA%\pip\Cache'
+
+environment:
+  matrix:
+    - python: py27
+      tox_env: py27
+      python_path: c:\python27
+    - python: py27-x64
+      tox_env: py27
+      python_path: c:\python27-x64
+    - python: py34
+      tox_env: py34
+      python_path: c:\python34
+    - python: py34-x64
+      tox_env: py34
+      python_path: c:\python34-x64
+    - python: py35
+      tox_env: py35
+      python_path: c:\python35
+    - python: py35-x64
+      tox_env: py35
+      python_path: c:\python35-x64
+    - python: py36
+      tox_env: py36
+      python_path: c:\python36
+    - python: py36-x64
+      tox_env: py36
+      python_path: c:\python36-x64
+    - python: py37
+      tox_env: py37
+      python_path: c:\python37
+    - python: py37-x64
+      tox_env: py37
+      python_path: c:\python37-x64
+
+install:
+  - SET "PATH=%python_path%;%python_path%\Scripts;%PATH%"
+  - pip install tox
+
+test_script:
+  tox -e %tox_env%

--- a/tests/legacy/test_watch_observers_winapi.py
+++ b/tests/legacy/test_watch_observers_winapi.py
@@ -65,7 +65,7 @@ if platform.is_windows():
             pass
 
         def test___init__(self):
-            SLEEP_TIME = 1
+            SLEEP_TIME = 2
             self.emitter.start()
             sleep(SLEEP_TIME)
             mkdir(p('fromdir'))


### PR DESCRIPTION
Enable Windows tests on Python 2.7, 3.5, 3.6 and 3.7 (32 and 64-bit). 
Notes:

- Appveyor using Windows Server 2012 R2 for running build and test. 
- Sleep time in legacy test test_watch_observers_winapi.py increased because build server sometimes to slow and test failed unexpectedly from time to time.

Fixes a part of #469.