### PR TITLE
Report-errors in emitter

### DIFF
--- a/src/watchdog/events.py
+++ b/src/watchdog/events.py
@@ -95,6 +95,7 @@ EVENT_TYPE_MOVED = 'moved'
 EVENT_TYPE_DELETED = 'deleted'
 EVENT_TYPE_CREATED = 'created'
 EVENT_TYPE_MODIFIED = 'modified'
+EVENT_TYPE_ERROR = 'error'
 
 
 class FileSystemEvent:
@@ -243,6 +244,22 @@ class DirMovedEvent(FileSystemMovedEvent):
 
     is_directory = True
 
+class FileObserverErrorEvent(FileSystemEvent):
+    """File system event representing an error in the monitor."""
+    event_type = EVENT_TYPE_ERROR
+
+    def __init__(self, src_path, exception):
+        self._exception = exception
+        super(FileObserverErrorEvent, self).__init__(src_path)
+
+    @property
+    def exception(self):
+        return self._exception
+
+    def __repr__(self):
+        return ("<%(class_name)s: exception=%(exception)r>"
+                ) % (dict(class_name=self.__class__.__name__,
+                          exception=repr(self.exception)))
 
 class FileSystemEventHandler:
     """

--- a/src/watchdog/observers/api.py
+++ b/src/watchdog/observers/api.py
@@ -19,6 +19,7 @@ import queue
 import threading
 from pathlib import Path
 
+from watchdog.events import FileObserverErrorEvent
 from watchdog.utils import BaseThread
 from watchdog.utils.bricks import SkipRepeatsQueue
 
@@ -145,7 +146,10 @@ class EventEmitter(BaseThread):
 
     def run(self):
         while self.should_keep_running():
-            self.queue_events(self.timeout)
+            try:
+                self.queue_events(self.timeout)
+            except Exception as ex:
+                self.queue_event(FileObserverErrorEvent(self._watch.path, ex))
 
 
 class EventDispatcher(BaseThread):


### PR DESCRIPTION
Emitters can raise exceptions, for example if a handle becomes invalidated.  Rather than handle it on a per-emitter basis, a catch-all can emit the underlying exception.

The caller can then choose to tear down an observer, or ignore the event as needed.

DRAFT:  Does this look reasonable?   Should I keep going (tests, use cases, docs).