### PR TITLE
Fix relative path handling for non-recursive watch in FSEventsObserver

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -8,8 +8,9 @@ Changelog
 
 2021-xx-xx • `full history <https://github.com/gorakhargosh/watchdog/compare/v2.1.2...master>`__
 
+- [mac] Fix relative path handling for non-recursive watch. (`#797 <https://github.com/gorakhargosh/watchdog/pull/797>`_)
 - [windows] On PyPy, events happening right after ``start()`` were missed. Add a workaround for that. (`#796 <https://github.com/gorakhargosh/watchdog/pull/796>`_)
-- Thanks to our beloved contributors: @oprypin
+- Thanks to our beloved contributors: @oprypin, @CCP-Aporia
 
 2.1.1
 ~~~~~

--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -84,7 +84,7 @@ class FSEventsEmitter(EventEmitter):
         self._start_time = 0.0
         self._starting_state = None
         self._lock = threading.Lock()
-        self._absolute_watch_path = os.path.abspath(self.watch.path)
+        self._absolute_watch_path = os.path.abspath(os.path.expanduser(self.watch.path))
 
     def on_thread_stop(self):
         _fsevents.remove_watch(self.watch)

--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -84,6 +84,7 @@ class FSEventsEmitter(EventEmitter):
         self._start_time = 0.0
         self._starting_state = None
         self._lock = threading.Lock()
+        self._absolute_watch_path = os.path.abspath(self.watch.path)
 
     def on_thread_stop(self):
         _fsevents.remove_watch(self.watch)
@@ -104,14 +105,14 @@ class FSEventsEmitter(EventEmitter):
 
     def _is_recursive_event(self, event):
         src_path = event.src_path if event.is_directory else os.path.dirname(event.src_path)
-        if src_path == self._watch.path:
+        if src_path == self._absolute_watch_path:
             return False
 
         if isinstance(event, (FileMovedEvent, DirMovedEvent)):
             # when moving something into the watch path we must always take the dirname,
             # otherwise we miss out on `DirMovedEvent`s
             dest_path = os.path.dirname(event.dest_path)
-            if dest_path == self._watch.path:
+            if dest_path == self._absolute_watch_path:
                 return False
 
         return True

--- a/tests/test_fsevents.py
+++ b/tests/test_fsevents.py
@@ -46,10 +46,10 @@ def teardown_function(function):
     rm(p(""), recursive=True)
 
 
-def start_watching(path=None, use_full_emitter=False):
+def start_watching(path=None, recursive=True, use_full_emitter=False):
     global emitter
     path = p("") if path is None else path
-    emitter = FSEventsEmitter(event_queue, ObservedWatch(path, recursive=True), suppress_history=True)
+    emitter = FSEventsEmitter(event_queue, ObservedWatch(path, recursive=recursive), suppress_history=True)
     emitter.start()
 
 
@@ -245,6 +245,52 @@ def test_converting_cfstring_to_pyunicode():
         assert event.src_path.endswith(dirname)
     finally:
         emitter.stop()
+
+
+def test_issue_797():
+    from watchdog.events import (
+        PatternMatchingEventHandler,
+        DirCreatedEvent,
+        DirModifiedEvent,
+        FileCreatedEvent,
+        FileModifiedEvent
+    )
+
+    class TestEventHandler(PatternMatchingEventHandler):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.expected_events = [
+                FileCreatedEvent(p('foo.json')),
+                FileModifiedEvent(p('foo.json'))
+            ]
+            self.observed_events = set()
+
+        def on_any_event(self, event):
+            logger.info(event)
+            self.expected_events.remove(event)
+            self.observed_events.add(event)
+            # expected_event = self.expected_events.pop(0)
+            # assert expected_event == event
+
+        def done(self):
+            return not self.expected_events
+
+    event_handler = TestEventHandler(patterns=["*.json"], ignore_patterns=[], ignore_directories=True)
+    observer = Observer()
+    observer.schedule(event_handler, p())
+    observer.start()
+    time.sleep(0.1)
+
+    try:
+        touch(p('foo.json'))
+        timeout_at = time.time() + 5
+        while not event_handler.done() and time.time() < timeout_at:
+            time.sleep(0.1)
+
+        assert event_handler.done()
+    finally:
+        observer.stop()
+        observer.join()
 
 
 def test_watchdog_recursive():


### PR DESCRIPTION
A watch path may be relative, while an event path is always absolute. Since the check for recursive events simply compared the watch path with the event path then that would fail in case the watch was set to a relative folder. This resolves the issue.

Fixes #797 