### PR TITLE
Fix installation of python 3.7.9 on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,7 +130,7 @@ jobs:
       os: windows
       language: shell
       before_install:
-        -choco install python3 --version=3.7.9
+        - choco install python3 --version=3.7.9
       env:
         - TOXENV=py37
         - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"


### PR DESCRIPTION
I'm guessing this would only leave the thread leak as the source of failure.