### PR TITLE
[BSD] Further support in tests

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -11,7 +11,7 @@ Changelog
 - Fixed the ``build_ext`` command on macOS Catalina (`#628 <https://github.com/gorakhargosh/watchdog/pull/628>`__)
 - Refactored ``dispatch()`` method of ``FileSystemEventHandler``,
   ``PatternMatchingEventHandler`` and ``RegexMatchingEventHandler``
-- Improve tests support on non Windows/Linux platforms (`#633 <https://github.com/gorakhargosh/watchdog/pull/633>`__)
+- Improve tests support on non Windows/Linux platforms (`#633 <https://github.com/gorakhargosh/watchdog/pull/633>`__, `#639 <https://github.com/gorakhargosh/watchdog/pull/639>`__)
 - Added FreeBSD CI support (`#532 <https://github.com/gorakhargosh/watchdog/pull/532>`__)
 - [BSD] Restore partial support (`#638 <https://github.com/gorakhargosh/watchdog/pull/638>`__)
 - Thanks to our beloved contributors: @BoboTiG, @evilham


### PR DESCRIPTION
There are some quirks resulting from the current observer implementation.

This only adds tests to check that other platforms won't be affected.