### PR TITLE
Add test for several observers on the same path

### DIFF
--- a/src/watchdog/observers/__init__.py
+++ b/src/watchdog/observers/__init__.py
@@ -65,14 +65,13 @@ if platform.is_linux():
         from .polling import PollingObserver as Observer
 
 elif platform.is_darwin():
-    # FIXME: catching too broad. Error prone
     try:
         from .fsevents import FSEventsObserver as Observer
-    except:
+    except Exception:
         try:
             from .kqueue import KqueueObserver as Observer
             warnings.warn("Failed to import fsevents. Fall back to kqueue")
-        except:
+        except Exception:
             from .polling import PollingObserver as Observer
             warnings.warn("Failed to import fsevents and kqueue. Fall back to polling.")
 
@@ -84,7 +83,7 @@ elif platform.is_windows():
     # polling explicitly for Windows XP
     try:
         from .read_directory_changes import WindowsApiObserver as Observer
-    except:
+    except Exception:
         from .polling import PollingObserver as Observer
         warnings.warn("Failed to import read_directory_changes. Fall back to polling.")
 

--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -139,7 +139,7 @@ class FSEventsEmitter(EventEmitter):
                                 callback,
                                 self.pathnames)
             _fsevents.read_events(self)
-        except:
+        except Exception:
             pass
 
 

--- a/src/watchdog/observers/winapi.py
+++ b/src/watchdog/observers/winapi.py
@@ -282,7 +282,7 @@ def close_directory_handle(handle):
     except WindowsError:
         try:
             CloseHandle(handle)   # close directory handle
-        except:
+        except Exception:
             return
 
 


### PR DESCRIPTION
To ensure #63 is fixed and no future regression.

Also refactored the `observer` fixture and added another one for this new test case.