### PR TITLE
Fix tests with Python 3.4. Using pytest < 3.3 for pytest-timeout < 1.…

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py{37,36,35,34,27,py3,py}
 deps = pytest-cov
        py{37,36,35,27,py3,py}: pytest-timeout
        py{34}: pytest-timeout<1.2.1
+       py{34}: pytest<3.3
 commands = py.test {posargs}
 
 [pytest]


### PR DESCRIPTION
…2.1 compatibility.
Fixes #500 