### PR TITLE
Fix #557 Drop Python 3.4 support 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,12 +12,6 @@ environment:
     - python: py27-x64
       tox_env: py27
       python_path: c:\python27-x64
-    - python: py34
-      tox_env: py34
-      python_path: c:\python34
-    - python: py34-x64
-      tox_env: py34
-      python_path: c:\python34-x64
     - python: py35
       tox_env: py35
       python_path: c:\python35

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,10 @@
 [tox]
-envlist = py{37,36,35,34,27,py3,py}
+envlist = py{37,36,35,27,py3,py}
 
 [testenv]
 deps =
     py{37,36,35,27,py3,py}: pytest-cov
     py{37,36,35,27,py3,py}: pytest-timeout
-    py{34}: pytest-timeout<1.2.1
-    py{34}: pytest<3.3
-    py{34}: pytest-cov==2.6.0
 extras = watchmedo
 commands =
     python -bb -m pytest {posargs}


### PR DESCRIPTION
Main problem with Python 3.4 is that pytest no more support it, this make difficult to keep tests in work state.