### PR TITLE
Avoid deprecation warning on CPython 3.9

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -8,7 +8,8 @@ Changelog
 
 202x-xx-xx • `full history <https://github.com/gorakhargosh/watchdog/compare/v1.0.2...master>`__
 
-- Thanks to our beloved contributors:
+- Avoid deprecated ``PyEval_InitThreads`` on Python 3.7+ (`#746 <https://github.com/gorakhargosh/watchdog/pull/746>`_)
+- Thanks to our beloved contributors: @bstaletic
 
 
 1.0.2

--- a/src/watchdog_fsevents.c
+++ b/src/watchdog_fsevents.c
@@ -611,7 +611,11 @@ watchdog_read_events(PyObject *self, PyObject *args)
 
     G_RETURN_NULL_IF_NOT(PyArg_ParseTuple(args, "O:loop", &emitter_thread));
 
+// PyEval_InitThreads() does nothing as of Python 3.7 and is deprecated in 3.9.
+// https://docs.python.org/3/c-api/init.html#c.PyEval_InitThreads
+#if PY_VERSION_HEX < 0x030700f0
     PyEval_InitThreads();
+#endif
 
     /* Allocate information and store thread state. */
     value = PyDict_GetItem(thread_to_run_loop, emitter_thread);


### PR DESCRIPTION
According to [the docs](https://docs.python.org/3/c-api/init.html#c.PyEval_InitThreads), we should just skip this call.