### PR TITLE
Add support for non-recursive watches in FSEventsEmitter

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -8,8 +8,8 @@ Changelog
 
 2021-0x-xx • `full history <https://github.com/gorakhargosh/watchdog/compare/v2.0.3...master>`__
 
--
-- Thanks to our beloved contributors: @
+- [mac] Add support for non-recursive watches in FSEventsEmitter (`#779 <https://github.com/gorakhargosh/watchdog/pull/779>`_)
+- Thanks to our beloved contributors: @CCP-Aporia, @
 
 
 2.0.3

--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -109,8 +109,10 @@ class FSEventsEmitter(EventEmitter):
         if src_path == self._watch.path:
             return False
 
-        if hasattr(event, "dest_path"):
-            dest_path = event.dest_path if event.is_directory else os.path.dirname(event.dest_path)
+        if isinstance(event, (FileMovedEvent, DirMovedEvent)):
+            # when moving something into the watch path we must always take the dirname,
+            # otherwise we miss out on `DirMovedEvent`s
+            dest_path = os.path.dirname(event.dest_path)
             if dest_path == self._watch.path:
                 return False
 

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -435,15 +435,16 @@ def test_recursive_off():
         if platform.is_linux():
             expect_event(FileClosedEvent(p('b')))
 
-    mkdir(p('dir1', 'dir2'))
-    with pytest.raises(Empty):
-        event_queue.get(timeout=5)
-    mkfile(p('dir1', 'dir2', 'somefile'))
-    with pytest.raises(Empty):
-        event_queue.get(timeout=5)
+    if platform.is_darwin():
+        mkdir(p('dir1', 'dir2'))
+        with pytest.raises(Empty):
+            event_queue.get(timeout=5)
+        mkfile(p('dir1', 'dir2', 'somefile'))
+        with pytest.raises(Empty):
+            event_queue.get(timeout=5)
 
-    mkdir(p('dir3'))
-    expect_event(DirModifiedEvent(p()))  # the contents of the parent directory changed
+        mkdir(p('dir3'))
+        expect_event(DirModifiedEvent(p()))  # the contents of the parent directory changed
 
 
 @pytest.mark.skipif(platform.is_windows(),

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -419,7 +419,6 @@ def test_recursive_on():
 
 
 @pytest.mark.flaky(max_runs=5, min_passes=1, rerun_filter=rerun_filter)
-@pytest.mark.skipif(platform.is_darwin(), reason="macOS watches are always recursive")
 def test_recursive_off():
     mkdir(p('dir1'))
     start_watching(recursive=False)
@@ -427,6 +426,9 @@ def test_recursive_off():
 
     with pytest.raises(Empty):
         event_queue.get(timeout=5)
+
+    mkfile(p('b'))
+    expect_event(FileCreatedEvent(p('b')))
 
 
 @pytest.mark.skipif(platform.is_windows(),

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -429,6 +429,21 @@ def test_recursive_off():
 
     mkfile(p('b'))
     expect_event(FileCreatedEvent(p('b')))
+    if not platform.is_windows():
+        expect_event(DirModifiedEvent(p()))
+
+        if platform.is_linux():
+            expect_event(FileClosedEvent(p('b')))
+
+    mkdir(p('dir1', 'dir2'))
+    with pytest.raises(Empty):
+        event_queue.get(timeout=5)
+    mkfile(p('dir1', 'dir2', 'somefile'))
+    with pytest.raises(Empty):
+        event_queue.get(timeout=5)
+
+    mkdir(p('dir3'))
+    expect_event(DirModifiedEvent(p()))  # the contents of the parent directory changed
 
 
 @pytest.mark.skipif(platform.is_windows(),

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -435,6 +435,7 @@ def test_recursive_off():
         if platform.is_linux():
             expect_event(FileClosedEvent(p('b')))
 
+    # currently limiting these additional events to macOS only, see https://github.com/gorakhargosh/watchdog/pull/779
     if platform.is_darwin():
         mkdir(p('dir1', 'dir2'))
         with pytest.raises(Empty):
@@ -445,6 +446,14 @@ def test_recursive_off():
 
         mkdir(p('dir3'))
         expect_event(DirModifiedEvent(p()))  # the contents of the parent directory changed
+
+        mv(p('dir1', 'dir2', 'somefile'), p('somefile'))
+        expect_event(FileMovedEvent(p('dir1', 'dir2', 'somefile'), p('somefile')))
+        expect_event(DirModifiedEvent(p()))
+
+        mv(p('dir1', 'dir2'), p('dir2'))
+        expect_event(DirMovedEvent(p('dir1', 'dir2'), p('dir2')))
+        expect_event(DirModifiedEvent(p()))
 
 
 @pytest.mark.skipif(platform.is_windows(),


### PR DESCRIPTION
The underlying `fseventsd` service always observes recursively. As such we're adding a filter in `FSEventEmitter` to support the non-recursive behaviour that is supported by other emitters.

Fixes #771