### PR TITLE
Use yaml.safe_load instead of yaml.load

### DIFF
--- a/src/watchdog/watchmedo.py
+++ b/src/watchdog/watchmedo.py
@@ -85,7 +85,7 @@ def load_config(tricks_file_pathname):
     f = open(tricks_file_pathname, 'rb')
     content = f.read()
     f.close()
-    config = yaml.load(content)
+    config = yaml.safe_load(content)
     return config
 
 

--- a/tests/test_watchmedo.py
+++ b/tests/test_watchmedo.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from watchdog import watchmedo
+import unittest
+import tempfile
+import yaml
+import os
+
+
+class TestWatchmedo(unittest.TestCase):
+    def setUp(self):
+        """Initial setup"""
+        tmp_dir = tempfile.gettempdir()
+        self.critical_dir = os.path.join(tmp_dir, 'critical')
+        self.valid_yaml_file = os.path.join(tmp_dir, 'config_file.yaml')
+        self.invalid_yaml_file = os.path.join(tmp_dir, 'tricks_file.yaml')
+        if not os.path.exists(self.valid_yaml_file):
+            f = open(self.valid_yaml_file, 'w')
+            f.write('one: value\ntwo:\n- value1\n- value2\n')
+            f.close()
+        if not os.path.exists(self.invalid_yaml_file):
+            f = open(self.invalid_yaml_file, 'w')
+            content = (
+                'one: value\n'
+                'run: !!python/object/apply:os.system ["mkdir {}"]\n'
+            ).format(self.critical_dir)
+            f.write(content)
+            f.close()
+
+    def test_load_config(self):
+        """Verifies the load of a valid yaml file"""
+        config = watchmedo.load_config(self.valid_yaml_file)
+        self.assertTrue(type(config) is dict)
+        self.assertTrue('one' in config)
+        self.assertTrue('two' in config)
+        self.assertTrue(type(config['two']) is list)
+        self.assertEqual(config['one'], 'value')
+        self.assertEqual(config['two'], ['value1', 'value2'])
+
+    def test_load_config_invalid(self):
+        """Verifies if safe load avoid the execution
+        of untrusted code inside yaml files"""
+        self.assertRaises(
+            yaml.constructor.ConstructorError,
+            watchmedo.load_config,
+            self.invalid_yaml_file
+        )
+        self.assertFalse(os.path.exists(self.critical_dir))
+
+    def tearDown(self):
+        """Perform a clean up before finishing the tests"""
+        if os.path.exists(self.critical_dir):
+            if os.path.isdir(self.critical_dir):
+                os.rmdir(self.critical_dir)
+            else:
+                os.remove(self.critical_dir)

--- a/tests/test_watchmedo.py
+++ b/tests/test_watchmedo.py
@@ -1,56 +1,42 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+
 from watchdog import watchmedo
-import unittest
-import tempfile
+import pytest
 import yaml
 import os
 
 
-class TestWatchmedo(unittest.TestCase):
-    def setUp(self):
-        """Initial setup"""
-        tmp_dir = tempfile.gettempdir()
-        self.critical_dir = os.path.join(tmp_dir, 'critical')
-        self.valid_yaml_file = os.path.join(tmp_dir, 'config_file.yaml')
-        self.invalid_yaml_file = os.path.join(tmp_dir, 'tricks_file.yaml')
-        if not os.path.exists(self.valid_yaml_file):
-            f = open(self.valid_yaml_file, 'w')
-            f.write('one: value\ntwo:\n- value1\n- value2\n')
-            f.close()
-        if not os.path.exists(self.invalid_yaml_file):
-            f = open(self.invalid_yaml_file, 'w')
-            content = (
-                'one: value\n'
-                'run: !!python/object/apply:os.system ["mkdir {}"]\n'
-            ).format(self.critical_dir)
-            f.write(content)
-            f.close()
+def test_load_config_valid(tmpdir):
+    """Verifies the load of a valid yaml file"""
 
-    def test_load_config(self):
-        """Verifies the load of a valid yaml file"""
-        config = watchmedo.load_config(self.valid_yaml_file)
-        self.assertTrue(type(config) is dict)
-        self.assertTrue('one' in config)
-        self.assertTrue('two' in config)
-        self.assertTrue(type(config['two']) is list)
-        self.assertEqual(config['one'], 'value')
-        self.assertEqual(config['two'], ['value1', 'value2'])
+    yaml_file = os.path.join(tmpdir, 'config_file.yaml')
+    with open(yaml_file, 'w') as f:
+        f.write('one: value\ntwo:\n- value1\n- value2\n')
 
-    def test_load_config_invalid(self):
-        """Verifies if safe load avoid the execution
-        of untrusted code inside yaml files"""
-        self.assertRaises(
-            yaml.constructor.ConstructorError,
-            watchmedo.load_config,
-            self.invalid_yaml_file
-        )
-        self.assertFalse(os.path.exists(self.critical_dir))
+    config = watchmedo.load_config(yaml_file)
+    assert isinstance(config, dict)
+    assert 'one' in config
+    assert 'two' in config
+    assert isinstance(config['two'], list)
+    assert config['one'] == 'value'
+    assert config['two'] == ['value1', 'value2']
 
-    def tearDown(self):
-        """Perform a clean up before finishing the tests"""
-        if os.path.exists(self.critical_dir):
-            if os.path.isdir(self.critical_dir):
-                os.rmdir(self.critical_dir)
-            else:
-                os.remove(self.critical_dir)
+
+def test_load_config_invalid(tmpdir):
+    """Verifies if safe load avoid the execution
+    of untrusted code inside yaml files"""
+
+    critical_dir = os.path.join(tmpdir, 'critical')
+    yaml_file = os.path.join(tmpdir, 'tricks_file.yaml')
+    with open(yaml_file, 'w') as f:
+        content = (
+            'one: value\n'
+            'run: !!python/object/apply:os.system ["mkdir {}"]\n'
+        ).format(critical_dir)
+        f.write(content)
+
+    with pytest.raises(yaml.constructor.ConstructorError):
+        watchmedo.load_config(yaml_file)
+
+    assert not os.path.exists(critical_dir)


### PR DESCRIPTION
As explained on issue #453 the use of the **yaml.load** function allows the execution of arbitrary python commands what is quite dangerous and discouraged, the problem can be solved by simply using the function **safe_load** instead.

In additional, two tests were added to ensure that **safe_load** is working as expected by properly loading valid yaml files and avoiding the execution of unstrusted commands.

Solves issue #453.