### PR TITLE
Fixed the build_ext command on macOS Catalina

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 
 2020-0x-xx • `full history <https://github.com/gorakhargosh/watchdog/compare/v0.10.1...master>`__
 
+- Fixed the ``build_ext`` command on macOS Catalina (`#628 <https://github.com/gorakhargosh/watchdog/pull/628>`__)
 - Refactored ``dispatch()`` method of ``FileSystemEventHandler``,
   ``PatternMatchingEventHandler`` and ``RegexMatchingEventHandler``
 - Thanks to our beloved contributors: @BoboTiG

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,9 @@ if sys.platform == 'darwin':
 
                 # Issue #620
                 '-Wno-nullability-completeness',
+                # Issue #628
+                '-Wno-nullability-extension',
+                '-Wno-newline-eof',
 
                 # required w/Xcode 5.1+ and above because of '-mno-fused-madd'
                 '-Wno-error=unused-command-line-argument'


### PR DESCRIPTION
Added `-Wno-nullability-extension` and `-Wno-newline-eof` to compilation arguments.

Fixes #628.