### PR TITLE
Replace mutable default arguments with the correct implementation.

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -8,7 +8,8 @@ Changelog
 
 2020-xx-xx • `full history <https://github.com/gorakhargosh/watchdog/compare/v0.10.3...master>`__
 
-- Thanks to our beloved contributors: @
+- Replace mutable default arguments with ``if None`` implementation (`#677 <https://github.com/gorakhargosh/watchdog/pull/677>`_)
+- Thanks to our beloved contributors: @Sraw
 
 
 0.10.3

--- a/src/watchdog/events.py
+++ b/src/watchdog/events.py
@@ -457,10 +457,14 @@ class RegexMatchingEventHandler(FileSystemEventHandler):
     Matches given regexes with file paths associated with occurring events.
     """
 
-    def __init__(self, regexes=[r".*"], ignore_regexes=[],
+    def __init__(self, regexes=None, ignore_regexes=None,
                  ignore_directories=False, case_sensitive=False):
         super(RegexMatchingEventHandler, self).__init__()
 
+        if regexes is None:
+            regexes = [r".*"]
+        if ignore_regexes is None:
+            ignore_regexes = []
         if case_sensitive:
             self._regexes = [re.compile(r) for r in regexes]
             self._ignore_regexes = [re.compile(r) for r in ignore_regexes]


### PR DESCRIPTION
This will avoid potential sharing state problems through different instances of the EventHandler.

The problem is very unlikely to happen, but whatever we fix a potential bug.