### PR TITLE
Added missed st_size in win32stat

### DIFF
--- a/src/watchdog/utils/win32stat.py
+++ b/src/watchdog/utils/win32stat.py
@@ -85,7 +85,7 @@ CloseHandle.restype = ctypes.wintypes.BOOL
 CloseHandle.argtypes = (ctypes.wintypes.HANDLE,)
 
 
-StatResult = namedtuple('StatResult', 'st_dev st_ino st_mode st_mtime')
+StatResult = namedtuple('StatResult', 'st_dev st_ino st_mode st_mtime st_size')
 
 def _to_mode(attr):
     m = 0
@@ -121,5 +121,6 @@ def stat(path):
     return StatResult(st_dev=info.dwVolumeSerialNumber,
                       st_ino=(info.nFileIndexHigh << 32) + info.nFileIndexLow,
                       st_mode=_to_mode(info.dwFileAttributes),
-                      st_mtime=_to_unix_time(info.ftLastWriteTime)
+                      st_mtime=_to_unix_time(info.ftLastWriteTime),
+                      st_size=(info.nFileSizeHigh << 32) + info.nFileSizeLow
                       )


### PR DESCRIPTION
For fixing broken test_snapshot_diff.py tests against Python 2.7 on Windows. 
Traceback from test output:

``` 
---------------------------- Captured stderr call -----------------------------
Exception in thread Thread-36:
Traceback (most recent call last):
  File "c:\python27\Lib\threading.py", line 801, in __bootstrap_inner
    self.run()
  File "C:\projects\watchdog\.tox\py27\lib\site-packages\watchdog\observers\api.py", line 145, in run
    self.queue_events(self.timeout)
  File "C:\projects\watchdog\.tox\py27\lib\site-packages\watchdog\observers\polling.py", line 102, in queue_events
    events = DirectorySnapshotDiff(self._snapshot, new_snapshot)
  File "C:\projects\watchdog\.tox\py27\lib\site-packages\watchdog\utils\dirsnapshot.py", line 105, in __init__
    if ref.mtime(path) != snapshot.mtime(path) or ref.size(path) != snapshot.size(path):
  File "C:\projects\watchdog\.tox\py27\lib\site-packages\watchdog\utils\dirsnapshot.py", line 272, in size
    return self._stat_info[path].st_size
AttributeError: 'StatResult' object has no attribute 'st_size'
________________________________ test_move_to _________________________________
p = <functools.partial object at 0x03433330>
    def test_move_to(p):
        mkdir(p('dir1'))
        mkdir(p('dir2'))
        touch(p('dir1', 'a'))
        ref = DirectorySnapshot(p('dir2'))
        mv(p('dir1', 'a'), p('dir2', 'b'))
>       diff = DirectorySnapshotDiff(ref, DirectorySnapshot(p('dir2')))
p          = <functools.partial object at 0x03433330>
ref        = {'c:\\users\\appveyor\\appdata\\local\\temp\\1\\tmpsos5bx\\dir2': StatResult(st_dev=3567992900L, st_ino=4785074607137295L, st_mode=16895, st_mtime=1553606971L)}
tests\test_snapshot_diff.py:43: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
.tox\py27\lib\site-packages\watchdog\utils\dirsnapshot.py:105: in __init__
    if ref.mtime(path) != snapshot.mtime(path) or ref.size(path) != snapshot.size(path):
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
self = {'c:\\users\\appveyor\\appdata\\local\\temp\\1\\tmpsos5bx\\dir2': StatResult(st_dev=3567992900L, st_ino=4785074607137295L, st_mode=16895, st_mtime=1553606971L)}
path = 'c:\\users\\appveyor\\appdata\\local\\temp\\1\\tmpsos5bx\\dir2'
    def size(self, path):
>       return self._stat_info[path].st_size
E       AttributeError: 'StatResult' object has no attribute 'st_size'
path       = 'c:\\users\\appveyor\\appdata\\local\\temp\\1\\tmpsos5bx\\dir2'
self       = {'c:\\users\\appveyor\\appdata\\local\\temp\\1\\tmpsos5bx\\dir2': StatResult(st_dev=3567992900L, st_ino=4785074607137295L, st_mode=16895, st_mtime=1553606971L)}
.tox\py27\lib\site-packages\watchdog\utils\dirsnapshot.py:272: AttributeError
```