### PR TITLE
Release from any branch

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -32,18 +32,18 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python: [3.6, 3.7, 3.8, 3.9]
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        ref: ${{ github.event.inputs.branch }}
-    - name: Use Python ${{ matrix.python }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python }}
-    - name: Install test dependencies
-      run: python -m pip install tox
-    - name: Test
-      run: python -m tox -e py
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.branch }}
+      - name: Use Python ${{ matrix.python }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install test dependencies
+        run: python -m pip install tox
+      - name: Test
+        run: python -m tox -e py
 
   macos-built-distributions:
     name: Build macOS wheels
@@ -118,16 +118,16 @@ jobs:
       - source-distribution
     runs-on: ubuntu-latest
     steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v2
-      with:
-        name: python-package-distributions
-        path: dist/
-    - name: What will we publish?
-      run: ls dist
-    - name: Publish
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
-        skip_existing: true
+      - name: Download all the dists
+        uses: actions/download-artifact@v2
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: What will we publish?
+        run: ls dist
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          skip_existing: true

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.inputs.branch }}
     - name: Use Python ${{ matrix.python }}
       uses: actions/setup-python@v2
       with:
@@ -50,6 +52,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.branch }}
       - name: Install Python
         uses: actions/setup-python@v2
       - name: Install build dependencies
@@ -70,6 +74,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.branch }}
       - name: Install Python
         uses: actions/setup-python@v2
       - name: Install build dependencies
@@ -92,6 +98,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.branch }}
       - name: Install Python
         uses: actions/setup-python@v2
       - name: Build source distribution

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -19,7 +19,7 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Branch to base the release from'
+        description: 'The branch, tag or SHA to release from'
         required: true
         default: 'master'
 


### PR DESCRIPTION
Fixes #741.

This updates #739 to actually use the input for the manual trigger to determine which branch to release from.

This would make it possible to back-publish wheels for 1.0.1 by running the workflow on 0f9acb736d857914c5da82d06ccbf7d2523e55c5 as the ref.