### PR TITLE
Make 'watchmedo' an extra installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,10 @@ matrix:
       python: "3.6"
       env: TOXENV=py36
     - os: linux
-      python: "3.7-dev"  # No 3.7 yet
+      python: "3.7"
       env: TOXENV=py37
+      dist: xenial
+      sudo: true
     - os: linux
       python: "pypy"
       env: TOXENV=pypy
@@ -36,12 +38,10 @@ matrix:
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then chmod +x .travis/install.sh && .travis/install.sh; fi
-  - DEPS=tox
 
 install:
-  - pip install --upgrade $DEPS
-  - pip list  # Helpful when debugging
-  - tox --notest
+  - python -m pip install tox
+  - tox --notest  # Note: keep it!
 
 script:
   - tox

--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ as command-line arguments and logs events generated:
 
 Shell Utilities
 ---------------
-Watchdog comes with a utility script called ``watchmedo``.
+Watchdog comes with an *optional* utility script called ``watchmedo``.
 Please type ``watchmedo --help`` at the shell prompt to
 know more about this tool.
 
@@ -126,11 +126,17 @@ Install from PyPI using ``pip``:
 
     $ python -m pip install watchdog
 
+    # or to install the watchmedo utility:
+    $ python -m pip install watchdog[watchmedo]
+
 Install from source:
     
 .. code-block:: bash
 
-    $ python setup.py install
+    $ python -m pip install -e .
+
+    # or to install the watchmedo utility:
+    $ python -m pip install -e .[watchmedo]
 
 
 Installation Caveats
@@ -165,9 +171,9 @@ ticket at the `issue tracker`_. For general help and questions use the official
 
 Create and activate your virtual environment, then::
 
-    pip install pytest
-    pip install -e .
-    py.test tests
+    python -m pip install pytest
+    python -m pip install -e .[watchmedo]
+    python -m pytest tests
 
 
 Supported Platforms

--- a/changelog.rst
+++ b/changelog.rst
@@ -8,6 +8,7 @@ API changes
 
 - Dropped support for Python 2.6, 3.2 and 3.3.
   If you are still running one of these obsolete Python version, you have to keep using watchdog < 0.10.0.
+- The ``watchmedo`` utility is no more installed by default but via the extra ``watchdog[watchmedo]``.
 
 0.8.2
 ~~~~~

--- a/debian/control
+++ b/debian/control
@@ -7,5 +7,5 @@ Standards-Version: 3.8.4
 
 Package: python-watchdog
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, python-argparse (>= 1.1), python-yaml (>= 3.09), python-argh (>= 0.14.2), python-pathtools (>= 0.1.1)
+Depends: ${shlibs:Depends}, ${misc:Depends}, python-yaml (>= 3.09), python-argh (>= 0.14.2), python-pathtools (>= 0.1.1)
 Description: Python Watchdog library for monitoring different directories

--- a/docs/source/global.rst.inc
+++ b/docs/source/global.rst.inc
@@ -19,7 +19,6 @@
 .. _CreateIoCompletionPort: http://msdn.microsoft.com/en-us/library/aa363862(v=VS.85).aspx
 
 .. _argh: http://pypi.python.org/pypi/argh
-.. _argparse: http://pypi.python.org/pypi/argparse
 .. _coverage: http://nedbatchelder.com/code/coverage/
 .. _file.monitor: http://github.com/pke/file.monitor
 .. _fsmonitor: http://github.com/shaurz/fsmonitor

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -15,7 +15,10 @@ Installing from PyPI using pip
 
 .. parsed-literal::
 
-    $ pip install |project_name|
+    $ python -m pip install |project_name|
+
+    # or to install the watchmedo utility:
+    $ python -m pip install |project_name|[watchmedo]
 
 Installing from source tarballs
 -------------------------------
@@ -25,7 +28,10 @@ Installing from source tarballs
     $ wget -c http://pypi.python.org/packages/source/w/watchdog/watchdog-|project_version|.tar.gz
     $ tar zxvf |project_name|-|project_version|.tar.gz
     $ cd |project_name|-|project_version|
-    $ python setup.py install
+    $ python -m pip install -e .
+
+    # or to install the watchmedo utility:
+    $ python -m pip install -e .[watchmedo]
 
 Installing from the code repository
 -----------------------------------
@@ -34,7 +40,10 @@ Installing from the code repository
 
     $ git clone --recursive git://github.com/gorakhargosh/watchdog.git
     $ cd watchdog
-    $ python setup.py install
+    $ python -m pip install -e.
+
+    # or to install the watchmedo utility:
+    $ python -m pip install -e.[watchmedo]
 
 .. _installation-dependencies:
 
@@ -50,15 +59,20 @@ using.
 +=====================+=============+=============+=============+=============+
 | XCode_              |             |             |     Yes     |             |
 +---------------------+-------------+-------------+-------------+-------------+
+| pathtools_          |     Yes     |     Yes     |     Yes     |     Yes     |
++---------------------+-------------+-------------+-------------+-------------+
+
+The following is a list of dependencies you need based on the operating system you are
+using the ``watchmedo`` utility.
+
++---------------------+-------------+-------------+-------------+-------------+
+| Operating system    |   Windows   |  Linux 2.6  | Mac OS X/   |     BSD     |
+| Dependency (row)    |             |             |   Darwin    |             |
++=====================+=============+=============+=============+=============+
 | PyYAML_             |     Yes     |     Yes     |     Yes     |     Yes     |
 +---------------------+-------------+-------------+-------------+-------------+
 | argh_               |     Yes     |     Yes     |     Yes     |     Yes     |
 +---------------------+-------------+-------------+-------------+-------------+
-| argparse_           |     Yes     |     Yes     |     Yes     |     Yes     |
-+---------------------+-------------+-------------+-------------+-------------+
-| pathtools_          |     Yes     |     Yes     |     Yes     |     Yes     |
-+---------------------+-------------+-------------+-------------+-------------+
-
 
 Installing Dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,10 @@ all_files  = 1
 [upload_sphinx]
 # Requires sphinx-pypi-upload to work.
 upload-dir = docs/build/html
+
+[tool:pytest]
+addopts =
+    --showlocals
+    -v
+    --cov=watchdog
+    --cov-report=term-missing

--- a/setup.py
+++ b/setup.py
@@ -85,15 +85,15 @@ class PyTest(TestCommand):
         errno = pytest.main(self.test_args)
         sys.exit(errno)
 
-tests_require=['pytest', 'pytest-cov', 'pytest-timeout >=0.3']
-
+tests_require = ['pytest>=3.6.0', 'pytest-cov', 'pytest-timeout>=1.3.1']
 install_requires = [
-    "PyYAML>=3.10",
-    "argh>=0.24.1",
     "pathtools>=0.1.1",
     'pyobjc-framework-Cocoa>=4.2.2 ; sys_platform == "darwin"',
     'pyobjc-framework-FSEvents>=4.2.2 ; sys_platform == "darwin"',
 ]
+extras_require = {
+    'watchmedo': ['PyYAML>=3.10', 'argh>=0.24.1'],
+}
 
 with open('README.rst') as f:
     readme = f.read()
@@ -151,6 +151,7 @@ setup(name="watchdog",
       packages=find_packages(SRC_DIR),
       include_package_data=True,
       install_requires=install_requires,
+      extras_require=extras_require,
       tests_require=tests_require,
       cmdclass={
           'build_ext': build_ext,
@@ -158,7 +159,7 @@ setup(name="watchdog",
       },
       ext_modules=ext_modules,
       entry_points={'console_scripts': [
-          'watchmedo = watchdog.watchmedo:main',
+          'watchmedo = watchdog.watchmedo:main [watchmedo]',
       ]},
       zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ import os.path
 from setuptools import setup, find_packages
 from setuptools.extension import Extension
 from setuptools.command.build_ext import build_ext
-from setuptools.command.test import test as TestCommand
 from distutils.util import get_platform
 
 SRC_DIR = 'src'
@@ -71,21 +70,6 @@ if get_platform().startswith('macosx'):
         ),
     ]
 
-
-class PyTest(TestCommand):
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = [
-            '--cov=' + SRC_DIR,
-            '--cov-report=term-missing',
-            'tests']
-        self.test_suite = True
-    def run_tests(self):
-        import pytest
-        errno = pytest.main(self.test_args)
-        sys.exit(errno)
-
-tests_require = ['pytest>=3.6.0', 'pytest-cov', 'pytest-timeout>=1.3.1']
 install_requires = [
     "pathtools>=0.1.1",
     'pyobjc-framework-Cocoa>=4.2.2 ; sys_platform == "darwin"',
@@ -152,10 +136,8 @@ setup(name="watchdog",
       include_package_data=True,
       install_requires=install_requires,
       extras_require=extras_require,
-      tests_require=tests_require,
       cmdclass={
           'build_ext': build_ext,
-          'test': PyTest,
       },
       ext_modules=ext_modules,
       entry_points={'console_scripts': [

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,15 @@
 envlist = py{37,36,35,34,27,py3,py}
 
 [testenv]
-deps = pytest-cov
-       py{37,36,35,27,py3,py}: pytest-timeout
-       py{34}: pytest-timeout<1.2.1
-       py{34}: pytest<3.3
-commands = py.test {posargs}
+deps =
+    py{37,36,35,27,py3,py}: pytest-cov
+    py{37,36,35,27,py3,py}: pytest-timeout
+    py{34}: pytest-timeout<1.2.1
+    py{34}: pytest<3.3
+    py{34}: pytest-cov==2.6.0
+extras = watchmedo
+commands =
+    python -m pytest {posargs}
 
 [pytest]
 addopts = --cov=watchdog

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,3 @@ deps =
 extras = watchmedo
 commands =
     python -m pytest {posargs}
-
-[pytest]
-addopts = --cov=watchdog
-          --cov-report=term-missing


### PR DESCRIPTION
This will defer the installation of requirements like `YAML` and `args`.

To install `watchmedo`:
```shell
python -m pip install watchdog[watchmedo]
```

Fixes #297.