### PR TITLE
fix: Handle SIGTERM more gracefully in watchmedo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,9 +33,9 @@ as command-line arguments and logs events generated:
         try:
             while True:
                 time.sleep(1)
-        except KeyboardInterrupt:
+        finally:
             observer.stop()
-        observer.join()
+            observer.join()
 
 
 Shell Utilities

--- a/changelog.rst
+++ b/changelog.rst
@@ -12,7 +12,8 @@ Changelog
 - Replace mutable default arguments with ``if None`` implementation (`#677 <https://github.com/gorakhargosh/watchdog/pull/677>`_)
 - Expand tests to Python 2.7 and 3.5-3.10 for GNU/Linux, macOS and Windows
 - [mac] Performance improvements for the `fsevents` module (`#680 <https://github.com/gorakhargosh/watchdog/pull/680>`_)
-- Thanks to our beloved contributors: @Sraw, @CCP-Aporia, @BoboTiG
+- Handle shutdown events from SIGTERM and SIGINT to `watchmedo` more reliably (`#693 <https://github.com/gorakhargosh/watchdog/pull/693>`_)
+- Thanks to our beloved contributors: @Sraw, @CCP-Aporia, @BoboTiG, @maybe-sybr
 
 
 0.10.3

--- a/docs/source/examples/logger.py
+++ b/docs/source/examples/logger.py
@@ -14,6 +14,6 @@ observer.start()
 try:
     while True:
         time.sleep(1)
-except KeyboardInterrupt:
+finally:
     observer.stop()
-observer.join()
+    observer.join()

--- a/docs/source/examples/patterns.py
+++ b/docs/source/examples/patterns.py
@@ -25,6 +25,6 @@ observer.start()
 try:
     while True:
         time.sleep(1)
-except KeyboardInterrupt:
+finally:
     observer.stop()
-observer.join()
+    observer.join()

--- a/docs/source/examples/simple.py
+++ b/docs/source/examples/simple.py
@@ -37,6 +37,6 @@ observer.start()
 try:
     while True:
         time.sleep(1)
-except KeyboardInterrupt:
+finally:
     observer.stop()
-observer.join()
+    observer.join()

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -48,8 +48,8 @@ file system changes and simply log them to the console::
         try:
             while observer.isAlive():
                 observer.join(1)
-        except KeyboardInterrupt:
+        finally:
             observer.stop()
-        observer.join()
+            observer.join()
 
 To stop the program, press Control-C.

--- a/src/watchdog/utils/__init__.py
+++ b/src/watchdog/utils/__init__.py
@@ -62,6 +62,13 @@ class UnsupportedLibc(Exception):
     pass
 
 
+class WatchdogShutdown(Exception):
+    """
+    Semantic exception used to signal an external shutdown event.
+    """
+    pass
+
+
 class BaseThread(threading.Thread):
     """ Convenience class for creating stoppable threads. """
 


### PR DESCRIPTION
This fixes some misbehaviour where the child process could be orphaned
if watchmedo received multiple SIGTERMs causing the `stop()` call to be
interrupted. By raising a semantic exception after neutering the signal
handler, we give ourselves a better chance of killing the child.