### PR TITLE
Fix detection of modified events on macOS

### DIFF
--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -108,10 +108,6 @@ class FSEventsEmitter(EventEmitter):
                         self.queue_event(DirModifiedEvent(os.path.dirname(event.path)))
                     # TODO: generate events for tree
 
-                elif event.is_modified or event.is_inode_meta_mod or event.is_xattr_mod :
-                    cls = DirModifiedEvent if event.is_directory else FileModifiedEvent
-                    self.queue_event(cls(event.path))
-
                 elif event.is_created:
                     cls = DirCreatedEvent if event.is_directory else FileCreatedEvent
                     self.queue_event(cls(event.path))
@@ -121,6 +117,11 @@ class FSEventsEmitter(EventEmitter):
                     cls = DirDeletedEvent if event.is_directory else FileDeletedEvent
                     self.queue_event(cls(event.path))
                     self.queue_event(DirModifiedEvent(os.path.dirname(event.path)))
+
+                elif event.is_modified or event.is_inode_meta_mod or event.is_xattr_mod:
+                    cls = DirModifiedEvent if event.is_directory else FileModifiedEvent
+                    self.queue_event(cls(event.path))
+
                 i += 1
 
     def run(self):


### PR DESCRIPTION
Fixes an issue where created events could incorrectly be classified as modified events if their `is_inode_meta_mod` or `is_xattr_mod` flags are set.

To discuss before merging: we might want to emit an additional modified event if those flags are set, in addition to the created event.