### PR TITLE
Fix Python 3.6 installation when the OS locale is set to POSIX

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -10,9 +10,9 @@ Changelog
 
 Other Changes
 =============
-
+- Fixed Python 3.6 installation when the OS locale is set to POSIX (`#615 <https://github.com/gorakhargosh/watchdog/pull/615>`__)
 - [snapshot] Added EmptyDirectorySnapshot (`#613 <https://github.com/gorakhargosh/watchdog/pull/613>`__)
-- Thanks to our beloved contributors: @Ajordat
+- Thanks to our beloved contributors: @Ajordat, @tehkirill
 
 
 0.10.0

--- a/setup.py
+++ b/setup.py
@@ -79,10 +79,10 @@ extras_require = {
     'watchmedo': ['PyYAML>=3.10', 'argh>=0.24.1'],
 }
 
-with open('README.rst') as f:
+with open('README.rst', encoding='utf-8') as f:
     readme = f.read()
 
-with open('changelog.rst') as f:
+with open('changelog.rst', encoding='utf-8') as f:
     changelog = f.read()
 
 setup(name="watchdog",

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@
 
 import sys
 import os.path
+from codecs import open
 from setuptools import setup, find_packages
 from setuptools.extension import Extension
 from setuptools.command.build_ext import build_ext


### PR DESCRIPTION
Fixes #615.