### PR TITLE
Add workflow for building and releasing wheels

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,125 @@
+# Because this library provides extension modules for macOS, but not for other
+# platforms, we want to provide built distributions for each macOS platform, but we
+# explicitly DON'T want to provide a cross-platform pure-Python wheel to fall back on.
+#
+# This is because in the event that a new Python version is released or a new
+# macOS platform is released, macOS users won't be able to install the built
+# distributions we've provided and should fall back to the source distribution,
+# but pip's behavior is to prefer a pure-Python wheel first, which will be
+# missing the extension modules.
+#
+# However, to provide built distributions for Linux and Windows (which don't
+# have extension modules) we can just build a pure-Python wheel on that
+# platform and override the platform name manually via wheel's --plat-name
+# feature, to provide a platform-specific wheel for all platforms.
+
+name: Test, Build & Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to base the release from'
+        required: true
+        default: 'master'
+
+jobs:
+  tests:
+    name: Run tests for ${{ matrix.os }} for ${{ matrix.python }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python: [3.6, 3.7, 3.8, 3.9]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Use Python ${{ matrix.python }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install test dependencies
+      run: python -m pip install tox
+    - name: Test
+      run: python -m tox -e py
+
+  macos-built-distributions:
+    name: Build macOS wheels
+    needs: tests
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Python
+        uses: actions/setup-python@v2
+      - name: Install build dependencies
+        run: python -m pip install cibuildwheel
+      - name: Build wheels
+        run: python -m cibuildwheel
+        env:
+          CIBW_SKIP: "cp27-* cp35-* pp27-*"  # skip 2.7 and 3.5 wheels
+      - uses: actions/upload-artifact@v2
+        with:
+          name: python-package-distributions
+          path: ./wheelhouse/*.whl
+
+  pure-built-distributions:
+    name: Build pure wheels
+    needs: tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Python
+        uses: actions/setup-python@v2
+      - name: Install build dependencies
+        run: python -m pip install -U setuptools wheel
+      - name: Build wheels
+        run: |
+          for platform in 'manylinux2014_x86_64' 'manylinux2014_i686' 'manylinux2014_aarch64' 'manylinux2014_armv7l' 'manylinux2014_ppc64' 'manylinux2014_ppc64le' 'manylinux2014_s390x' 'win32' 'win_amd64' 'win_ia64'
+          do
+            python setup.py bdist_wheel --plat-name $platform
+          done
+      - uses: actions/upload-artifact@v2
+        with:
+          name: python-package-distributions
+          path: ./dist/*.whl
+
+  source-distribution:
+    needs: tests
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Python
+        uses: actions/setup-python@v2
+      - name: Build source distribution
+        run: python setup.py sdist
+      - name: Store the source distribution
+        uses: actions/upload-artifact@v2
+        with:
+          name: python-package-distributions
+          path: dist
+          retention-days: 4
+
+  publish:
+    needs:
+      - macos-built-distributions
+      - pure-built-distributions
+      - source-distribution
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v2
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: What will we publish?
+      run: ls dist
+    - name: Publish
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        skip_existing: true

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py{310,39,38,37,36,35,py3}
 skip_missing_interpreters = True
 
 [testenv]
+usedevelop = true
 deps =
     -r requirements-tests.txt
 commands =


### PR DESCRIPTION
This is configured to use a PyPI API token instead of a username/password. An API token can be minted at https://pypi.org/manage/account/ and should be set as `PYPI_API_TOKEN` in the GitHub UI at https://github.com/gorakhargosh/watchdog/settings/secrets/actions.

Once the secret is set and this PR is merged, the workflow will be available at https://github.com/gorakhargosh/watchdog/actions?query=workflow%3A%22Test%2C+Build+%26+Publish%22 and can be triggered via "Run workflow".

Fixes #428.
