### PR TITLE
Eliminate unnecessary delay with inotify events

### DIFF
--- a/src/watchdog/observers/inotify_buffer.py
+++ b/src/watchdog/observers/inotify_buffer.py
@@ -50,6 +50,33 @@ class InotifyBuffer(BaseThread):
         self.stop()
         self.join()
 
+    def _group_events(self, event_list):
+        """Group any matching move events"""
+        grouped = []
+        for inotify_event in event_list:
+            logger.debug("in-event %s", inotify_event)
+            def matching_from_event(event):
+                return (not isinstance(event, tuple) and event.is_moved_from
+                        and event.cookie == inotify_event.cookie)
+
+            if inotify_event.is_moved_to:
+                # Check if move_from is already in the buffer
+                for index, event in enumerate(grouped):
+                    if matching_from_event(event):
+                        grouped[index] = (event, inotify_event)
+                        break
+                else:
+                    # Check if move_from is in delayqueue already
+                    from_event = self._queue.remove(matching_from_event)
+                    if from_event is not None:
+                        grouped.append((from_event, inotify_event))
+                    else:
+                        logger.debug("could not find matching move_from event")
+                        grouped.append(inotify_event)
+            else:
+                grouped.append(inotify_event)
+        return grouped
+
     def run(self):
         """Read event from `inotify` and add them to `queue`. When reading a
         IN_MOVE_TO event, remove the previous added matching IN_MOVE_FROM event
@@ -58,24 +85,13 @@ class InotifyBuffer(BaseThread):
         deleted_self = False
         while self.should_keep_running() and not deleted_self:
             inotify_events = self._inotify.read_events()
-            for inotify_event in inotify_events:
-                logger.debug("in-event %s", inotify_event)
-                if inotify_event.is_moved_to:
+            grouped_events = self._group_events(inotify_events)
+            for inotify_event in grouped_events:
+                # Only add delay for unmatched move_from events
+                delay = not isinstance(inotify_event, tuple) and inotify_event.is_moved_from
+                self._queue.put(inotify_event, delay)
 
-                    def matching_from_event(event):
-                        return (not isinstance(event, tuple) and event.is_moved_from
-                                and event.cookie == inotify_event.cookie)
-
-                    from_event = self._queue.remove(matching_from_event)
-                    if from_event is not None:
-                        self._queue.put((from_event, inotify_event))
-                    else:
-                        logger.debug("could not find matching move_from event")
-                        self._queue.put(inotify_event)
-                else:
-                    self._queue.put(inotify_event)
-
-                if inotify_event.is_delete_self and \
+                if not isinstance(inotify_event, tuple) and inotify_event.is_delete_self and \
                         inotify_event.src_path == self._inotify.path:
                     # Deleted the watched directory, stop watching for events
                     deleted_self = True

--- a/tests/test_delayed_queue.py
+++ b/tests/test_delayed_queue.py
@@ -18,11 +18,22 @@ from time import time
 from watchdog.utils.delayed_queue import DelayedQueue
 
 
-def test_get():
+def test_delayed_get():
     q = DelayedQueue(2)
-    q.put("")
+    q.put("", True)
     inserted = time()
     q.get()
     elapsed = time() - inserted
     # 2.10 instead of 2.05 for slow macOS slaves on Travis
     assert 2.10 > elapsed > 1.99
+
+def test_nondelayed_get():
+    q = DelayedQueue(2)
+    q.put("", False)
+    inserted = time()
+    q.get()
+    elapsed = time() - inserted
+    # Far less than 1 second
+    assert elapsed < 1
+
+


### PR DESCRIPTION
Proposing a change to the way inotify events are processed to avoid (almost) completely all delays for the clients.

1) As far as I know most Linux filesystems implement moves as atomic operations, so we should expect to always have IN_MOVE_FROM and IN_MOVE_TO events in the buffer. By doing the move operation matching on the event list from the buffer without going through the DelayQueue we can avoid introducing delays when IN_MOVE_FROM and IN_MOVE_TO are readily available.
2) Do not add a delay for any non-move events. There is no matching to be done, so these events can be dispatched to clients immediately. Move events will stall the queue, so we don't end up with out of order events.

Sorry for resubmitting.