### PR TITLE
Support eventlet monkey patching in SkipRepeatsQueue

### DIFF
--- a/src/watchdog/utils/bricks.py
+++ b/src/watchdog/utils/bricks.py
@@ -39,7 +39,7 @@ Classes
 from .compat import queue
 
 
-class SkipRepeatsQueue(queue.Queue):
+class SkipRepeatsQueue(queue.Queue, object):
 
     """Thread-safe implementation of an special queue where a
     put of the last-item put'd will be dropped.
@@ -83,12 +83,12 @@ class SkipRepeatsQueue(queue.Queue):
     """
 
     def _init(self, maxsize):
-        queue.Queue._init(self, maxsize)
+        super(SkipRepeatsQueue, self)._init(maxsize)
         self._last_item = None
 
     def _put(self, item):
         if item != self._last_item:
-            queue.Queue._put(self, item)
+            super(SkipRepeatsQueue, self)._put(item)
             self._last_item = item
         else:
             # `put` increments `unfinished_tasks` even if we did not put
@@ -96,7 +96,7 @@ class SkipRepeatsQueue(queue.Queue):
             self.unfinished_tasks -= 1
 
     def _get(self):
-        item = queue.Queue._get(self)
+        item = super(SkipRepeatsQueue, self)._get()
         if item is self._last_item:
             self._last_item = None
         return item

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,9 +42,12 @@ def no_warnings(recwarn):
     warnings = []
     for warning in recwarn:  # pragma: no cover
         message = str(warning.message)
+        filename = warning.filename
         if (
             "Not importing directory" in message
             or "Using or importing the ABCs" in message
+            or "dns.hash module will be removed in future versions" in message
+            or ("eventlet" in filename and "eventlet" in filename)
         ):
             continue
         warnings.append("{w.filename}:{w.lineno} {w.message}".format(w=warning))

--- a/tests/markers.py
+++ b/tests/markers.py
@@ -1,0 +1,5 @@
+from platform import python_implementation
+import pytest
+
+
+cpython_only = pytest.mark.skipif(python_implementation() != "CPython", reason="CPython only.")

--- a/tests/test_skip_repeats_queue.py
+++ b/tests/test_skip_repeats_queue.py
@@ -16,10 +16,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 from watchdog.utils.bricks import SkipRepeatsQueue
 
+from .markers import cpython_only
 
-def test_basic_queue():
+
+def basic_actions():
     q = SkipRepeatsQueue()
 
     e1 = (2, 'fred')
@@ -34,6 +37,10 @@ def test_basic_queue():
     assert e2 == q.get()
     assert e3 == q.get()
     assert q.empty()
+
+
+def test_basic_queue():
+    basic_actions()
 
 
 def test_allow_nonconsecutive():
@@ -81,3 +88,14 @@ def test_consecutives_allowed_across_empties():
     q.put(e1)  # this repeat is allowed because 'last' added is now gone from queue
     assert e1 == q.get()
     assert q.empty()
+
+
+@cpython_only
+def test_eventlet_monkey_patching():
+    try:
+        import eventlet
+    except ImportError:
+        pytest.skip("eventlet not installed")
+
+    eventlet.monkey_patch()
+    basic_actions()

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ skip_missing_interpreters = True
 
 [testenv]
 deps =
+    eventlet
     flake8
     pytest-cov
     pytest-timeout


### PR DESCRIPTION
- Introduced the `@cpython_only` marker for tests.
- I used that trick for the fix: https://stackoverflow.com/a/6714313/1117028
- Fixes #332.