### PR TITLE
Fixes missing notification for deletion of watched dir on macOS

### DIFF
--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -133,7 +133,6 @@ class FSEventsEmitter(EventEmitter):
                     # This will be set if root or any if its parents is renamed or
                     # deleted.
                     # TODO: find out new path and generate DirMovedEvent?
-                    # self.queue_event(DirDeletedEvent(self.watch.path))
                     self.queue_event(DirDeletedEvent(self.watch.path))
                     self.stop()
 

--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -123,6 +123,20 @@ class FSEventsEmitter(EventEmitter):
                     cls = DirDeletedEvent if event.is_directory else FileDeletedEvent
                     self.queue_event(cls(src_path))
                     self.queue_event(DirModifiedEvent(os.path.dirname(src_path)))
+
+                    if src_path == self.watch.path:
+                        # this should not really occur, instead we expect
+                        # is_root_changed to be set
+                        self.stop()
+
+                elif event.is_root_changed:
+                    # This will be set if root or any if its parents is renamed or
+                    # deleted.
+                    # TODO: find out new path and generate DirMovedEvent?
+                    # self.queue_event(DirDeletedEvent(self.watch.path))
+                    self.queue_event(DirDeletedEvent(self.watch.path))
+                    self.stop()
+
                 i += 1
 
     def run(self):

--- a/src/watchdog/observers/inotify.py
+++ b/src/watchdog/observers/inotify.py
@@ -170,8 +170,8 @@ class InotifyEmitter(EventEmitter):
                 cls = DirCreatedEvent if event.is_directory else FileCreatedEvent
                 self.queue_event(cls(src_path))
                 self.queue_event(DirModifiedEvent(os.path.dirname(src_path)))
-            elif event.is_delete_self:
-                self.queue_event(DirDeletedEvent(self.watch.path))
+            elif event.is_delete_self and src_path == self.watch.path:
+                self.queue_event(DirDeletedEvent(src_path))
                 self.stop()
 
     def _decode_path(self, path):

--- a/src/watchdog/observers/inotify.py
+++ b/src/watchdog/observers/inotify.py
@@ -170,6 +170,9 @@ class InotifyEmitter(EventEmitter):
                 cls = DirCreatedEvent if event.is_directory else FileCreatedEvent
                 self.queue_event(cls(src_path))
                 self.queue_event(DirModifiedEvent(os.path.dirname(src_path)))
+            elif event.is_delete_self:
+                self.queue_event(DirDeletedEvent(self.watch.path))
+                self.stop()
 
     def _decode_path(self, path):
         """Decode path only if unicode string was passed to this emitter. """

--- a/src/watchdog/observers/read_directory_changes.py
+++ b/src/watchdog/observers/read_directory_changes.py
@@ -22,6 +22,7 @@ import time
 
 from watchdog.events import (
     DirCreatedEvent,
+    DirDeletedEvent,
     DirMovedEvent,
     DirModifiedEvent,
     FileCreatedEvent,
@@ -121,6 +122,7 @@ class WindowsApiEmitter(EventEmitter):
                 elif winapi_event.is_removed:
                     self.queue_event(FileDeletedEvent(src_path))
                 elif winapi_event.is_removed_self:
+                    self.queue_event(DirDeletedEvent(self.watch.path))
                     self.stop()
 
 

--- a/src/watchdog_fsevents.c
+++ b/src/watchdog_fsevents.c
@@ -467,7 +467,7 @@ watchdog_FSEventStreamCreate(StreamCallbackInfo *stream_callback_info_ref,
                                      paths,
                                      kFSEventStreamEventIdSinceNow,
                                      stream_latency,
-                                     kFSEventStreamCreateFlagNoDefer | kFSEventStreamCreateFlagFileEvents);
+                                     kFSEventStreamCreateFlagNoDefer | kFSEventStreamCreateFlagFileEvents | kFSEventStreamCreateFlagWatchRoot);
     CFRelease(paths);
     return stream_ref;
 }

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -64,7 +64,11 @@ def setup_teardown(tmpdir):
 
     yield
 
-    emitter.stop()
+    try:
+        emitter.stop()
+    except OSError:
+        # watch was already stopped, e.g., in `test_delete_self`
+        pass
     emitter.join(5)
     assert not emitter.is_alive()
 

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -283,10 +283,13 @@ def test_delete_self():
     start_watching(p('dir1'))
     rm(p('dir1'), True)
 
-    if platform.is_darwin():
-        event = event_queue.get(timeout=5)[0]
-        assert event.src_path == p('dir1')
-        assert isinstance(event, FileDeletedEvent)
+    event = event_queue.get(timeout=5)[0]
+    assert event.src_path == p('dir1')
+    assert isinstance(event, DirDeletedEvent)
+
+    emitter.join(timeout=1)
+    assert not emitter.is_alive()
+
 
 
 @pytest.mark.skipif(platform.is_windows() or platform.is_bsd(),

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -291,6 +291,19 @@ def test_delete_self():
     assert not emitter.is_alive()
 
 
+@pytest.mark.flaky(max_runs=5, min_passes=1, rerun_filter=rerun_filter)
+def test_move_self():
+    mkdir(p('dir1'))
+    start_watching(p('dir1'))
+    mv(p('dir1'), p('dir2'))
+
+    event = event_queue.get(timeout=5)[0]
+    assert event.src_path == p('dir1')
+    # TODO: check DirMovedEvent or DirDeletedEvent
+
+    emitter.join(timeout=1)
+    assert not emitter.is_alive()
+
 
 @pytest.mark.skipif(platform.is_windows() or platform.is_bsd(),
                     reason="Windows|BSD create another set of events for this test")

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -291,20 +291,6 @@ def test_delete_self():
     assert not emitter.is_alive()
 
 
-@pytest.mark.flaky(max_runs=5, min_passes=1, rerun_filter=rerun_filter)
-def test_move_self():
-    mkdir(p('dir1'))
-    start_watching(p('dir1'))
-    mv(p('dir1'), p('dir2'))
-
-    event = event_queue.get(timeout=5)[0]
-    assert event.src_path == p('dir1')
-    # TODO: check DirMovedEvent or DirDeletedEvent
-
-    emitter.join(timeout=1)
-    assert not emitter.is_alive()
-
-
 @pytest.mark.skipif(platform.is_windows() or platform.is_bsd(),
                     reason="Windows|BSD create another set of events for this test")
 def test_fast_subdirectory_creation_deletion():

--- a/tests/test_fsevents.py
+++ b/tests/test_fsevents.py
@@ -100,7 +100,9 @@ E       SystemError: <built-in function stop> returned a result with an error se
     w = observer.schedule(FileSystemEventHandler(), a, recursive=False)
     rmdir(a)
     time.sleep(0.1)
-    observer.unschedule(w)
+    with pytest.raises(KeyError):
+        # watch no longer exists!
+        observer.unschedule(w)
 
 
 def test_watchdog_recursive():

--- a/tests/test_inotify_c.py
+++ b/tests/test_inotify_c.py
@@ -40,7 +40,11 @@ def watching(path=None, use_full_emitter=False):
     emitter = Emitter(event_queue, ObservedWatch(path, recursive=True))
     emitter.start()
     yield
-    emitter.stop()
+    try:
+        emitter.stop()
+    except OSError:
+        # watch was already stopped, e.g., because root was deleted
+        pass
     emitter.join(5)
 
 


### PR DESCRIPTION
This PR fixes an issue which would prevent us from being notified when the watched directory is deleted. This is achieved by passing the `kFSEventStreamCreateFlagWatchRoot` to the watch.