### PR TITLE
Add compatibility with old macOS versions

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -9,7 +9,8 @@ Changelog
 202x-xx-xx • `full history <https://github.com/gorakhargosh/watchdog/compare/v1.0.1...master>`__
 
 - [mac] Fix missing ``event_id`` attribute in ``fsevents`` (`#721 <https://github.com/gorakhargosh/watchdog/pull/721>`_)
-- Thanks to our beloved contributors: @SamSchott
+- [mac] Add compatibility with old macOS versions (`#733` <https://github.com/gorakhargosh/watchdog/pull/733>`_)
+- Thanks to our beloved contributors: @SamSchott, @CCP-Aporia
 
 
 1.0.1

--- a/src/watchdog_fsevents.c
+++ b/src/watchdog_fsevents.c
@@ -28,6 +28,18 @@
 
 
 /* Compatibility; since fsevents won't set these on earlier macOS versions the properties will always be False */
+#if MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_7
+#error Watchdog module requires at least Mac OS X 10.7
+#endif
+#ifndef MAC_OS_X_VERSION_10_9
+#define MAC_OS_X_VERSION_10_9         1090
+#endif
+#ifndef MAC_OS_X_VERSION_10_10
+#define MAC_OS_X_VERSION_10_10      101000
+#endif
+#ifndef MAC_OS_X_VERSION_10_13
+#define MAC_OS_X_VERSION_10_13      101300
+#endif
 #if MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_9
 #define kFSEventStreamEventFlagOwnEvent 0x00080000
 #endif

--- a/src/watchdog_fsevents.c
+++ b/src/watchdog_fsevents.c
@@ -28,14 +28,14 @@
 
 
 /* Compatibility; since fsevents won't set these on earlier macOS versions the properties will always be False */
-#if MAC_OS_X_VERSION_MAX_ALLOWED <= MAC_OS_X_VERSION_10_9
+#if MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_9
 #define kFSEventStreamEventFlagOwnEvent 0x00080000
 #endif
-#if MAC_OS_X_VERSION_MAX_ALLOWED <= MAC_OS_X_VERSION_10_10
+#if MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_10
 #define kFSEventStreamEventFlagItemIsHardlink 0x00100000
 #define kFSEventStreamEventFlagItemIsLastHardlink 0x00200000
 #endif
-#if MAC_OS_X_VERSION_MAX_ALLOWED <= MAC_OS_X_VERSION_10_13
+#if MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_13
 #define kFSEventStreamEventFlagItemCloned 0x00400000
 #endif
 

--- a/src/watchdog_fsevents.c
+++ b/src/watchdog_fsevents.c
@@ -20,10 +20,24 @@
 
 
 #include <Python.h>
+#include <Availability.h>
 #include <CoreFoundation/CoreFoundation.h>
 #include <CoreServices/CoreServices.h>
 #include <stdlib.h>
 #include <signal.h>
+
+
+/* Compatibility; since fsevents won't set these on earlier macOS versions the properties will always be False */
+#if MAC_OS_X_VERSION_MAX_ALLOWED <= MAC_OS_X_VERSION_10_9
+#define kFSEventStreamEventFlagOwnEvent 0x00080000
+#endif
+#if MAC_OS_X_VERSION_MAX_ALLOWED <= MAC_OS_X_VERSION_10_10
+#define kFSEventStreamEventFlagItemIsHardlink 0x00100000
+#define kFSEventStreamEventFlagItemIsLastHardlink 0x00200000
+#endif
+#if MAC_OS_X_VERSION_MAX_ALLOWED <= MAC_OS_X_VERSION_10_13
+#define kFSEventStreamEventFlagItemCloned 0x00400000
+#endif
 
 
 /* Convenience macros to make code more readable. */


### PR DESCRIPTION
Fix #732 

Note that this is mostly untested as I don't have access to old machines and all my local python versions (installed via MacPorts) were configured for Big Sur which makes it impossible to build the extension for an earlier version.