### PR TITLE
Added class EmptyDirectorySnapshot to fix issue #612.

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -11,8 +11,8 @@ Changelog
 Other Changes
 =============
 
--
-- Thanks to our beloved contributors:
+- [snapshot] Added EmptyDirectorySnapshot (`#613 <https://github.com/gorakhargosh/watchdog/pull/613>`__)
+- Thanks to our beloved contributors: @Ajordat
 
 
 0.10.0

--- a/src/watchdog/utils/dirsnapshot.py
+++ b/src/watchdog/utils/dirsnapshot.py
@@ -347,3 +347,18 @@ class DirectorySnapshot(object):
 
     def __repr__(self):
         return str(self._stat_info)
+
+
+class DirectorySnapshotEmpty(object):
+    """Class to implement an empty snapshot. This is used together with
+    DirectorySnapshot and DirectorySnapshotDiff in order to get all the files/folders
+    in the directory as created.
+    """
+
+    @staticmethod
+    def path(_):
+        return None
+
+    @property
+    def paths(self):
+        return set()

--- a/src/watchdog/utils/dirsnapshot.py
+++ b/src/watchdog/utils/dirsnapshot.py
@@ -353,7 +353,7 @@ class DirectorySnapshot(object):
         return str(self._stat_info)
 
 
-class DirectorySnapshotEmpty(object):
+class EmptyDirectorySnapshot(object):
     """Class to implement an empty snapshot. This is used together with
     DirectorySnapshot and DirectorySnapshotDiff in order to get all the files/folders
     in the directory as created.

--- a/src/watchdog/utils/dirsnapshot.py
+++ b/src/watchdog/utils/dirsnapshot.py
@@ -42,6 +42,10 @@ Classes
    :members:
    :show-inheritance:
 
+.. autoclass:: DirectorySnapshotEmpty
+   :members:
+   :show-inheritance:
+
 """
 
 import errno

--- a/src/watchdog/utils/dirsnapshot.py
+++ b/src/watchdog/utils/dirsnapshot.py
@@ -371,9 +371,8 @@ class EmptyDirectorySnapshot(object):
 
     @property
     def paths(self):
-        """
-        Mock up method to return a set of file/directory paths in the snapshot. As the
-        snapshot is intended to be empty, it always returns an empty set.
+        """Mock up method to return a set of file/directory paths in the snapshot. As
+        the snapshot is intended to be empty, it always returns an empty set.
 
         :returns:
             An empty set.

--- a/src/watchdog/utils/dirsnapshot.py
+++ b/src/watchdog/utils/dirsnapshot.py
@@ -361,8 +361,21 @@ class EmptyDirectorySnapshot(object):
 
     @staticmethod
     def path(_):
+        """Mock up method to return the path of the received inode. As the snapshot
+        is intended to be empty, it always returns None.
+
+        :returns:
+            None.
+        """
         return None
 
     @property
     def paths(self):
+        """
+        Mock up method to return a set of file/directory paths in the snapshot. As the
+        snapshot is intended to be empty, it always returns an empty set.
+
+        :returns:
+            An empty set.
+        """
         return set()

--- a/tests/test_snapshot_diff.py
+++ b/tests/test_snapshot_diff.py
@@ -21,7 +21,7 @@ import time
 
 from watchdog.utils.dirsnapshot import DirectorySnapshot
 from watchdog.utils.dirsnapshot import DirectorySnapshotDiff
-from watchdog.utils.dirsnapshot import DirectorySnapshotEmpty
+from watchdog.utils.dirsnapshot import EmptyDirectorySnapshot
 from watchdog.utils import platform
 
 from .shell import mkdir, touch, mv, rm
@@ -212,7 +212,7 @@ def test_empty_snapshot(p):
     touch(p('a'))
     mkdir(p('b', 'c'), parents=True)
     ref = DirectorySnapshot(p(''))
-    empty = DirectorySnapshotEmpty()
+    empty = EmptyDirectorySnapshot()
 
     diff = DirectorySnapshotDiff(empty, ref)
     assert diff.files_created == [p('a')]

--- a/tests/test_snapshot_diff.py
+++ b/tests/test_snapshot_diff.py
@@ -21,6 +21,7 @@ import time
 
 from watchdog.utils.dirsnapshot import DirectorySnapshot
 from watchdog.utils.dirsnapshot import DirectorySnapshotDiff
+from watchdog.utils.dirsnapshot import DirectorySnapshotEmpty
 from watchdog.utils import platform
 
 from .shell import mkdir, touch, mv, rm
@@ -200,3 +201,19 @@ def test_ignore_device(monkeypatch, p):
     diff_without_device = DirectorySnapshotDiff(ref, snapshot, ignore_device=True)
     assert diff_without_device.files_deleted == []
     assert diff_without_device.files_created == []
+
+
+def test_empty_snapshot(p):
+    # Create a file and declare a DirectorySnapshot and a DirectorySnapshotEmpty.
+    # When we make the diff, although both objects were declared with the same items on
+    # the directory, the file and directories created BEFORE the DirectorySnapshot will
+    # be detected as newly created.
+
+    touch(p('a'))
+    mkdir(p('b', 'c'), parents=True)
+    ref = DirectorySnapshot(p(''))
+    empty = DirectorySnapshotEmpty()
+
+    diff = DirectorySnapshotDiff(empty, ref)
+    assert diff.files_created == [p('a')]
+    assert sorted(diff.dirs_created) == sorted([p(''), p('b'), p('b', 'c')])


### PR DESCRIPTION
I've added the class EmptyDirectorySnapshot.

This class is used to fake a DirectorySnapshot of an empty directory. The utility of this is to detect the files and folders of an already-with-content directory as just created.

This can be useful if the application needs to process all the files ignoring if they were created before or after the start of the application.

For example, if the folder has the following structure:
```bash
├── folder
│   └── file_in_folder.txt
├── file_a.txt
└── file_b.txt
```

If we run the following lines of code:
```python
current_snapshot = DirectorySnapshot('/')
diff = DirectorySnapshotDiff(EmptyDirectorySnapshot(), current_snapshot)
```
The resulting `diff` will comply with the following asserts:
```python
assert diff.files_created = ['/file_a.txt', '/file_b.txt', '/folder/file_in_folder.txt']
assert diff.dirs_created = ['/', '/folder']
```