### PR TITLE
Refactor handling of coalesced events

### DIFF
--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -137,10 +137,16 @@ class FSEventsEmitter(EventEmitter):
             # keeping track of paths since those are more likely to be reused than
             # inodes.
 
+            # Likewise, some events will have a spurious `is_modified`,
+            # `is_inode_meta_mod` or `is_xattr_mod` flag set. We currently do not
+            # suppress those but could do so if the item still exists by caching the
+            # stat result and verifying that it did change.
+
             if event.is_created and event.is_removed:
 
                 # Events will only be coalesced for the same item / inode.
                 # The sequence deleted -> created therefore cannot occur.
+                # Any combination with renamed cannot occur either.
 
                 if event.inode not in self._fs_view:
                     self._queue_created_event(event, src_path, src_dirname)

--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -289,7 +289,13 @@ class FSEventsEmitter(EventEmitter):
 
     def on_thread_start(self):
         if self.suppress_history:
-            self._starting_state = DirectorySnapshot(self.watch.path)
+
+            if isinstance(self.watch.path, bytes):
+                watch_path = os.fsdecode(self.watch.path)
+            else:
+                watch_path = self.watch.path
+
+            self._starting_state = DirectorySnapshot(watch_path)
 
     def _encode_path(self, path):
         """Encode path only if bytes were passed to this emitter. """

--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -129,8 +129,6 @@ class FSEventsEmitter(EventEmitter):
                 before_start = old_inode == event.inode
             except KeyError:
                 before_start = False
-
-            logger.debug(self._starting_state)
         else:
             before_start = False
 

--- a/src/watchdog/observers/inotify_c.py
+++ b/src/watchdog/observers/inotify_c.py
@@ -313,6 +313,8 @@ class Inotify:
             except OSError as e:
                 if e.errno == errno.EINTR:
                     continue
+                else:
+                    raise
             break
 
         with self._lock:

--- a/src/watchdog_fsevents.c
+++ b/src/watchdog_fsevents.c
@@ -579,7 +579,11 @@ watchdog_FSEventStreamCreate(StreamCallbackInfo *stream_callback_info_ref,
                                      paths,
                                      kFSEventStreamEventIdSinceNow,
                                      stream_latency,
-                                     kFSEventStreamCreateFlagNoDefer | kFSEventStreamCreateFlagFileEvents | kFSEventStreamCreateFlagWatchRoot | kFSEventStreamCreateFlagUseExtendedData | kFSEventStreamCreateFlagUseCFTypes);
+                                     kFSEventStreamCreateFlagNoDefer
+                                     | kFSEventStreamCreateFlagFileEvents
+                                     | kFSEventStreamCreateFlagWatchRoot
+                                     | kFSEventStreamCreateFlagUseExtendedData
+                                     | kFSEventStreamCreateFlagUseCFTypes);
     CFRelease(paths);
     return stream_ref;
 }

--- a/tests/shell.py
+++ b/tests/shell.py
@@ -49,6 +49,12 @@ def pwd():
     return path
 
 
+def mkfile(path):
+    """Creates a file"""
+    with open(path, 'ab'):
+        pass
+
+
 def mkdir(path, parents=False):
     """Creates a directory (optionally also creates all the parent directories
   in the path)."""

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -387,7 +387,6 @@ def test_delete_self():
 
 @pytest.mark.skipif(platform.is_windows() or platform.is_bsd(),
                     reason="Windows|BSD create another set of events for this test")
-@pytest.mark.skipif(platform.is_darwin(), reason="FSEvents coalesced events make it impossible to assert this way")
 def test_fast_subdirectory_creation_deletion():
     root_dir = p('dir1')
     sub_dir = p('dir1', 'subdir1')

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -621,6 +621,11 @@ def test_file_lifecyle():
         expect_event(DirModifiedEvent(p()))
 
     expect_event(FileModifiedEvent(p('a')))
+
+    if platform.is_linux():
+        expect_event(FileClosedEvent(p('a')))
+        expect_event(DirModifiedEvent(p()))
+
     expect_event(FileMovedEvent(p('a'), p('b')))
 
     if not platform.is_windows():

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -217,13 +217,6 @@ def test_modify():
 
     touch(p('a'))
 
-    # Because the tests run so fast then on macOS it is almost certain that
-    # we receive a coalesced event from fseventsd here, which triggers an
-    # additional file created event and dir modified event here.
-    if platform.is_darwin():
-        expect_event(FileCreatedEvent(p('a')))
-        expect_event(DirModifiedEvent(p()))
-
     expect_event(FileModifiedEvent(p('a')))
 
     if platform.is_linux():

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -21,7 +21,7 @@ import logging
 from functools import partial
 from queue import Queue, Empty
 
-from .shell import mkdir, touch, mv, rm
+from .shell import mkfile, mkdir, touch, mv, rm
 from watchdog.utils import platform
 from watchdog.events import (
     FileDeletedEvent,
@@ -98,11 +98,10 @@ def start_watching(path=None, use_full_emitter=False, recursive=True):
         # As such, let's create a sentinel event that tells us that we are
         # good to go.
         sentinel_file = os.path.join(path, '.sentinel' if isinstance(path, str) else '.sentinel'.encode())
-        touch(sentinel_file)
+        mkfile(sentinel_file)
         sentinel_events = [
             FileCreatedEvent(sentinel_file),
             DirModifiedEvent(path),
-            FileModifiedEvent(sentinel_file)
         ]
         next_sentinel_event = sentinel_events.pop(0)
         now = time.monotonic()
@@ -199,9 +198,9 @@ def test_create_wrong_encoding():
 
 @pytest.mark.flaky(max_runs=5, min_passes=1, rerun_filter=rerun_filter)
 def test_delete():
-    touch(p('a'))
-    start_watching()
+    mkfile(p('a'))
 
+    start_watching()
     rm(p('a'))
 
     expect_event(FileDeletedEvent(p('a')))
@@ -212,7 +211,7 @@ def test_delete():
 
 @pytest.mark.flaky(max_runs=5, min_passes=1, rerun_filter=rerun_filter)
 def test_modify():
-    touch(p('a'))
+    mkfile(p('a'))
     start_watching()
 
     touch(p('a'))
@@ -229,7 +228,7 @@ def test_modify():
 def test_move():
     mkdir(p('dir1'))
     mkdir(p('dir2'))
-    touch(p('dir1', 'a'))
+    mkfile(p('dir1', 'a'))
     start_watching()
 
     mv(p('dir1', 'a'), p('dir2', 'b'))
@@ -258,7 +257,7 @@ def test_move():
 def test_case_change():
     mkdir(p('dir1'))
     mkdir(p('dir2'))
-    touch(p('dir1', 'file'))
+    mkfile(p('dir1', 'file'))
     start_watching()
 
     mv(p('dir1', 'file'), p('dir2', 'FILE'))
@@ -287,7 +286,7 @@ def test_case_change():
 def test_move_to():
     mkdir(p('dir1'))
     mkdir(p('dir2'))
-    touch(p('dir1', 'a'))
+    mkfile(p('dir1', 'a'))
     start_watching(p('dir2'))
 
     mv(p('dir1', 'a'), p('dir2', 'b'))
@@ -302,7 +301,7 @@ def test_move_to():
 def test_move_to_full():
     mkdir(p('dir1'))
     mkdir(p('dir2'))
-    touch(p('dir1', 'a'))
+    mkfile(p('dir1', 'a'))
     start_watching(p('dir2'), use_full_emitter=True)
     mv(p('dir1', 'a'), p('dir2', 'b'))
 
@@ -316,7 +315,7 @@ def test_move_to_full():
 def test_move_from():
     mkdir(p('dir1'))
     mkdir(p('dir2'))
-    touch(p('dir1', 'a'))
+    mkfile(p('dir1', 'a'))
     start_watching(p('dir1'))
 
     mv(p('dir1', 'a'), p('dir2', 'b'))
@@ -331,7 +330,7 @@ def test_move_from():
 def test_move_from_full():
     mkdir(p('dir1'))
     mkdir(p('dir2'))
-    touch(p('dir1', 'a'))
+    mkfile(p('dir1', 'a'))
     start_watching(p('dir1'), use_full_emitter=True)
     mv(p('dir1', 'a'), p('dir2', 'b'))
 
@@ -344,8 +343,8 @@ def test_move_from_full():
 @pytest.mark.flaky(max_runs=5, min_passes=1, rerun_filter=rerun_filter)
 def test_separate_consecutive_moves():
     mkdir(p('dir1'))
-    touch(p('dir1', 'a'))
-    touch(p('b'))
+    mkfile(p('dir1', 'a'))
+    mkfile(p('b'))
     start_watching(p('dir1'))
     mv(p('dir1', 'a'), p('c'))
     mv(p('b'), p('dir1', 'd'))
@@ -411,7 +410,7 @@ def test_fast_subdirectory_creation_deletion():
 @pytest.mark.flaky(max_runs=5, min_passes=1, rerun_filter=rerun_filter)
 def test_passing_unicode_should_give_unicode():
     start_watching(str(p()))
-    touch(p('a'))
+    mkfile(p('a'))
     event = event_queue.get(timeout=5)[0]
     assert isinstance(event.src_path, str)
 
@@ -421,7 +420,7 @@ def test_passing_unicode_should_give_unicode():
                            " unicode for paths.")
 def test_passing_bytes_should_give_bytes():
     start_watching(p().encode())
-    touch(p('a'))
+    mkfile(p('a'))
     event = event_queue.get(timeout=5)[0]
     assert isinstance(event.src_path, bytes)
 
@@ -558,7 +557,7 @@ def test_renaming_top_level_directory_on_windows():
                     reason="Windows create another set of events for this test")
 def test_move_nested_subdirectories():
     mkdir(p('dir1/dir2/dir3'), parents=True)
-    touch(p('dir1/dir2/dir3', 'a'))
+    mkfile(p('dir1/dir2/dir3', 'a'))
     start_watching()
     mv(p('dir1/dir2'), p('dir2'))
 
@@ -590,7 +589,7 @@ def test_move_nested_subdirectories():
                     reason="Non-Windows create another set of events for this test")
 def test_move_nested_subdirectories_on_windows():
     mkdir(p('dir1/dir2/dir3'), parents=True)
-    touch(p('dir1/dir2/dir3', 'a'))
+    mkfile(p('dir1/dir2/dir3', 'a'))
     start_watching(p(''))
     mv(p('dir1/dir2'), p('dir2'))
 

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -106,7 +106,7 @@ def start_watching(path=None, use_full_emitter=False, recursive=True):
         ]
         next_sentinel_event = sentinel_events.pop(0)
         now = time.monotonic()
-        while time.monotonic() <= now + 30.0:
+        while time.monotonic() <= now + 2:
             try:
                 event = event_queue.get(timeout=0.5)[0]
                 if event == next_sentinel_event:
@@ -128,11 +128,10 @@ def rerun_filter(exc, *args):
     return False
 
 
-def expect_event(expected_event, timeout=30.0):
+def expect_event(expected_event, timeout=2):
     """ Utility function to wait up to `timeout` seconds for an `event_type` for `path` to show up in the queue.
 
     Provides some robustness for the otherwise flaky nature of asynchronous notifications.
-    NB: specifying a timeout of less than 30 seconds doesn't play nicely on macOS
     """
     try:
         event = event_queue.get(timeout=timeout)[0]

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -388,6 +388,7 @@ def test_fast_subdirectory_creation_deletion():
     for _ in range(times):
         mkdir(sub_dir)
         rm(sub_dir, True)
+        time.sleep(0.01)  # required for macOS emitter to catch up with us
     count = {DirCreatedEvent: 0,
              DirModifiedEvent: 0,
              DirDeletedEvent: 0}

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -618,6 +618,7 @@ def test_file_lifecyle():
 
     if platform.is_linux():
         expect_event(FileClosedEvent(p('a')))
+        expect_event(DirModifiedEvent(p()))
 
     expect_event(FileModifiedEvent(p('a')))
     expect_event(FileMovedEvent(p('a'), p('b')))


### PR DESCRIPTION
This PR aims to clean up and handle more corner cases when dealing with coalesced events. The major changes are:

1. Now that we record the inode in addition to the path, it has becomes clear that file system events for different inodes are never coalesced. This means that sequences such as `deleted -> created` are never combined in a single event because the new file (likely) has a different inode. The code logic has been updated to exploit this. See the extensive inline comments.

1. Handling of coalesced events for renames was broken:
    * Additional flags for the destination event where not processed. This processing has been added.
    * Selected additional flags (modified flags) for the source event would be processed but queued *after* the rename. Cases like `created -> renamed` would just emit a renamed event. This has been fixed by processing `renamed` flags after `created` and `modified` flags.

2. Duplicate created events could be emitted and required special accommodation in the tests. This has been fixed by reintroducing the cache of past events (`_fs_view`) but keeping the inode instead of the path. This makes false positives in the cache unlikely.

3. A significant problem in the tests, despite the use of a sentinel event, was leftover flags from previous events. For instance, creating a file at `/path/a` before starting the watch could result in a coalesced `is_created` flag for subsequent events for the same file, even after the sentinel event was registered. We can filter this if we recorded the original created event and stored its inode in `_fs_view`. If we did not record this events, a spurious created event is emitted. This has been "fixed" by taking a directory snapshot before starting the watch. This snapshot is optional (`suppress_history` kwarg) and is deleted after 60 sec to free memory.

4. As a result of the above, we no longer need the sentinel event logic for the tests. This also enables other users to write test without creating their own workarounds, by setting `suppress_history = True`.

One issue which is not addressed by this PR: spurious `is_modified` or `is_inode_meta_mod` flags are not filtered. This would be possible by not only caching indoes but also stat results in `_fs_view` and verifying if the item was modified by confirming that the stat info indeed changed. This will however not work if the item no longer exists when we do the stat call.

A minor change to the test: Instead of creating all new files with `touch`, they are now created with `mkfile` to prevent spurious `is_inode_meta_mod` flags.
