### PR TITLE
Added parameter `ignore_device` to constructor of DirectorySnapshotDiff.

### DIFF
--- a/src/watchdog/utils/dirsnapshot.py
+++ b/src/watchdog/utils/dirsnapshot.py
@@ -75,9 +75,11 @@ class DirectorySnapshotDiff(object):
         deleted = ref.paths - snapshot.paths
 
         if ignore_device:
-            def get_inode(directory, full_path): return directory.inode(full_path)[0]
+            def get_inode(directory, full_path):
+                return directory.inode(full_path)[0]
         else:
-            def get_inode(directory, full_path): return directory.inode(full_path)
+            def get_inode(directory, full_path):
+                return directory.inode(full_path)
 
         # check that all unchanged paths have the same inode
         for path in ref.paths & snapshot.paths:

--- a/src/watchdog/utils/dirsnapshot.py
+++ b/src/watchdog/utils/dirsnapshot.py
@@ -68,6 +68,16 @@ class DirectorySnapshotDiff(object):
         with the reference snapshot.
     :type snapshot:
         :class:`DirectorySnapshot`
+    :param ignore_device:
+        A boolean indicating whether to ignore the device id or not.
+        By default, a file may be uniquely identified by a combination of its first
+        inode and its device id. The problem is that the device id may (or may not)
+        change between system boots. This problem would cause the DirectorySnapshotDiff
+        to think a file has been deleted and created again but it would be the
+        exact same file.
+        Set to True only if you are sure you will always use the same device.
+    :type ignore_device:
+        :class:`bool`
     """
 
     def __init__(self, ref, snapshot, ignore_device=False):


### PR DESCRIPTION
To compare two DirectorySnapshots the file attributes are used. It uniquely identifies a file using the `st_ino` and `st_dev` values of a file.

The problem is that st_dev may change between reboots as stated [in the GNU manual](https://www.gnu.org/software/libc/manual/html_node/Attribute-Meanings.html). Therefore if we compare a snapshot of a previous boot with the current one, DirectorySnapshotDiff may report a file as deleted and created again even if it hasn't been touched.

This PR adds the optional parameter `ignore_device` to the constructor of DirectorySnapshotDiff to just use the value `st_ino` and ignore `st_dev`.