### PR TITLE
Add separate method for file/directory metadata modifcation

### DIFF
--- a/src/watchdog/events.py
+++ b/src/watchdog/events.py
@@ -68,6 +68,15 @@ Event Classes
    :members:
    :show-inheritance:
 
+.. autoclass:: FileAttribEvent
+   :members:
+   :show-inheritance:
+
+.. autoclass:: FileAttribEvent
+   :members:
+   :show-inheritance:
+
+
 
 Event Handler Classes
 ---------------------
@@ -203,6 +212,9 @@ class FileDeletedEvent(FileSystemEvent):
 
 
 class FileAttribEvent(FileSystemEvent):
+    """
+    File system event representing file metadata modification on the file system.
+    """
     event_type = EVENT_TYPE_ATTRIB
 
 
@@ -261,6 +273,9 @@ class DirMovedEvent(FileSystemMovedEvent):
 
 
 class DirAttribEvent(FileSystemEvent):
+    """
+    File system event representing directory metadata modification on the file system.
+    """
     event_type = EVENT_TYPE_ATTRIB
     is_directory = True
 

--- a/src/watchdog/events.py
+++ b/src/watchdog/events.py
@@ -100,6 +100,7 @@ EVENT_TYPE_DELETED = 'deleted'
 EVENT_TYPE_CREATED = 'created'
 EVENT_TYPE_MODIFIED = 'modified'
 EVENT_TYPE_CLOSED = 'closed'
+EVENT_TYPE_ATTRIB = 'attrib'
 
 
 class FileSystemEvent:
@@ -201,6 +202,10 @@ class FileDeletedEvent(FileSystemEvent):
     event_type = EVENT_TYPE_DELETED
 
 
+class FileAttribEvent(FileSystemEvent):
+    event_type = EVENT_TYPE_ATTRIB
+
+
 class FileModifiedEvent(FileSystemEvent):
     """File system event representing file modification on the file system."""
 
@@ -255,6 +260,11 @@ class DirMovedEvent(FileSystemMovedEvent):
     is_directory = True
 
 
+class DirAttribEvent(FileSystemEvent):
+    event_type = EVENT_TYPE_ATTRIB
+    is_directory = True
+
+
 class FileSystemEventHandler:
     """
     Base file system event handler that you can override methods from.
@@ -275,6 +285,7 @@ class FileSystemEventHandler:
             EVENT_TYPE_MODIFIED: self.on_modified,
             EVENT_TYPE_MOVED: self.on_moved,
             EVENT_TYPE_CLOSED: self.on_closed,
+            EVENT_TYPE_ATTRIB: self.on_attrib,
         }[event.event_type](event)
 
     def on_any_event(self, event):
@@ -331,6 +342,13 @@ class FileSystemEventHandler:
             :class:`FileClosedEvent`
         """
 
+    def on_attrib(self, event):
+        """Called when a file or directory metadata is modified.
+        :param event:
+            Event representing file/directory metadata modification.
+        :type event:
+            :class:`FileAttribEvent` or :class:`DirAttribEvent`
+        """
 
 class PatternMatchingEventHandler(FileSystemEventHandler):
     """

--- a/src/watchdog/events.py
+++ b/src/watchdog/events.py
@@ -533,6 +533,12 @@ class LoggingEventHandler(FileSystemEventHandler):
         what = 'directory' if event.is_directory else 'file'
         self.logger.info("Modified %s: %s", what, event.src_path)
 
+    def on_attrib(self, event):
+        super().on_attrib(event)
+
+        what = 'directory' if event.is_directory else 'file'
+        self.logger.info("Attrib %s: %s", what, event.src_path)
+
 
 def generate_sub_moved_events(src_dir_path, dest_dir_path):
     """Generates an event list of :class:`DirMovedEvent` and

--- a/src/watchdog/observers/fsevents2.py
+++ b/src/watchdog/observers/fsevents2.py
@@ -34,7 +34,9 @@ from watchdog.events import (
     DirDeletedEvent,
     DirModifiedEvent,
     DirCreatedEvent,
-    DirMovedEvent
+    DirMovedEvent,
+    FileAttribEvent,
+    DirAttribEvent,
 )
 from watchdog.observers.api import (
     BaseObserver,
@@ -225,8 +227,12 @@ class FSEventsEmitter(EventEmitter):
                     self.queue_event(DirModifiedEvent(os.path.dirname(event.path)))
                 # TODO: generate events for tree
 
-            elif event.is_modified or event.is_inode_meta_mod or event.is_xattr_mod :
+            elif event.is_modified:
                 cls = DirModifiedEvent if event.is_directory else FileModifiedEvent
+                self.queue_event(cls(event.path))
+
+            elif event.is_inode_meta_mod or event.is_xattr_mod:
+                cls = DirAttribEvent if event.is_directory else FileAttribEvent
                 self.queue_event(cls(event.path))
 
             elif event.is_created:

--- a/src/watchdog/observers/inotify.py
+++ b/src/watchdog/observers/inotify.py
@@ -87,6 +87,8 @@ from watchdog.events import (
     FileMovedEvent,
     FileCreatedEvent,
     FileClosedEvent,
+    FileAttribEvent,
+    DirAttribEvent,
     generate_sub_moved_events,
     generate_sub_created_events,
 )
@@ -155,7 +157,7 @@ class InotifyEmitter(EventEmitter):
                     for sub_event in generate_sub_created_events(src_path):
                         self.queue_event(sub_event)
             elif event.is_attrib:
-                cls = DirModifiedEvent if event.is_directory else FileModifiedEvent
+                cls = DirAttribEvent if event.is_directory else FileAttribEvent
                 self.queue_event(cls(src_path))
             elif event.is_modify:
                 cls = DirModifiedEvent if event.is_directory else FileModifiedEvent

--- a/src/watchdog/observers/kqueue.py
+++ b/src/watchdog/observers/kqueue.py
@@ -100,6 +100,8 @@ from watchdog.events import (
     EVENT_TYPE_DELETED,
     EVENT_TYPE_CREATED,
     generate_sub_moved_events,
+    FileAttribEvent,
+    DirAttribEvent,
 )
 
 # Maximum number of events to process.
@@ -553,9 +555,9 @@ class KqueueEmitter(EventEmitter):
                 yield event
         elif is_attrib_modified(kev):
             if descriptor.is_directory:
-                yield DirModifiedEvent(src_path)
+                yield DirAttribEvent(src_path)
             else:
-                yield FileModifiedEvent(src_path)
+                yield FileAttribEvent(src_path)
         elif is_modified(kev):
             if descriptor.is_directory:
                 if self.watch.is_recursive or self.watch.path == src_path:


### PR DESCRIPTION
Hi there,

As we discussed here #260, I tried to solve the problem using two new events for inotify, kqueue, and fsevents2 backends. So far, I've found no solution for the windows, as in this [document](https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-file_notify_information) describes it does not have an action for this purpose.



