### PR TITLE
In Python 2.7 when call os.listdir() on file or not existing directory gives errno.EINVAL instead ENOTDIR

### DIFF
--- a/src/watchdog/utils/dirsnapshot.py
+++ b/src/watchdog/utils/dirsnapshot.py
@@ -220,7 +220,7 @@ class DirectorySnapshot(object):
                 # list of its parent and trying to delete its contents. If this
                 # happens we treat it as empty. Likewise if the directory was replaced
                 # with a file of the same name (less likely, but possible).
-                if e.errno == errno.ENOENT or e.errno == errno.ENOTDIR:
+                if e.errno in (errno.ENOENT, errno.ENOTDIR, errno.EINVAL):
                     return
                 else:
                     raise


### PR DESCRIPTION
**`test_snapshot_diff.py::test_detect_modify_for_moved_files`** replay situation when the directory deleted, and then the file creating with same name as deleted directory. After this called **`os.listdir()`** on the path that corresponds to file (and previously to directory). **`DirectorySnapshot`** must not be a raises exceptions in this situation. In Python 3 **`os.listdir()`** raises **`NotADirectoryError`** exception, that corresponds to **`errno.ENOTDIR`**. so test passes. In Python 2 raises **`WindowsError`** 267 (ERROR_DIRECTORY the directory name is invalid), that correspond to **`errno.EINVAL`**, that not handled, so test fails.