### PR TITLE
[WIP] FSEventsEmitter order events by mtime

### DIFF
--- a/src/watchdog/utils/dirsnapshot.py
+++ b/src/watchdog/utils/dirsnapshot.py
@@ -242,9 +242,7 @@ class DirectorySnapshotDiff(object):
         There are few exceptions:
             * Changes in metadata (e.g., permissions) may be lost.
             * Moved files are given before moved directories.
-            * Swaps in location will be reported successively.
-            * File location swaps (a -> b, b -> a) are reported as modified
-              events for the individual location.
+            * Swaps in location will be reported as ...
 
         To recreate the reported changes:
             * Apply all events in order.


### PR DESCRIPTION
This is an updated version, similar to the somewhat outdated PR #311. This essentially orders emitted events by mtime and prevents confusion when `FileDeletedEvent`s and `FileCreatedEvent`s appear out of order. This would fix for instance #538.

This issue only appears when using `DirectorySnapshot` to poll for events, as `FSEventsEmitter` does, and therefore does not seem to affect most observers.

Let me know if this is the right place to fix this, or if a modification of DirectorySnapshot is more appropriate.