### PR TITLE
Allow to monitor single file

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -8,7 +8,8 @@ Changelog
 
 2020-0x-xx • `full history <https://github.com/gorakhargosh/watchdog/compare/v0.10.2...master>`__
 
-- Thanks to our beloved contributors: @
+- [inotify] Allow to monitor single file (`#655 <https://github.com/gorakhargosh/watchdog/pull/655>`__)
+- Thanks to our beloved contributors: @brant-ruan
 
 
 0.10.2

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -5,3 +5,4 @@ flaky
 pytest
 pytest-cov
 pytest-timeout
+pathlib

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -5,4 +5,3 @@ flaky
 pytest
 pytest-cov
 pytest-timeout
-pathlib

--- a/src/watchdog/observers/inotify_c.py
+++ b/src/watchdog/observers/inotify_c.py
@@ -197,7 +197,10 @@ class Inotify(object):
         self._path = path
         self._event_mask = event_mask
         self._is_recursive = recursive
-        self._add_dir_watch(path, recursive, event_mask)
+        if os.path.isdir(path):
+            self._add_dir_watch(path, recursive, event_mask)
+        else:
+            self._add_watch(path, event_mask)
         self._moved_from_events = dict()
 
     @property

--- a/tests/test_inotify_c.py
+++ b/tests/test_inotify_c.py
@@ -172,8 +172,8 @@ def test_non_ascii_path():
 
 def test_watch_file():
     path = p("this_is_a_file")
-    from pathlib import Path
-    Path(path).touch()
+    with open(path, "a"):
+        pass
     with watching(path):
         os.remove(path)
         event, _ = event_queue.get(timeout=5)

--- a/tests/test_inotify_c.py
+++ b/tests/test_inotify_c.py
@@ -168,3 +168,13 @@ def test_non_ascii_path():
         assert event.src_path == path
         # Just make sure it doesn't raise an exception.
         assert repr(event)
+
+
+def test_watch_file():
+    path = p("this_is_a_file")
+    from pathlib import Path
+    Path(path).touch()
+    with watching(path):
+        os.remove(path)
+        event, _ = event_queue.get(timeout=5)
+        assert repr(event)


### PR DESCRIPTION
Currently on Linux using watchdog we can only monitor directories... But for many cases it is necessary to enable the users to monitor files (not directory)