### PR TITLE
[tests] Mark tests from test_delayed_queue.py as flaky

### DIFF
--- a/tests/test_delayed_queue.py
+++ b/tests/test_delayed_queue.py
@@ -15,9 +15,12 @@
 # limitations under the License.
 
 from time import time
+
+import pytest
 from watchdog.utils.delayed_queue import DelayedQueue
 
 
+@pytest.mark.flaky(max_runs=5, min_passes=1)
 def test_delayed_get():
     q = DelayedQueue(2)
     q.put("", True)
@@ -28,6 +31,7 @@ def test_delayed_get():
     assert 2.10 > elapsed > 1.99
 
 
+@pytest.mark.flaky(max_runs=5, min_passes=1)
 def test_nondelayed_get():
     q = DelayedQueue(2)
     q.put("", False)


### PR DESCRIPTION
There are many random failures on slow macOS machines:
```python
    def test_delayed_get():
        q = DelayedQueue(2)
        q.put("", True)
        inserted = time()
        q.get()
        elapsed = time() - inserted
        # 2.10 instead of 2.05 for slow macOS slaves on Travis
>       assert 2.10 > elapsed > 1.99
E       assert 2.1 > 2.1072750091552734
```

Marking those tests as flaky should fix them.