### PR TITLE
Trigger modified event when the file size has changed.

### DIFF
--- a/src/watchdog/utils/dirsnapshot.py
+++ b/src/watchdog/utils/dirsnapshot.py
@@ -102,11 +102,11 @@ class DirectorySnapshotDiff(object):
         modified = set()
         for path in ref.paths & snapshot.paths:
             if ref.inode(path) == snapshot.inode(path):
-                if ref.mtime(path) != snapshot.mtime(path):
+                if ref.mtime(path) != snapshot.mtime(path) or ref.size(path) != snapshot.size(path):
                     modified.add(path)
         
         for (old_path, new_path) in moved:
-            if ref.mtime(old_path) != snapshot.mtime(new_path):
+            if ref.mtime(old_path) != snapshot.mtime(new_path) or ref.size(old_path) != snapshot.size(new_path):
                 modified.add(old_path)
         
         self._dirs_created = [path for path in created if snapshot.isdir(path)]
@@ -267,6 +267,9 @@ class DirectorySnapshot(object):
     
     def mtime(self, path):
         return self._stat_info[path].st_mtime
+
+    def size(self, path):
+        return self._stat_info[path].st_size
     
     def stat_info(self, path):
         """

--- a/tests/shell.py
+++ b/tests/shell.py
@@ -29,6 +29,7 @@ import os.path
 import tempfile
 import shutil
 import errno
+import time
 
 
 # def tree(path='.', show_files=False):
@@ -108,3 +109,14 @@ def mkdtemp():
 
 def ls(path='.'):
     return os.listdir(path)
+
+
+def msize(path):
+    """Modify the file size without updating the modified time."""
+    with open(path, 'w') as w:
+        w.write('')
+    os.utime(path, (0, 0))
+    time.sleep(0.4)
+    with open(path, 'w') as w:
+        w.write('0')
+    os.utime(path, (0, 0))

--- a/tests/test_observers_polling.py
+++ b/tests/test_observers_polling.py
@@ -41,7 +41,8 @@ from .shell import (
     mkdtemp,
     touch,
     rm,
-    mv
+    mv,
+    msize
 )
 
 
@@ -99,6 +100,12 @@ def test___init__(event_queue, emitter):
     rm(p('afile'))
 
     sleep(SLEEP_TIME)
+    msize(p('bfile'))
+
+    sleep(SLEEP_TIME)
+    rm(p('bfile'))
+
+    sleep(SLEEP_TIME)
     emitter.stop()
 
     # What we need here for the tests to pass is a collection type
@@ -131,6 +138,13 @@ def test___init__(event_queue, emitter):
 
         DirModifiedEvent(p()),
         FileDeletedEvent(p('afile')),
+
+        DirModifiedEvent(p()),
+        FileCreatedEvent(p('bfile')),
+        FileModifiedEvent(p('bfile')),
+
+        DirModifiedEvent(p()),
+        FileDeletedEvent(p('bfile')),
     }
 
     expected.add(FileMovedEvent(p('fromfile'), p('project', 'tofile')))


### PR DESCRIPTION
`PollingObserver` works well in most cases.
When `dd` commands were executed on cephfs, file size were changed, but `Modified Event` could not be triggered. 
command: ```dd if=/dev/zero of=test count=1 bs=1G```
I looked at the filesystem and found that the modified time of the file would not change during `dd`. This problem is found only when the count parameter of the `dd` command is 1 on `cephfs`.
I recommend add the judgment of file size of `Modified Event`.
