### PR TITLE
Fix changed tox behaviour on Appveyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ environment:
 
 install:
   - SET "PATH=%python_path%;%python_path%\Scripts;%PATH%"
-  - pip install tox
+  - pip install tox -U --force-reinstall
 
 test_script:
   tox -e %tox_env%


### PR DESCRIPTION
Part of builds on Appveyor CI failing, issue described [here](https://github.com/tox-dev/tox/issues/1302). This PR force installation of tox for recreating virtualenv.