### PR TITLE
Don't pass event flag as ID on macOS

### DIFF
--- a/src/watchdog_fsevents.c
+++ b/src/watchdog_fsevents.c
@@ -299,7 +299,7 @@ watchdog_FSEventStreamCallback(ConstFSEventStreamRef          stream_ref,
     }
     for (i = 0; i < num_events; ++i)
     {
-        id = PyLong_FromLongLong(event_flags[i]);
+        id = PyLong_FromLongLong(event_ids[i]);
         path = PyUnicode_FromString(event_paths[i]);
         flags = PyLong_FromLong(event_flags[i]);
         if (G_NOT(path && flags && id))


### PR DESCRIPTION
This fixes #723 by properly passing the event ID and not the event flags.