### PR TITLE
PR: Prevent raising an exception when a file in a monitored folder has no permissions

### DIFF
--- a/src/watchdog/observers/inotify_c.py
+++ b/src/watchdog/observers/inotify_c.py
@@ -424,6 +424,10 @@ class Inotify(object):
             raise OSError(errno.ENOSPC, "inotify watch limit reached")
         elif err == errno.EMFILE:
             raise OSError(errno.EMFILE, "inotify instance limit reached")
+        elif err == errno.EACCES:
+            # Prevent raising an exception when a file with no permissions
+            # changes
+            pass
         else:
             raise OSError(err, os.strerror(err))
 


### PR DESCRIPTION
Fixes https://github.com/spyder-ide/spyder/issues/12636

cc @ccordoba12