### PR TITLE
Catch OSError when stopping inotify emitter multiple times

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -10,6 +10,7 @@ Changelog
 
 - Avoid deprecated ``PyEval_InitThreads`` on Python 3.7+ (`#746 <https://github.com/gorakhargosh/watchdog/pull/746>`_)
 - [inotify] Add support for ``IN_CLOSE_WRITE`` events. A ``FileCloseEvent`` event will be fired. Note that ``IN_CLOSE_NOWRITE`` events are not handled to prevent much noise. (`#184 <https://github.com/gorakhargosh/watchdog/pull/184>`_, `#245 <https://github.com/gorakhargosh/watchdog/pull/245>`_, `#280 <https://github.com/gorakhargosh/watchdog/pull/280>`_, `#313 <https://github.com/gorakhargosh/watchdog/pull/313>`_, `#690 <https://github.com/gorakhargosh/watchdog/pull/690>`_)
+- [inotify] Allow to stop the emitter multiple times (`#760 <https://github.com/gorakhargosh/watchdog/pull/760>`_)
 - [mac] Support coalesced filesystem events (`#734 <https://github.com/gorakhargosh/watchdog/pull/734>`_)
 - [mac] Drop support for OSX 10.12 and earlier (`#750 <https://github.com/gorakhargosh/watchdog/pull/750>`_)
 - [mac] Fix an issue when renaming an item changes only the casing (`#750 <https://github.com/gorakhargosh/watchdog/pull/750>`_)

--- a/src/watchdog/observers/inotify.py
+++ b/src/watchdog/observers/inotify.py
@@ -180,7 +180,8 @@ class InotifyEmitter(EventEmitter):
             #     cls = FileClosedEvent
             #     self.queue_event(cls(src_path))
             elif event.is_delete_self and src_path == self.watch.path:
-                self.queue_event(DirDeletedEvent(src_path))
+                cls = DirDeletedEvent if event.is_directory else FileDeletedEvent
+                self.queue_event(cls(src_path))
                 self.stop()
 
     def _decode_path(self, path):

--- a/src/watchdog/observers/inotify.py
+++ b/src/watchdog/observers/inotify.py
@@ -120,6 +120,7 @@ class InotifyEmitter(EventEmitter):
     def on_thread_stop(self):
         if self._inotify:
             self._inotify.close()
+            self._inotify = None
 
     def queue_events(self, timeout, full_events=False):
         # If "full_events" is true, then the method will report unmatched move events as separate events

--- a/src/watchdog/observers/inotify_c.py
+++ b/src/watchdog/observers/inotify_c.py
@@ -275,7 +275,12 @@ class Inotify:
             if self._path in self._wd_for_path:
                 wd = self._wd_for_path[self._path]
                 inotify_rm_watch(self._inotify_fd, wd)
-            os.close(self._inotify_fd)
+
+            try:
+                os.close(self._inotify_fd)
+            except OSError:
+                # descriptor may be invalid because file was deleted
+                pass
 
     def read_events(self, event_buffer_size=DEFAULT_EVENT_BUFFER_SIZE):
         """

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -70,11 +70,7 @@ def setup_teardown(tmpdir):
 
     yield
 
-    try:
-        emitter.stop()
-    except OSError:
-        # watch was already stopped, e.g., in `test_delete_self`
-        pass
+    emitter.stop()
     emitter.join(5)
     assert not emitter.is_alive()
 

--- a/tests/test_inotify_c.py
+++ b/tests/test_inotify_c.py
@@ -40,11 +40,7 @@ def watching(path=None, use_full_emitter=False):
     emitter = Emitter(event_queue, ObservedWatch(path, recursive=True))
     emitter.start()
     yield
-    try:
-        emitter.stop()
-    except OSError:
-        # watch was already stopped, e.g., because root was deleted
-        pass
+    emitter.stop()
     emitter.join(5)
 
 


### PR DESCRIPTION
Fixes #758 by allowing an `InotifyEmitter.stop()` to be called when the emitter is already stopped. This brings the inotify backend in line with other backends.