### PR TITLE
Remove `easy_install` instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,19 +120,13 @@ Please file enhancement requests at the `issue tracker`_.
 
 Installation
 ------------
-Installing from PyPI using ``pip``:
+Install from PyPI using ``pip``:
     
 .. code-block:: bash
 
     $ python -m pip install watchdog
 
-Installing from PyPI using ``easy_install``:
-    
-.. code-block:: bash
-
-    $ easy_install watchdog
-
-Installing from source:
+Install from source:
     
 .. code-block:: bash
 


### PR DESCRIPTION
`pip` is recommended installer for python n00bs these days. 

Those who still need `easy_install` for some particular reason will know about far more about it than we can hope to put in the readme.