### PR TITLE
Avoid private threading._dangling object

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 from functools import partial
 import os
-import sys
 import threading
 import pytest
 from . import shell
@@ -28,15 +27,8 @@ def no_thread_leaks():
     Fail on thread leak.
     We do not use pytest-threadleak because it is not reliable.
     """
-
     yield
-
-    if sys.version_info < (3,):
-        return
-
-    main = threading.main_thread()
-    assert not [th for th in threading._dangling
-                if th is not main and th.is_alive()]
+    assert threading.active_count() == 1  # Only the main thread
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 from functools import partial
+import gc
 import os
 import threading
 import pytest
@@ -28,6 +29,7 @@ def no_thread_leaks():
     We do not use pytest-threadleak because it is not reliable.
     """
     yield
+    gc.collect()  # Clear the stuff from other function-level fixtures
     assert threading.active_count() == 1  # Only the main thread
 
 

--- a/tests/test_observers_polling.py
+++ b/tests/test_observers_polling.py
@@ -69,6 +69,7 @@ def emitter(event_queue):
     em.start()
     yield em
     em.stop()
+    em.join(5)
 
 
 def test___init__(event_queue, emitter):


### PR DESCRIPTION
This alternative for the no_thread_leaks fixture for testing works on
Python 2.7 and doesn't require any private object from the standard
library

Although the _dangling object still exists in Python 3.8.0, it's not
reliable in the sense that any new Python version may remove it