### PR TITLE
[mac] Fix callback exceptions when the watcher is deleted but still receiving events

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -8,8 +8,8 @@ Changelog
 
 2021-0x-xx • `full history <https://github.com/gorakhargosh/watchdog/compare/v2.1.0...master>`__
 
--
-- Thanks to our beloved contributors:
+- [mac] Fix callback exceptions when the watcher is deleted but still receiving events
+- Thanks to our beloved contributors: @rom1win, @BoboTiG
 
 
 2.1.0

--- a/changelog.rst
+++ b/changelog.rst
@@ -9,7 +9,7 @@ Changelog
 2021-0x-xx • `full history <https://github.com/gorakhargosh/watchdog/compare/v2.1.0...master>`__
 
 - [mac] Fix callback exceptions when the watcher is deleted but still receiving events
-- Thanks to our beloved contributors: @rom1win, @BoboTiG
+- Thanks to our beloved contributors: @rom1win, @BoboTiG, @CCP-Aporia
 
 
 2.1.0

--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -83,7 +83,7 @@ class FSEventsEmitter(EventEmitter):
         self.suppress_history = suppress_history
         self._start_time = 0.0
         self._starting_state = None
-        self._lock = threading.RLock()
+        self._lock = threading.Lock()
 
     def on_thread_stop(self):
         _fsevents.remove_watch(self.watch)
@@ -296,10 +296,6 @@ class FSEventsEmitter(EventEmitter):
                     paths, inodes, flags, ids
                 )
             ]
-            if not self.watch:
-                # The watcher might be cleared on thread stop but the C callback would
-                # still send events. Let's ignore them to prevent unhandled exceptions later.
-                return
             with self._lock:
                 self.queue_events(self.timeout, events)
         except Exception:

--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -289,6 +289,9 @@ class FSEventsEmitter(EventEmitter):
                 self._fs_view.clear()
 
     def events_callback(self, paths, inodes, flags, ids):
+        """Callback passed to FSEventStreamCreate(), it will receive all
+        FS events and queue them.
+        """
         try:
             events = [
                 _fsevents.NativeEvent(path, inode, event_flags, event_id)

--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -289,9 +289,10 @@ class FSEventsEmitter(EventEmitter):
         """Callback passed to FSEventStreamCreate(), it will receive all
         FS events and queue them.
         """
+        cls = _fsevents.NativeEvent
         try:
             events = [
-                _fsevents.NativeEvent(path, inode, event_flags, event_id)
+                cls(path, inode, event_flags, event_id)
                 for path, inode, event_flags, event_id in zip(
                     paths, inodes, flags, ids
                 )

--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -86,11 +86,8 @@ class FSEventsEmitter(EventEmitter):
         self._lock = threading.RLock()
 
     def on_thread_stop(self):
-        if self.watch:
-            _fsevents.remove_watch(self.watch)
-            _fsevents.stop(self)
-            with self._lock:
-                self._watch = None
+        _fsevents.remove_watch(self.watch)
+        _fsevents.stop(self)
 
     def queue_event(self, event):
         # fsevents defaults to be recursive, so if the watch was meant to be non-recursive then we need to drop

--- a/src/watchdog_fsevents.c
+++ b/src/watchdog_fsevents.c
@@ -784,17 +784,20 @@ static PyObject *
 watchdog_remove_watch(PyObject *self, PyObject *watch)
 {
     UNUSED(self);
-    PyObject *value = PyDict_GetItem(watch_to_stream, watch);
+    PyObject *streamref_capsule = PyDict_GetItem(watch_to_stream, watch);
+    if (!streamref_capsule) {
+        // A watch might have been removed explicitly before, in which case we can simply early out.
+        Py_RETURN_NONE;
+    }
     PyDict_DelItem(watch_to_stream, watch);
 
-    FSEventStreamRef stream_ref = PyCapsule_GetPointer(value, NULL);
+    FSEventStreamRef stream_ref = PyCapsule_GetPointer(streamref_capsule, NULL);
 
     FSEventStreamStop(stream_ref);
     FSEventStreamInvalidate(stream_ref);
     FSEventStreamRelease(stream_ref);
 
-    Py_INCREF(Py_None);
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 PyDoc_STRVAR(watchdog_stop__doc__,

--- a/tests/test_fsevents.py
+++ b/tests/test_fsevents.py
@@ -127,7 +127,7 @@ def test_watcher_deletion_while_receiving_events_1(caplog, observer):
 
     with caplog.at_level(logging.ERROR), patch.object(FSEventsEmitter, "events_callback", new=cb):
         start_watching(tmpdir)
-        # Less than #00 is not enough events to trigger the error
+        # Less than 100 is not enough events to trigger the error
         for n in range(100):
             touch(p("{}.txt".format(n)))
         emitter.stop()

--- a/tests/test_fsevents.py
+++ b/tests/test_fsevents.py
@@ -227,9 +227,7 @@ E       SystemError: <built-in function stop> returned a result with an error se
     w = observer.schedule(FileSystemEventHandler(), a, recursive=False)
     rmdir(a)
     time.sleep(0.1)
-    with pytest.raises(KeyError):
-        # watch no longer exists!
-        observer.unschedule(w)
+    observer.unschedule(w)
 
 
 def test_converting_cfstring_to_pyunicode():

--- a/tests/test_fsevents.py
+++ b/tests/test_fsevents.py
@@ -12,6 +12,10 @@ import time
 from functools import partial
 from os import mkdir, rmdir
 from queue import Queue
+from random import random
+from threading import Thread
+from time import sleep
+from unittest.mock import patch
 
 import _watchdog_fsevents as _fsevents
 from watchdog.events import FileSystemEventHandler
@@ -98,6 +102,86 @@ def test_add_watch_twice(observer):
         _fsevents.add_watch(h, w, callback, [w.path])
     _fsevents.remove_watch(w)
     rmdir(a)
+
+
+def test_watcher_deletion_while_receiving_events_1(caplog, observer):
+    """
+    When the watcher is stopped while there are events, such exception could happen:
+
+        Traceback (most recent call last):
+            File "observers/fsevents.py", line 327, in events_callback
+            self.queue_events(self.timeout, events)
+            File "observers/fsevents.py", line 187, in queue_events
+            src_path = self._encode_path(event.path)
+            File "observers/fsevents.py", line 352, in _encode_path
+            if isinstance(self.watch.path, bytes):
+        AttributeError: 'NoneType' object has no attribute 'path'
+    """
+    tmpdir = p()
+
+    orig = FSEventsEmitter.events_callback
+
+    def cb(*args):
+        FSEventsEmitter.stop(emitter)
+        orig(*args)
+
+    with caplog.at_level(logging.ERROR), patch.object(FSEventsEmitter, "events_callback", new=cb):
+        start_watching(tmpdir)
+        # Less than #00 is not enough events to trigger the error
+        for n in range(100):
+            touch(p("{}.txt".format(n)))
+        emitter.stop()
+        assert not caplog.records
+
+
+def test_watcher_deletion_while_receiving_events_2(caplog):
+    """Note: that test takes about 20 seconds to complete.
+
+    Quite similar test to prevent another issue
+    when the watcher is stopped while there are events, such exception could happen:
+
+        Traceback (most recent call last):
+            File "observers/fsevents.py", line 327, in events_callback
+              self.queue_events(self.timeout, events)
+            File "observers/fsevents.py", line 235, in queue_events
+              self._queue_created_event(event, src_path, src_dirname)
+            File "observers/fsevents.py", line 132, in _queue_created_event
+              self.queue_event(cls(src_path))
+            File "observers/fsevents.py", line 104, in queue_event
+              if self._watch.is_recursive:
+        AttributeError: 'NoneType' object has no attribute 'is_recursive'
+    """
+
+    def try_to_fail():
+        tmpdir = p()
+        start_watching(tmpdir)
+
+        def create_files():
+            # Less than 2000 is not enough events to trigger the error
+            for n in range(2000):
+                touch(p(str(n) + ".txt"))
+
+        def stop(em):
+            sleep(random())
+            em.stop()
+
+        th1 = Thread(target=create_files)
+        th2 = Thread(target=stop, args=(emitter,))
+
+        try:
+            with caplog.at_level(logging.ERROR):
+                th1.start()
+                th2.start()
+                th1.join()
+                th2.join()
+                assert not caplog.records
+        finally:
+            emitter.stop()
+
+    # 20 attempts to make the random failure happen
+    for _ in range(20):
+        try_to_fail()
+        sleep(random())
 
 
 def test_remove_watch_twice():


### PR DESCRIPTION
The watcher might be cleared on thread stop but the C callback would still send events.
Let's ignore them to prevent unhandled exceptions later:

```python
    AttributeError: 'NoneType' object has no attribute 'is_recursive'
      File "watchdog/observers/fsevents.py", line 299, in callback
        emitter.queue_events(emitter.timeout, events)
      File "watchdog/observers/fsevents.py", line 261, in queue_events
        self._queue_created_event(event, src_path, src_dirname)
      File "watchdog/observers/fsevents.py", line 124, in _queue_created_event
        self.queue_event(DirModifiedEvent(dirname))
      File "watchdog/observers/fsevents.py", line 97, in queue_event
        if self._watch.is_recursive :
```

Or even:

```python
    AttributeError: 'NoneType' object has no attribute 'path'
      File "watchdog/observers/fsevents.py", line 299, in callback
        emitter.queue_events(emitter.timeout, events)
      File "watchdog/observers/fsevents.py", line 174, in queue_events
        src_path = self._encode_path(event.path)
      File "watchdog/observers/fsevents.py", line 323, in _encode_path
        if isinstance(self.watch.path, bytes):
```

Co-authored-by: Romain Grasland <rgrasland@nuxeo.com>