### PR TITLE
Fixes for native fs-events

### DIFF
--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -111,7 +111,7 @@ class FSEventsEmitter(EventEmitter):
                         self.queue_event(DirModifiedEvent(os.path.dirname(event.path)))
                     # TODO: generate events for tree
 
-                elif event.is_modified or event.is_inode_meta_mod or event.is_xattr_mod :
+                elif event.is_modified or event.is_inode_meta_mod or event.is_xattr_mod:
                     cls = DirModifiedEvent if event.is_directory else FileModifiedEvent
                     self.queue_event(cls(event.path))
 

--- a/src/watchdog_fsevents.c
+++ b/src/watchdog_fsevents.c
@@ -313,7 +313,7 @@ watchdog_FSEventStreamCallback(ConstFSEventStreamRef          stream_ref,
     }
     for (i = 0; i < num_events; ++i)
     {
-        id = PyLong_FromLongLong(event_flags[i]);
+        id = PyLong_FromLongLong(event_ids[i]);
 #if PY_MAJOR_VERSION >= 3
         path = PyUnicode_FromString(event_paths[i]);
         flags = PyLong_FromLong(event_flags[i]);

--- a/src/watchdog_fsevents.c
+++ b/src/watchdog_fsevents.c
@@ -149,11 +149,29 @@ PyObject* NativeEventTypeID(PyObject* instance, void* closure)
         Py_RETURN_FALSE; \
     }
 
+FLAG_PROPERTY(IsMustScanSubDirs, kFSEventStreamEventFlagMustScanSubDirs)
+FLAG_PROPERTY(IsUserDropped, kFSEventStreamEventFlagUserDropped)
+FLAG_PROPERTY(IsKernelDropped, kFSEventStreamEventFlagKernelDropped)
+FLAG_PROPERTY(IsEventIdsWrapped, kFSEventStreamEventFlagEventIdsWrapped)
+FLAG_PROPERTY(IsHistoryDone, kFSEventStreamEventFlagHistoryDone)
+FLAG_PROPERTY(IsRootChanged, kFSEventStreamEventFlagRootChanged)
+FLAG_PROPERTY(IsMount, kFSEventStreamEventFlagMount)
+FLAG_PROPERTY(IsUnmount, kFSEventStreamEventFlagUnmount)
 FLAG_PROPERTY(IsCreated, kFSEventStreamEventFlagItemCreated)
 FLAG_PROPERTY(IsRemoved, kFSEventStreamEventFlagItemRemoved)
+FLAG_PROPERTY(IsInodeMetaMod, kFSEventStreamEventFlagItemInodeMetaMod)
 FLAG_PROPERTY(IsRenamed, kFSEventStreamEventFlagItemRenamed)
 FLAG_PROPERTY(IsModified, kFSEventStreamEventFlagItemModified)
+FLAG_PROPERTY(IsItemFinderInfoMod, kFSEventStreamEventFlagItemFinderInfoMod)
+FLAG_PROPERTY(IsChangeOwner, kFSEventStreamEventFlagItemChangeOwner)
+FLAG_PROPERTY(IsXattrMod, kFSEventStreamEventFlagItemXattrMod)
+FLAG_PROPERTY(IsFile, kFSEventStreamEventFlagItemIsFile)
 FLAG_PROPERTY(IsDirectory, kFSEventStreamEventFlagItemIsDir)
+FLAG_PROPERTY(IsSymlink, kFSEventStreamEventFlagItemIsSymlink)
+FLAG_PROPERTY(IsOwnEvent, kFSEventStreamEventFlagOwnEvent)
+FLAG_PROPERTY(IsHardlink, kFSEventStreamEventFlagItemIsHardlink)
+FLAG_PROPERTY(IsLastHardlink, kFSEventStreamEventFlagItemIsLastHardlink)
+FLAG_PROPERTY(IsCloned, kFSEventStreamEventFlagItemCloned)
 
 static int NativeEventInit(NativeEventObject *self, PyObject *args, PyObject *kwds)
 {
@@ -171,11 +189,29 @@ static PyGetSetDef NativeEventProperties[] = {
     {"flags", NativeEventTypeFlags, NULL, "The raw mask of flags as returend by FSEvents", NULL},
     {"path", NativeEventTypePath, NULL, "The path for which this event was generated", NULL},
     {"id", NativeEventTypeID, NULL, "The id of the generated event", NULL},
+    {"must_scan_subdirs", NativeEventTypeIsMustScanSubDirs, NULL, "True if application must rescan all subdirectories", NULL},
+    {"is_user_dropped", NativeEventTypeIsUserDropped, NULL, "True if a failure during event buffering occured", NULL},
+    {"is_kernel_dropped", NativeEventTypeIsKernelDropped, NULL, "True if a failure during event buffering occured", NULL},
+    {"is_event_ids_wrapped", NativeEventTypeIsEventIdsWrapped, NULL, "True if event_id wrapped around", NULL},
+    {"is_history_done", NativeEventTypeIsHistoryDone, NULL, "True if all historical events are done", NULL},
+    {"is_root_changed", NativeEventTypeIsRootChanged, NULL, "True if a change to one of the directories along the path to one of the directories you watch occurred", NULL},
+    {"is_mount", NativeEventTypeIsMount, NULL, "True if a volume is mounted underneath one of the paths being monitored", NULL},
+    {"is_unmount", NativeEventTypeIsUnmount, NULL, "True if a volume is unmounted underneath one of the paths being monitored", NULL},
     {"is_created", NativeEventTypeIsCreated, NULL, "True if self.path was created on the filesystem", NULL},
     {"is_removed", NativeEventTypeIsRemoved, NULL, "True if self.path was removed from the filesystem", NULL},
+    {"is_inode_meta_mod", NativeEventTypeIsInodeMetaMod, NULL, "True if meta data for self.path was modified ", NULL},
     {"is_renamed", NativeEventTypeIsRenamed, NULL, "True if self.path was renamed on the filesystem", NULL},
     {"is_modified", NativeEventTypeIsModified, NULL, "True if self.path was modified", NULL},
+    {"is_item_finder_info_modified", NativeEventTypeIsItemFinderInfoMod, NULL, "True if FinderInfo for self.path was modified", NULL},
+    {"is_owner_change", NativeEventTypeIsChangeOwner, NULL, "True if self.path had its ownership changed", NULL},
+    {"is_xattr_mod", NativeEventTypeIsXattrMod, NULL, "True if extended attributes for self.path were modified ", NULL},
+    {"is_file", NativeEventTypeIsFile, NULL, "True if self.path is a file", NULL},
     {"is_directory", NativeEventTypeIsDirectory, NULL, "True if self.path is a directory", NULL},
+    {"is_symlink", NativeEventTypeIsSymlink, NULL, "True if self.path is a symbolic link", NULL},
+    {"is_own_event", NativeEventTypeIsOwnEvent, NULL, "True if the event originated from our own process", NULL},
+    {"is_hardlink", NativeEventTypeIsHardlink, NULL, "True if self.path is a hard link", NULL},
+    {"is_last_hardlink", NativeEventTypeIsLastHardlink, NULL, "True if self.path was the last hard link", NULL},
+    {"is_cloned", NativeEventTypeIsCloned, NULL, "True if self.path is a clone or was cloned", NULL},
     {NULL, NULL, NULL, NULL, NULL},
 };
 

--- a/tests/test_fsevents.py
+++ b/tests/test_fsevents.py
@@ -12,12 +12,13 @@ import time
 from functools import partial
 from os import mkdir, rmdir
 
+from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 from watchdog.observers.api import ObservedWatch
 from watchdog.observers.fsevents import FSEventsEmitter
 
 from . import Queue
-from .shell import mkdtemp, rm
+from .shell import mkdtemp, rm, touch
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
@@ -96,7 +97,49 @@ E       SystemError: <built-in function stop> returned a result with an error se
     """
     a = p("a")
     mkdir(a)
-    w = observer.schedule(event_queue, a, recursive=False)
+    w = observer.schedule(FileSystemEventHandler(), a, recursive=False)
     rmdir(a)
     time.sleep(0.1)
     observer.unschedule(w)
+
+
+def test_watchdog_recursive():
+    """ See https://github.com/gorakhargosh/watchdog/issues/706
+    """
+    from watchdog.observers import Observer
+    from watchdog.events import FileSystemEventHandler
+    import os.path
+
+    class Handler(FileSystemEventHandler):
+        def __init__(self):
+            FileSystemEventHandler.__init__(self)
+            self.changes = []
+
+        def on_any_event(self, event):
+            self.changes.append(os.path.basename(event.src_path))
+
+    handler = Handler()
+    observer = Observer()
+
+    watches = []
+    watches.append(observer.schedule(handler, str(p('')), recursive=True))
+
+    try:
+        observer.start()
+        time.sleep(0.1)
+
+        touch(p('my0.txt'))
+        mkdir(p('dir_rec'))
+        touch(p('dir_rec', 'my1.txt'))
+
+        expected = {"dir_rec", "my0.txt", "my1.txt"}
+        timeout_at = time.time() + 5
+        while not expected.issubset(handler.changes) and time.time() < timeout_at:
+            time.sleep(0.2)
+
+        assert expected.issubset(handler.changes), "Did not find expected changes. Found: {}".format(handler.changes)
+    finally:
+        for watch in watches:
+            observer.unschedule(watch)
+        observer.stop()
+        observer.join(1)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{310,39,38,37,36,35,27,py3,py}
+envlist = py{35,27,py}
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Some fixes and code simplifications for the native fsevents module: 
1) PyCapsule is supported in 2.7, and so is the `PyBytes_` C API, so we can remove a bunch of the `#if PY_MAJOR_VERSION` conditionals.
2) Ensure on the C side that a valid UTF-8 encoded path is passed. This was one source of error memory corruption on my machine.
3) Exposes missing attributes on `NativeEvent` (and provides additional ones that weren't exposed so far). This fixes #702 .

Alas, the Python 2.7 tests currently fail with an interesting error in `tests/test_fsevents.py::test_unschedule_removed_folder` that I still need to investigate. So this draft PR is primarily to see what the CI says for everything that I cannot test locally.