### PR TITLE
Setup Travis to support Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,16 +25,45 @@ matrix:
     - os: linux
       python: "pypy3"
       env: TOXENV=pypy3
-    - os: osx
+    - name: "Python: 2.7"
+      os: osx
       language: generic
       env:
         - PYTHON_VERSION=2.7
         - TOXENV=py27
-    - os: osx
+    - name: "Python: 3.7"
+      os: osx
       language: generic
       env:
         - PYTHON_VERSION=3.7
         - TOXENV=py37
+    - name: "Python: 2.7"
+      os: windows
+      language: shell
+      before_install:
+        - choco install python2
+        - python -m pip install --upgrade pip
+      env:
+        - TOXENV=py27
+        - export PATH="/c/Python27:/c/Python27/Scripts:$PATH"
+    - name: "Python 3.7"
+      os: windows
+      language: shell
+      before_install:
+        - choco install python --version 3.7
+        - python -m pip install --upgrade pip
+      env:
+        - TOXENV=py37
+        - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
+    - name: "Python: 3.8"
+      os: windows
+      language: shell
+      before_install:
+        - choco install python --version 3.8
+        - python -m pip install --upgrade pip
+      env:
+        - TOXENV=py38
+        - export PATH="/c/Python38:/c/Python38/Scripts:$PATH"
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then chmod +x .travis/install.sh && .travis/install.sh; fi

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -81,6 +81,12 @@ def start_watching(path=None, use_full_emitter=False, recursive=True):
     emitter.start()
 
 
+def rerun_filter(exc, *args):
+    time.sleep(5)
+    return issubclass(exc[0], Empty) and platform.is_windows()
+
+
+@pytest.mark.flaky(max_runs=5, min_passes=1, rerun_filter=rerun_filter)
 def test_create():
     start_watching()
     open(p('a'), 'a').close()
@@ -95,6 +101,7 @@ def test_create():
         assert isinstance(event, DirModifiedEvent)
 
 
+@pytest.mark.flaky(max_runs=5, min_passes=1, rerun_filter=rerun_filter)
 def test_delete():
     touch(p('a'))
     start_watching()
@@ -110,6 +117,7 @@ def test_delete():
         assert isinstance(event, DirModifiedEvent)
 
 
+@pytest.mark.flaky(max_runs=5, min_passes=1, rerun_filter=rerun_filter)
 def test_modify():
     touch(p('a'))
     start_watching()
@@ -120,6 +128,7 @@ def test_modify():
     assert isinstance(event, FileModifiedEvent)
 
 
+@pytest.mark.flaky(max_runs=5, min_passes=1, rerun_filter=rerun_filter)
 def test_move():
     mkdir(p('dir1'))
     mkdir(p('dir2'))
@@ -150,6 +159,7 @@ def test_move():
         assert isinstance(event, DirModifiedEvent)
 
 
+@pytest.mark.flaky(max_runs=5, min_passes=1, rerun_filter=rerun_filter)
 def test_move_to():
     mkdir(p('dir1'))
     mkdir(p('dir2'))
@@ -181,6 +191,7 @@ def test_move_to_full():
     assert event.src_path is None  # Should equal None since the path was not watched
 
 
+@pytest.mark.flaky(max_runs=5, min_passes=1, rerun_filter=rerun_filter)
 def test_move_from():
     mkdir(p('dir1'))
     mkdir(p('dir2'))
@@ -212,6 +223,7 @@ def test_move_from_full():
     assert event.dest_path is None  # Should equal None since path not watched
 
 
+@pytest.mark.flaky(max_runs=5, min_passes=1, rerun_filter=rerun_filter)
 def test_separate_consecutive_moves():
     mkdir(p('dir1'))
     touch(p('dir1', 'a'))
@@ -239,6 +251,7 @@ def test_separate_consecutive_moves():
         assert isinstance(event, DirModifiedEvent)
 
 
+@pytest.mark.flaky(max_runs=5, min_passes=1, rerun_filter=rerun_filter)
 def test_delete_self():
     mkdir(p('dir1'))
     start_watching(p('dir1'))
@@ -280,6 +293,7 @@ def test_fast_subdirectory_creation_deletion():
                      DirDeletedEvent: times}
 
 
+@pytest.mark.flaky(max_runs=5, min_passes=1, rerun_filter=rerun_filter)
 def test_passing_unicode_should_give_unicode():
     start_watching(str_cls(p("")))
     touch(p('a'))
@@ -297,6 +311,7 @@ def test_passing_bytes_should_give_bytes():
     assert isinstance(event.src_path, bytes)
 
 
+@pytest.mark.flaky(max_runs=5, min_passes=1, rerun_filter=rerun_filter)
 def test_recursive_on():
     mkdir(p('dir1', 'dir2', 'dir3'), True)
     start_watching()
@@ -316,6 +331,7 @@ def test_recursive_on():
         assert isinstance(event, FileModifiedEvent)
 
 
+@pytest.mark.flaky(max_runs=5, min_passes=1, rerun_filter=rerun_filter)
 def test_recursive_off():
     mkdir(p('dir1'))
     start_watching(recursive=False)
@@ -381,6 +397,7 @@ def test_renaming_top_level_directory():
             assert event.src_path == p('a2', 'b')
 
 
+@pytest.mark.flaky(max_runs=5, min_passes=1, rerun_filter=rerun_filter)
 @pytest.mark.skipif(platform.is_linux(),
                     reason="Linux create another set of events for this test")
 def test_renaming_top_level_directory_on_windows():
@@ -467,6 +484,7 @@ def test_move_nested_subdirectories():
     assert isinstance(event, FileModifiedEvent)
 
 
+@pytest.mark.flaky(max_runs=5, min_passes=1, rerun_filter=rerun_filter)
 @pytest.mark.skipif(platform.is_linux(),
                     reason="Linux create another set of events for this test")
 def test_move_nested_subdirectories_on_windows():

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ deps =
     flake8
     pytest-cov
     pytest-timeout
+    flaky
 extras = watchmedo
 commands =
     python -m flake8 docs tools src tests


### PR DESCRIPTION
This PR show the simple way to support testing watchdog under Windows when using Travis-CI. Supported only Python versions 2.7 and 3.7 and only 64-bit version. This PR not included dropping appveyor.yml and cutting they build status from README.rst. Now performance of Windows VMs in Travis-CI looks not optimized. Many  tests failed because events not received in time. But I want to stay this PR is open, for getting feedback and advices. I think environment may be cached, and restored later for faster setup and tests run.