### PR TITLE
Removed pinned macOS requirements for fsevents2

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -9,6 +9,7 @@ Changelog
 2020-0x-xx • `full history <https://github.com/gorakhargosh/watchdog/compare/v0.10.1...master>`__
 
 - Fixed the ``build_ext`` command on macOS Catalina (`#628 <https://github.com/gorakhargosh/watchdog/pull/628>`__)
+- Removed pinned macOS requirements for ``fsevents2`` (`#635 <https://github.com/gorakhargosh/watchdog/pull/635>`__)
 - Refactored ``dispatch()`` method of ``FileSystemEventHandler``,
   ``PatternMatchingEventHandler`` and ``RegexMatchingEventHandler``
 - Improve tests support on non Windows/Linux platforms (`#633 <https://github.com/gorakhargosh/watchdog/pull/633>`__, `#639 <https://github.com/gorakhargosh/watchdog/pull/639>`__)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,14 +1,3 @@
-[options]
-install_requires =
-    pathtools >= 0.1.1
-    pyobjc-framework-Cocoa >= 4.2.2 ; sys_platform == "darwin"
-    pyobjc-framework-FSEvents >= 4.2.2 ; sys_platform == "darwin"
-
-[options.extras_require]
-watchmedo =
-    PyYAML >= 3.10
-    argh >= 0.24.1
-
 [build_sphinx]
 source-dir = docs/source
 build-dir  = docs/build

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,13 @@ if sys.platform == 'darwin':
         ),
     ]
 
+install_requires = [
+    "pathtools>=0.1.1",
+]
+extras_require = {
+    'watchmedo': ['PyYAML>=3.10', 'argh>=0.24.1'],
+}
+
 with open('README.rst', encoding='utf-8') as f:
     readme = f.read()
 
@@ -131,6 +138,8 @@ setup(name="watchdog",
       package_dir={'': SRC_DIR},
       packages=find_packages(SRC_DIR),
       include_package_data=True,
+      install_requires=install_requires,
+      extras_require=extras_require,
       cmdclass={
           'build_ext': build_ext,
       },

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -43,7 +43,7 @@ if platform.is_linux():
     )
 elif platform.is_darwin():
     pytestmark = pytest.mark.skip("FIXME: issue #546.")
-    from watchdog.observers.fsevents2 import FSEventsEmitter as Emitter
+    from watchdog.observers.fsevents import FSEventsEmitter as Emitter
 elif platform.is_windows():
     from watchdog.observers.read_directory_changes import (
         WindowsApiEmitter as Emitter


### PR DESCRIPTION
This partially reverts 6baa210d605459c8d2c5ddcac146c001cdf2f24d and fixes several issues with old `setuptools` versions.

Finally, this is how we did for eleases before 0.10.0 where PyObjC requirements were not required, but one would just install them manually.

Fixes #635 and #643.