### PR TITLE
Improve handling of rename events on macOS

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -11,6 +11,8 @@ Changelog
 - Avoid deprecated ``PyEval_InitThreads`` on Python 3.7+ (`#746 <https://github.com/gorakhargosh/watchdog/pull/746>`_)
 - [inotify] Add support for ``IN_CLOSE_WRITE`` events. A ``FileCloseEvent`` event will be fired. Note that ``IN_CLOSE_NOWRITE`` events are not handled to prevent much noise. (`#184 <https://github.com/gorakhargosh/watchdog/pull/184>`_, `#245 <https://github.com/gorakhargosh/watchdog/pull/245>`_, `#280 <https://github.com/gorakhargosh/watchdog/pull/280>`_, `#313 <https://github.com/gorakhargosh/watchdog/pull/313>`_, `#690 <https://github.com/gorakhargosh/watchdog/pull/690>`_)
 - [mac] Support coalesced filesystem events (`#734 <https://github.com/gorakhargosh/watchdog/pull/734>`_)
+- [mac] Drop support for OSX 10.12 and earlier (`#750 <https://github.com/gorakhargosh/watchdog/pull/750>`_)
+- [mac] Fix an issue when renaming an item changes only the casing (`#750 <https://github.com/gorakhargosh/watchdog/pull/750>`_)
 - Thanks to our beloved contributors: @bstaletic, @lukassup, @ysard, @SamSchott, @CCP-Aporia
 
 

--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -119,10 +119,7 @@ class FSEventsEmitter(EventEmitter):
 
             if event.is_created:
                 cls = DirCreatedEvent if event.is_directory else FileCreatedEvent
-                if not event.is_coalesced or (
-                    event.is_coalesced and not event.is_renamed and not event.is_modified and not
-                    event.is_inode_meta_mod and not event.is_xattr_mod
-                ):
+                if os.path.exists(event.path):
                     self.queue_event(cls(src_path))
                     self.queue_event(DirModifiedEvent(os.path.dirname(src_path)))
 
@@ -138,7 +135,7 @@ class FSEventsEmitter(EventEmitter):
 
             if event.is_removed:
                 cls = DirDeletedEvent if event.is_directory else FileDeletedEvent
-                if not event.is_coalesced or (event.is_coalesced and not os.path.exists(event.path)):
+                if not os.path.exists(event.path):
                     self.queue_event(cls(src_path))
                     self.queue_event(DirModifiedEvent(os.path.dirname(src_path)))
 

--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -119,7 +119,10 @@ class FSEventsEmitter(EventEmitter):
 
             if event.is_created:
                 cls = DirCreatedEvent if event.is_directory else FileCreatedEvent
-                if os.path.exists(event.path):
+                if not event.is_coalesced or (
+                    event.is_coalesced and not event.is_renamed and not event.is_modified and not
+                    event.is_inode_meta_mod and not event.is_xattr_mod
+                ):
                     self.queue_event(cls(src_path))
                     self.queue_event(DirModifiedEvent(os.path.dirname(src_path)))
 
@@ -135,7 +138,7 @@ class FSEventsEmitter(EventEmitter):
 
             if event.is_removed:
                 cls = DirDeletedEvent if event.is_directory else FileDeletedEvent
-                if not os.path.exists(event.path):
+                if not event.is_coalesced or (event.is_coalesced and not os.path.exists(event.path)):
                     self.queue_event(cls(src_path))
                     self.queue_event(DirModifiedEvent(os.path.dirname(src_path)))
 

--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -156,7 +156,6 @@ class FSEventsEmitter(EventEmitter):
                 logger.info("Stopping because root path was changed")
                 self.stop()
 
-
     def run(self):
         try:
             def callback(paths, inodes, flags, ids, emitter=self):

--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -87,7 +87,8 @@ class FSEventsEmitter(EventEmitter):
 
         while events:
             event = events.pop(0)
-            logger.info(event)
+            flags = ", ".join(attr for attr in dir(event) if getattr(event, attr) is True)
+            logger.info(f"{event}: {flags}")
             src_path = self._encode_path(event.path)
 
             if event.is_renamed:

--- a/src/watchdog_fsevents.c
+++ b/src/watchdog_fsevents.c
@@ -28,29 +28,9 @@
 
 
 /* Compatibility; since fsevents won't set these on earlier macOS versions the properties will always be False */
-#if MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_7
-#error Watchdog module requires at least Mac OS X 10.7
-#endif
-#ifndef MAC_OS_X_VERSION_10_9
-#define MAC_OS_X_VERSION_10_9         1090
-#endif
-#ifndef MAC_OS_X_VERSION_10_10
-#define MAC_OS_X_VERSION_10_10      101000
-#endif
-#ifndef MAC_OS_X_VERSION_10_13
-#define MAC_OS_X_VERSION_10_13      101300
-#endif
-#if MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_9
-#define kFSEventStreamEventFlagOwnEvent 0x00080000
-#endif
-#if MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_10
-#define kFSEventStreamEventFlagItemIsHardlink 0x00100000
-#define kFSEventStreamEventFlagItemIsLastHardlink 0x00200000
-#endif
 #if MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_13
-#define kFSEventStreamEventFlagItemCloned 0x00400000
+#error Watchdog module requires at least Mac OS X 10.13
 #endif
-
 
 /* Convenience macros to make code more readable. */
 #define G_NOT(o)                        !o

--- a/src/watchdog_fsevents.c
+++ b/src/watchdog_fsevents.c
@@ -193,11 +193,19 @@ static int NativeEventInit(NativeEventObject *self, PyObject *args, PyObject *kw
 {
     static char *kwlist[] = {"path", "inode", "flags", "id", NULL};
 
+    self->inode = NULL;
+
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "|sOIL", kwlist, &self->path, &self->inode, &self->flags, &self->id)) {
         return -1;
     }
 
+    Py_INCREF(self->inode);
+
     return 0;
+}
+
+static void NativeEventDealloc(NativeEventObject *self) {
+    Py_XDECREF(self->inode);
 }
 
 static PyGetSetDef NativeEventProperties[] = {
@@ -244,6 +252,7 @@ static PyTypeObject NativeEventType = {
     .tp_getset = NativeEventProperties,
     .tp_init = (initproc) NativeEventInit,
     .tp_repr = (reprfunc) NativeEventRepr,
+    .tp_dealloc = (destructor) NativeEventDealloc,
 };
 
 

--- a/src/watchdog_fsevents.c
+++ b/src/watchdog_fsevents.c
@@ -298,8 +298,6 @@ PyObject * CFString_AsPyUnicode(CFStringRef cf_string_ref)
         py_string = PyUnicode_FromString(c_string_ptr);
     }
 
-    Py_INCREF(py_string);
-
     return py_string;
 
 }
@@ -320,7 +318,6 @@ PyObject * CFNumberRef_AsPyLong(CFNumberRef cf_number)
     CFNumberGetValue(cf_number, kCFNumberSInt64Type, &c_int);
 
     py_long = PyLong_FromLong(c_int);
-    Py_INCREF(py_long);
 
     return py_long;
 }

--- a/src/watchdog_fsevents.c
+++ b/src/watchdog_fsevents.c
@@ -29,7 +29,7 @@
 
 /* Compatibility; since fsevents won't set these on earlier macOS versions the properties will always be False */
 #if MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_13
-#error Watchdog module requires at least Mac OS X 10.13
+#error Watchdog module requires at least macOS 10.13
 #endif
 
 /* Convenience macros to make code more readable. */

--- a/src/watchdog_fsevents.c
+++ b/src/watchdog_fsevents.c
@@ -89,7 +89,7 @@ typedef struct {
 typedef struct {
     PyObject_HEAD
     const char *path;
-    long inode;
+    PyObject *inode;
     FSEventStreamEventFlags flags;
     FSEventStreamEventId id;
 } NativeEventObject;
@@ -98,7 +98,7 @@ PyObject* NativeEventRepr(PyObject* instance) {
     NativeEventObject *self = (NativeEventObject*)instance;
 
     return PyUnicode_FromFormat(
-        "NativeEvent(path=\"%s\", inode=%llu, flags=%x, id=%llu)",
+        "NativeEvent(path=\"%s\", inode=%S, flags=%x, id=%llu)",
         self->path,
         self->inode,
         self->flags,
@@ -193,7 +193,7 @@ static int NativeEventInit(NativeEventObject *self, PyObject *args, PyObject *kw
 {
     static char *kwlist[] = {"path", "inode", "flags", "id", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|sLIL", kwlist, &self->path, &self->inode, &self->flags, &self->id)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|sOIL", kwlist, &self->path, &self->inode, &self->flags, &self->id)) {
         return -1;
     }
 

--- a/src/watchdog_fsevents.c
+++ b/src/watchdog_fsevents.c
@@ -725,6 +725,25 @@ watchdog_read_events(PyObject *self, PyObject *args)
     return Py_None;
 }
 
+PyDoc_STRVAR(watchdog_flush_events__doc__,
+        MODULE_NAME ".flush_events(watch) -> None\n\
+Flushes events for the watch.\n\n\
+:param watch:\n\
+    The watch to flush.\n");
+static PyObject *
+watchdog_flush_events(PyObject *self, PyObject *watch)
+{
+    UNUSED(self);
+    PyObject *value = PyDict_GetItem(watch_to_stream, watch);
+
+    FSEventStreamRef stream_ref = PyCapsule_GetPointer(value, NULL);
+
+    FSEventStreamFlushSync(stream_ref);
+
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
 PyDoc_STRVAR(watchdog_remove_watch__doc__,
         MODULE_NAME ".remove_watch(watch) -> None\n\
 Removes a watch from the event loop.\n\n\
@@ -787,6 +806,7 @@ static PyMethodDef watchdog_fsevents_methods[] =
 {
     {"add_watch",    watchdog_add_watch,    METH_VARARGS, watchdog_add_watch__doc__},
     {"read_events",  watchdog_read_events,  METH_VARARGS, watchdog_read_events__doc__},
+    {"flush_events", watchdog_flush_events, METH_O,       watchdog_flush_events__doc__},
     {"remove_watch", watchdog_remove_watch, METH_O,       watchdog_remove_watch__doc__},
 
     /* Aliases for compatibility with macfsevents. */

--- a/src/watchdog_fsevents.c
+++ b/src/watchdog_fsevents.c
@@ -124,7 +124,8 @@ PyObject* NativeEventTypeInode(PyObject* instance, void* closure)
 {
     UNUSED(closure);
     NativeEventObject *self = (NativeEventObject*)instance;
-    return PyLong_FromLong(self->inode);
+    Py_INCREF(self->inode);
+    return self->inode;
 }
 
 PyObject* NativeEventTypeID(PyObject* instance, void* closure)

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -56,6 +56,12 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 
+if platform.is_darwin():
+    # enable more verbose logs
+    fsevents_logger = logging.getLogger("fsevents")
+    fsevents_logger.setLevel(logging.INFO)
+
+
 @pytest.fixture(autouse=True)
 def setup_teardown(tmpdir):
     global p, emitter, event_queue

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -257,6 +257,35 @@ def test_move():
 
 
 @pytest.mark.flaky(max_runs=5, min_passes=1, rerun_filter=rerun_filter)
+def test_case_change():
+    mkdir(p('dir1'))
+    mkdir(p('dir2'))
+    touch(p('dir1', 'file'))
+    start_watching()
+
+    mv(p('dir1', 'file'), p('dir2', 'FILE'))
+
+    if not platform.is_windows():
+        expect_event(FileMovedEvent(p('dir1', 'file'), p('dir2', 'FILE')))
+    else:
+        event = event_queue.get(timeout=5)[0]
+        assert event.src_path == p('dir1', 'file')
+        assert isinstance(event, FileDeletedEvent)
+        event = event_queue.get(timeout=5)[0]
+        assert event.src_path == p('dir2', 'FILE')
+        assert isinstance(event, FileCreatedEvent)
+
+    event = event_queue.get(timeout=5)[0]
+    assert event.src_path in [p('dir1'), p('dir2')]
+    assert isinstance(event, DirModifiedEvent)
+
+    if not platform.is_windows():
+        event = event_queue.get(timeout=5)[0]
+        assert event.src_path in [p('dir1'), p('dir2')]
+        assert isinstance(event, DirModifiedEvent)
+
+
+@pytest.mark.flaky(max_runs=5, min_passes=1, rerun_filter=rerun_filter)
 def test_move_to():
     mkdir(p('dir1'))
     mkdir(p('dir2'))

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -59,7 +59,7 @@ logger = logging.getLogger(__name__)
 if platform.is_darwin():
     # enable more verbose logs
     fsevents_logger = logging.getLogger("fsevents")
-    fsevents_logger.setLevel(logging.INFO)
+    fsevents_logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_fsevents.py
+++ b/tests/test_fsevents.py
@@ -63,17 +63,17 @@ def observer():
 
 @pytest.mark.parametrize('event,expectation', [
     # invalid flags
-    (_fsevents.NativeEvent('', 0, 0), False),
+    (_fsevents.NativeEvent('', 0, 0, 0), False),
     # renamed
-    (_fsevents.NativeEvent('', 0x00000800, 0), False),
+    (_fsevents.NativeEvent('', 0, 0x00000800, 0), False),
     # renamed, removed
-    (_fsevents.NativeEvent('', 0x00000800 | 0x00000200, 0), True),
+    (_fsevents.NativeEvent('', 0, 0x00000800 | 0x00000200, 0), True),
     # renamed, removed, created
-    (_fsevents.NativeEvent('', 0x00000800 | 0x00000200 | 0x00000100, 0), True),
+    (_fsevents.NativeEvent('', 0, 0x00000800 | 0x00000200 | 0x00000100, 0), True),
     # renamed, removed, created, itemfindermod
-    (_fsevents.NativeEvent('', 0x00000800 | 0x00000200 | 0x00000100 | 0x00002000, 0), True),
+    (_fsevents.NativeEvent('', 0, 0x00000800 | 0x00000200 | 0x00000100 | 0x00002000, 0), True),
     # xattr, removed, modified, itemfindermod
-    (_fsevents.NativeEvent('', 0x00008000 | 0x00000200 | 0x00001000 | 0x00002000, 0), False),
+    (_fsevents.NativeEvent('', 0, 0x00008000 | 0x00000200 | 0x00001000 | 0x00002000, 0), False),
 ])
 def test_coalesced_event_check(event, expectation):
     assert event.is_coalesced == expectation

--- a/tests/test_observers_api.py
+++ b/tests/test_observers_api.py
@@ -85,6 +85,7 @@ def test_event_dispatcher():
     event_dispatcher.start()
     time.sleep(1)
     event_dispatcher.stop()
+    event_dispatcher.join()
 
 
 def test_observer_basic():


### PR DESCRIPTION
At the moment, the two native events which are emitted when an item is renamed are paired to a single `MovedEvent` by relying on an undocumented behaviour of the File System Events API: two such events will have event IDs which differ only by 1. This may stop working without notice and fails to cover two corner-cases:

1. When an item is renamed by changing only the casing of the name, the native events appear to have IDs differing by 2.
2. When a renamed event is coalesced with another event, its event ID may differ from the observed but undocumented behaviour.

This PR matches native event pairs by inode instead. This is achieved by actively recording not only the path but also the inode for all events in the extension module. Such extended information is provided when creating the FSEventsStream with the `kFSEventStreamCreateFlagUseExtendedData` and `kFSEventStreamCreateFlagUseCFTypes` flags. This requires dealing CFTypes instead of ctypes in the extension module.

Other changes in this PR:

* Expose a method to flush the FSEventsStream.
* Simplify the handling of coalesced events in the Python code. This seems to result in more consistent behaviour in case of coalescing.
