### PR TITLE
Adapt tests to improve BSD support.

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -11,7 +11,8 @@ Changelog
 - Fixed the ``build_ext`` command on macOS Catalina (`#628 <https://github.com/gorakhargosh/watchdog/pull/628>`__)
 - Refactored ``dispatch()`` method of ``FileSystemEventHandler``,
   ``PatternMatchingEventHandler`` and ``RegexMatchingEventHandler``
-- Thanks to our beloved contributors: @BoboTiG
+- Improve tests support on non Windows/Linux platforms (`#633 <https://github.com/gorakhargosh/watchdog/pull/633>`__)
+- Thanks to our beloved contributors: @BoboTiG, @evilham
 
 
 0.10.1

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -231,10 +231,10 @@ def test_move_from_full():
 def test_separate_consecutive_moves():
     mkdir(p('dir1'))
     touch(p('dir1', 'a'))
-    touch(p('dir1', 'b'))
+    touch(p('b'))
     start_watching(p('dir1'))
     mv(p('dir1', 'a'), p('c'))
-    mv(p('dir1', 'b'), p('dir1', 'd'))
+    mv(p('b'), p('dir1', 'd'))
 
     event = event_queue.get(timeout=5)[0]
     assert event.src_path == p('dir1', 'a')


### PR DESCRIPTION
Preparation for #632. 

The only doubt I have here is regarding:  `test_separate_consecutive_moves`:
As far as the current KqueueEmitter is concerned, it looks like if we add a file from a different directory it is equivalent to that file being created and not renamed, as the test expects. Does this patch to the test make sense?


There was a false Linux|Windows dichotomy in some tests, so instead of
skipping certain tests on certain platforms, this now skips tests when
*not* on the expected platform.
E.g. InotifyFullEmitter tests shouldn't run on non-Linux and the
Windows-specific tests shouldn't run on non-Windows.