### PR TITLE
Added event_time attr to the FileSystemEvent for more accurate timing…

### DIFF
--- a/src/watchdog/events.py
+++ b/src/watchdog/events.py
@@ -94,6 +94,9 @@ import logging
 import re
 from watchdog.utils.patterns import match_any_paths
 
+from datetime import datetime
+# System time as in iso format.
+iso_time = lambda: datetime.isoformat(datetime.now())
 
 EVENT_TYPE_MOVED = 'moved'
 EVENT_TYPE_DELETED = 'deleted'
@@ -127,6 +130,14 @@ class FileSystemEvent:
 
     def __init__(self, src_path):
         self._src_path = src_path
+        self._event_time = iso_time() # Time when the object was created
+
+    @property
+    def event_time(self):
+        """ The time FileSystemEvent object was created, rather than 
+        the time FileSystemEventHandler is run. Which is always 
+        different due to blocking."""
+        return self._event_time  #> ie 2021-01-19T12:34:44.772505
 
     @property
     def src_path(self):
@@ -139,17 +150,19 @@ class FileSystemEvent:
     def __repr__(self):
         return ("<%(class_name)s: event_type=%(event_type)s, "
                 "src_path=%(src_path)r, "
-                "is_directory=%(is_directory)s>"
+                "is_directory=%(is_directory)s, "
+                "event_time=%(event_time)s> "
                 ) % (dict(
                      class_name=self.__class__.__name__,
                      event_type=self.event_type,
                      src_path=self.src_path,
-                     is_directory=self.is_directory))
+                     is_directory=self.is_directory,
+                     event_time=self.event_time))
 
     # Used for comparison of events.
     @property
     def key(self):
-        return (self.event_type, self.src_path, self.is_directory)
+        return (self.event_type, self.src_path, self.is_directory, self.event_time)
 
     def __eq__(self, event):
         return self.key == event.key


### PR DESCRIPTION
Due to blocking their is a delay between when FileSystemEvent obj is created and when the FileSystemEventHandler processed the event. Is means you could only collect the time the event was handled, rather than the time it the event was created.

Events are processed one by one so any blocking on the FileSystemEventHandler affects the time.

So I added 'event_time' property to FileSystemEvent base class to accurately log the time the event was created.

>>> print(event)
<FileModifiedEvent: event_type=modified, src_path='./watch2.py', is_directory=False, event_time=2021-01-19T12:51:29.821598>