### PR TITLE
Add missing exception objects

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -8,7 +8,9 @@ Changelog
 
 2021-0x-x • `full history <https://github.com/gorakhargosh/watchdog/compare/v2.0.1...master>`__
 
-- Thanks to our beloved contributors: @
+- [mac] Add missing exception objects (`#766 <https://github.com/gorakhargosh/watchdog/pull/766>`_)
+
+- Thanks to our beloved contributors: @CCP-Aporia
 
 
 2.0.1

--- a/src/watchdog_fsevents.c
+++ b/src/watchdog_fsevents.c
@@ -641,7 +641,10 @@ watchdog_add_watch(PyObject *self, PyObject *args)
 
     /* Create an instance of the callback information structure. */
     stream_callback_info_ref = PyMem_New(StreamCallbackInfo, 1);
-    G_RETURN_NULL_IF_NULL(stream_callback_info_ref);
+    if(stream_callback_info_ref == NULL) {
+        PyErr_SetString(PyExc_SystemError, "Failed allocating stream callback info");
+        return NULL;
+    }
 
     /* Create an FSEvent stream and
      * Save the stream reference to the global watch-to-stream dictionary. */

--- a/tests/test_fsevents.py
+++ b/tests/test_fsevents.py
@@ -79,6 +79,27 @@ def test_coalesced_event_check(event, expectation):
     assert event.is_coalesced == expectation
 
 
+def test_add_watch_twice(observer):
+    """ Adding the same watch twice used to result in a null pointer return without an exception.
+
+    See https://github.com/gorakhargosh/watchdog/issues/765
+    """
+
+    a = p("a")
+    mkdir(a)
+    h = FileSystemEventHandler()
+    w = ObservedWatch(a, recursive=False)
+
+    def callback(path, inodes, flags, ids):
+        pass
+
+    _fsevents.add_watch(h, w, callback, [w.path])
+    with pytest.raises(RuntimeError):
+        _fsevents.add_watch(h, w, callback, [w.path])
+    _fsevents.remove_watch(w)
+    rmdir(a)
+
+
 def test_remove_watch_twice():
     """
 ValueError: PyCapsule_GetPointer called with invalid PyCapsule object


### PR DESCRIPTION
As discovered in #765 there were two error conditions in `_fsevents.add_watch` that didn't set their exception status.