### PR TITLE
[snapshot] Removed the walker_callback argument

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -13,6 +13,8 @@ Breaking Changes
 
 - Dropped support for Python 2.6, 3.2 and 3.3
 - Emitters that failed to start are now removed
+- [snapshot] Removed the deprecated ``walker_callback`` argument,
+  use ``stat`` instead
 - [watchmedo] The utility is no more installed by default but via the extra
   ``watchdog[watchmedo]``
 

--- a/src/watchdog/observers/kqueue.py
+++ b/src/watchdog/observers/kqueue.py
@@ -435,12 +435,14 @@ class KqueueEmitter(EventEmitter):
         # A collection of KeventDescriptor.
         self._descriptors = KeventDescriptorSet()
 
-        def walker_callback(path, stat_info, self=self):
+        def custom_stat(path, self=self):
+            stat_info = stat(path)
             self._register_kevent(path, stat.S_ISDIR(stat_info.st_mode))
+            return stat_info
 
         self._snapshot = DirectorySnapshot(watch.path,
-                                           watch.is_recursive,
-                                           walker_callback)
+                                           recursive=watch.is_recursive,
+                                           stat=custom_stat)
 
     def _register_kevent(self, path, is_directory):
         """

--- a/src/watchdog/utils/dirsnapshot.py
+++ b/src/watchdog/utils/dirsnapshot.py
@@ -226,31 +226,27 @@ class DirectorySnapshot(object):
         snapshot; ``False`` otherwise.
     :type recursive:
         ``bool``
-    :param walker_callback:
-        .. deprecated:: 0.7.2
     :param stat:
         Use custom stat function that returns a stat structure for path.
         Currently only st_dev, st_ino, st_mode and st_mtime are needed.
 
-        A function with the signature ``walker_callback(path, stat_info)``
-        which will be called for every entry in the directory tree.
+        A function taking a ``path`` as argument which will be called
+        for every entry in the directory tree.
     :param listdir:
         Use custom listdir function. For details see ``os.scandir`` if available, else ``os.listdir``.
     """
 
     def __init__(self, path, recursive=True,
-                 walker_callback=(lambda p, s: None),
                  stat=default_stat,
                  listdir=scandir):
         self.recursive = recursive
-        self.walker_callback = walker_callback
         self.stat = stat
         self.listdir = listdir
 
         self._stat_info = {}
         self._inode_to_path = {}
 
-        st = stat(path)
+        st = self.stat(path)
         self._stat_info[path] = st
         self._inode_to_path[(st.st_ino, st.st_dev)] = path
 
@@ -258,7 +254,6 @@ class DirectorySnapshot(object):
             i = (st.st_ino, st.st_dev)
             self._inode_to_path[i] = p
             self._stat_info[p] = st
-            walker_callback(p, st)
 
     def walk(self, root):
         try:

--- a/tests/test_snapshot_diff.py
+++ b/tests/test_snapshot_diff.py
@@ -16,11 +16,14 @@
 
 import errno
 import os
+import pickle
 import time
-from .shell import mkdir, touch, mv, rm
+
 from watchdog.utils.dirsnapshot import DirectorySnapshot
 from watchdog.utils.dirsnapshot import DirectorySnapshotDiff
 from watchdog.utils import platform
+
+from .shell import mkdir, touch, mv, rm
 
 
 def wait():
@@ -33,6 +36,13 @@ def wait():
         time.sleep(1.5)
     else:
         time.sleep(0.5)
+
+
+def test_pickle(p):
+    """It should be possible to pickle a snapshot."""
+    mkdir(p('dir1'))
+    snasphot = DirectorySnapshot(p('dir1'))
+    pickle.dumps(snasphot)
 
 
 def test_move_to(p):


### PR DESCRIPTION
It is deprecated since 0.8.0. Use the `stat` one instead.

Fixes #598.