### PR TITLE
Avoid race condition crash when a directory is swapped for a file

### DIFF
--- a/src/watchdog/utils/dirsnapshot.py
+++ b/src/watchdog/utils/dirsnapshot.py
@@ -218,8 +218,9 @@ class DirectorySnapshot(object):
             except OSError as e:
                 # Directory may have been deleted between finding it in the directory
                 # list of its parent and trying to delete its contents. If this
-                # happens we treat it as empty.
-                if e.errno == errno.ENOENT:
+                # happens we treat it as empty. Likewise if the directory was replaced
+                # with a file of the same name (less likely, but possible).
+                if e.errno == errno.ENOENT or e.errno == errno.ENOTDIR:
                     return
                 else:
                     raise


### PR DESCRIPTION
This commit builds off the race condition checking introduced in 2e8319992, but also correctly handles the case where a directory is replaced with a file before it can be walked.

For example:
1. [external] create `/a/b/c.txt`
2. [watchdog] walk `/a` (contains directory `/a/b/` at this point)
3. [external] `rm -rf /a/b/`
4. [external] `touch /a/b`
5. [watchdog] walk `/a/b/` (raises `NotADirectoryError`/`ENOTDIR`)

Also adds a test case that runs through the above example to ensure that an exception is no longer raised.