### PR TITLE
Change documetation link to readthedocs.io, this closes #410 and #565

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -267,7 +267,7 @@ to do:
 .. _source code: http://github.com/gorakhargosh/watchdog
 .. _issue tracker: http://github.com/gorakhargosh/watchdog/issues
 .. _Apache License, version 2.0: http://www.apache.org/licenses/LICENSE-2.0
-.. _documentation: http://packages.python.org/watchdog/
+.. _documentation: https://watchdog.readthedocs.io/
 .. _stackoverflow: http://stackoverflow.com/questions/tagged/python-watchdog
 .. _mailing list: http://groups.google.com/group/watchdog-python
 .. _repository: http://github.com/gorakhargosh/watchdog


### PR DESCRIPTION
Change documentation link to provided by @danilobellini [here](https://github.com/gorakhargosh/watchdog/issues/485#issuecomment-547742267).