### PR TITLE
Fix the build_ext command on macOS

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -11,6 +11,9 @@ Changelog
 Other Changes
 =============
 - Fixed Python 2.7 to 3.6 installation when the OS locale is set to POSIX (`#615 <https://github.com/gorakhargosh/watchdog/pull/615>`__)
+- Fixed the ``build_ext`` command on macOS  (`#618 <https://github.com/gorakhargosh/watchdog/pull/618>`__, `#620 <https://github.com/gorakhargosh/watchdog/pull/620>`_)
+- Moved requirements to ``setup.cfg``  (`#617 <https://github.com/gorakhargosh/watchdog/pull/617>`__)
+- [mac] Removed old C code for Python 2.5 in the `fsevents` C implementation
 - [snapshot] Added ``EmptyDirectorySnapshot`` (`#613 <https://github.com/gorakhargosh/watchdog/pull/613>`__)
 - Thanks to our beloved contributors: @Ajordat, @tehkirill, @BoboTiG
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,14 @@
+[options]
+install_requires =
+    pathtools >= 0.1.1
+    pyobjc-framework-Cocoa >= 4.2.2 ; sys_platform == "darwin"
+    pyobjc-framework-FSEvents >= 4.2.2 ; sys_platform == "darwin"
+
+[options.extras_require]
+watchmedo =
+    PyYAML >= 3.10
+    argh >= 0.24.1
+
 [build_sphinx]
 source-dir = docs/source
 build-dir  = docs/build

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ from codecs import open
 from setuptools import setup, find_packages
 from setuptools.extension import Extension
 from setuptools.command.build_ext import build_ext
-from distutils.util import get_platform
 
 SRC_DIR = 'src'
 WATCHDOG_PKG_DIR = os.path.join(SRC_DIR, 'watchdog')
@@ -38,7 +37,7 @@ else:
     version = imp.load_source('version', os.path.join(WATCHDOG_PKG_DIR, 'version.py'))
 
 ext_modules = []
-if get_platform().startswith('macosx'):
+if sys.platform == 'darwin':
     ext_modules = [
         Extension(
             name='_watchdog_fsevents',
@@ -61,7 +60,6 @@ if get_platform().startswith('macosx'):
                 '-std=c99',
                 '-pedantic',
                 '-Wall',
-                '-Werror',
                 '-Wextra',
                 '-fPIC',
 
@@ -70,15 +68,6 @@ if get_platform().startswith('macosx'):
             ]
         ),
     ]
-
-install_requires = [
-    "pathtools>=0.1.1",
-    'pyobjc-framework-Cocoa>=4.2.2 ; sys_platform == "darwin"',
-    'pyobjc-framework-FSEvents>=4.2.2 ; sys_platform == "darwin"',
-]
-extras_require = {
-    'watchmedo': ['PyYAML>=3.10', 'argh>=0.24.1'],
-}
 
 with open('README.rst', encoding='utf-8') as f:
     readme = f.read()
@@ -136,8 +125,6 @@ setup(name="watchdog",
       package_dir={'': SRC_DIR},
       packages=find_packages(SRC_DIR),
       include_package_data=True,
-      install_requires=install_requires,
-      extras_require=extras_require,
       cmdclass={
           'build_ext': build_ext,
       },

--- a/src/watchdog_fsevents.c
+++ b/src/watchdog_fsevents.c
@@ -26,22 +26,16 @@
 #include <signal.h>
 
 
-#if (PY_VERSION_HEX < 0x02050000) && !defined(PY_SSIZE_T_MIN)
-typedef int Py_ssize_t;
-#define PY_SSIZE_T_MIN INT_MIN
-#define PY_SSIZE_T_MAX INT_MAX
-#endif
-
 /* Convenience macros to make code more readable. */
-#define G_NOT(o)                        (!(o))
-#define G_IS_NULL(o)                    ((o) == NULL)
-#define G_IS_NOT_NULL(o)                ((o) != NULL)
-#define G_RETURN_NULL_IF_NULL(o)        do{if(NULL == (o)){ return NULL; }}while(0)
-#define G_RETURN_NULL_IF(condition)     do{if((condition)){ return NULL; }}while(0)
-#define G_RETURN_NULL_IF_NOT(condition) do{if(!(condition)){ return NULL; }}while(0)
-#define G_RETURN_IF(condition)          do{if((condition)){ return; }}while(0)
-#define G_RETURN_IF_NOT(condition)      do{if(!(condition)){ return; }}while(0)
-#define UNUSED(x)                       (void)(x)
+#define G_NOT(o)                        !o
+#define G_IS_NULL(o)                    o == NULL
+#define G_IS_NOT_NULL(o)                o != NULL
+#define G_RETURN_NULL_IF_NULL(o)        do { if (NULL == o) { return NULL; } } while (0)
+#define G_RETURN_NULL_IF(condition)     do { if (condition) { return NULL; } } while (0)
+#define G_RETURN_NULL_IF_NOT(condition) do { if (!condition) { return NULL; } } while (0)
+#define G_RETURN_IF(condition)          do { if (condition) { return; } } while (0)
+#define G_RETURN_IF_NOT(condition)      do { if (!condition) { return; } } while (0)
+#define UNUSED(x)                       (void)x
 
 /* Error message definitions. */
 #define ERROR_CANNOT_CALL_CALLBACK "Unable to call Python callback."

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ skip_missing_interpreters = True
 
 [testenv]
 deps =
+    -e .
     eventlet
     flake8
     pytest-cov


### PR DESCRIPTION
- Fixed the `build_ext` command on macOS
- Moved requirements to `setup.cfg`
- [mac] Removed old C code for Python 2.5 in the `fsevents` C implementation


Fixes #617,  #618 and #620.