### PR TITLE
_load_libc is not needed

### DIFF
--- a/src/watchdog/observers/inotify_c.py
+++ b/src/watchdog/observers/inotify_c.py
@@ -25,39 +25,7 @@ from functools import reduce
 from ctypes import c_int, c_char_p, c_uint32
 from watchdog.utils import UnsupportedLibc
 
-
-def _load_libc():
-    libc_path = None
-    try:
-        libc_path = ctypes.util.find_library('c')
-    except (OSError, RuntimeError):
-        # Note: find_library will on some platforms raise these undocumented
-        # errors, e.g.on android OSError "No usable temporary directory found"
-        # will be raised.
-        pass
-
-    if libc_path is not None:
-        return ctypes.CDLL(libc_path)
-
-    # Fallbacks
-    try:
-        return ctypes.CDLL('libc.so')
-    except OSError:
-        pass
-
-    try:
-        return ctypes.CDLL('libc.so.6')
-    except OSError:
-        pass
-
-    # uClibc
-    try:
-        return ctypes.CDLL('libc.so.0')
-    except OSError as err:
-        raise err
-
-
-libc = _load_libc()
+libc = ctypes.CDLL(None)
 
 if not hasattr(libc, 'inotify_init') or \
         not hasattr(libc, 'inotify_add_watch') or \


### PR DESCRIPTION
libc is used by python interpreter itself, thus `dlopen(NULL)` is sufficient -- we don't need to load the library _again_, and can instead refer to the functions already in the running process.