### PR TITLE
add quotes for zsh compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,7 +127,7 @@ Install from PyPI using ``pip``:
     $ python -m pip install -U watchdog
 
     # or to install the watchmedo utility:
-    $ python -m pip install -U watchdog[watchmedo]
+    $ python -m pip install -U "watchdog[watchmedo]"
 
 Install from source:
 


### PR DESCRIPTION
In zsh:

```bash
❯ python3 -m pip install -U watchdog[watchmedo]

zsh: no matches found: watchdog[watchmedo]
```

does not work, but this does:

```
❯ python3 -m pip install -U "watchdog[watchmedo]"
Defaulting to user installation because normal site-packages is not writeable
Requirement already satisfied: watchdog[watchmedo] in /home/bsg/.local/lib/python3.6/site-packages (2.1.3)
Collecting argh>=0.24.1
  Downloading argh-0.26.2-py2.py3-none-any.whl (30 kB)
Requirement already satisfied: PyYAML>=3.10 in /usr/lib/python3/dist-packages (from watchdog[watchmedo]) (3.12)
Installing collected packages: argh
Successfully installed argh-0.26.2
```

In bash, both forms work.

