### PR TITLE
Fix SkipRepeatsQueue._put() raises AttributeError (#817)

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -10,7 +10,8 @@ Changelog
 
 - [watchmedo] Fix usage of ``os.setsid()`` and ``os.killpg()`` Unix-only functions.  (`#809 <https://github.com/gorakhargosh/watchdog/pull/809>`_)
 - [mac] Fix missing ``FileModifiedEvent`` on permission or ownership changes of a file.  (`#809 <https://github.com/gorakhargosh/watchdog/pull/814>`_)
-- Thanks to our beloved contributors: @replabrobin, @BoboTiG, @SamSchott
+- [mac] Fix a possible ``AttributeError`` in ``SkipRepeatsQueue._put()``.  (`#818 <https://github.com/gorakhargosh/watchdog/pull/818>`_)
+- Thanks to our beloved contributors: @replabrobin, @BoboTiG, @SamSchott, @AndreiB97
 
 2.1.3
 ~~~~~

--- a/src/watchdog/utils/bricks.py
+++ b/src/watchdog/utils/bricks.py
@@ -87,7 +87,7 @@ class SkipRepeatsQueue(queue.Queue):
         self._last_item = None
 
     def _put(self, item):
-        if item != self._last_item:
+        if self._last_item is None or item != self._last_item:
             super()._put(item)
             self._last_item = item
         else:

--- a/tests/test_skip_repeats_queue.py
+++ b/tests/test_skip_repeats_queue.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 import pytest
+import watchdog.events as events
 from watchdog.utils.bricks import SkipRepeatsQueue
 
 from .markers import cpython_only
@@ -56,6 +57,18 @@ def test_allow_nonconsecutive():
     assert e2 == q.get()
     assert e1 == q.get()
     assert q.empty()
+
+
+def test_put_with_watchdog_events():
+    # FileSystemEvent.__ne__() uses the key property without
+    # doing any type checking. Since _last_item is set to
+    # None in __init__(), an AttributeError is raised when
+    # FileSystemEvent.__ne__() tries to use None.key
+    queue = SkipRepeatsQueue()
+    dummy_file = 'dummy.txt'
+    event = events.FileCreatedEvent(dummy_file)
+    queue.put(event)
+    assert queue.get() is event
 
 
 def test_prevent_consecutive():


### PR DESCRIPTION
This fixes an issue with `SkipRepeatsQueue._put()` which causes it to raise
an `AttributeError` on the first put. This is done by adding a check to test
if `_last_item` is set to `None`, which is the value set by `__init__()`

Issue: https://github.com/gorakhargosh/watchdog/issues/817