### PR TITLE
Fix watching non-recursive files in a symlinked directory (821)

### DIFF
--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -84,7 +84,7 @@ class FSEventsEmitter(EventEmitter):
         self._start_time = 0.0
         self._starting_state = None
         self._lock = threading.Lock()
-        self._absolute_watch_path = os.path.abspath(os.path.expanduser(self.watch.path))
+        self._absolute_watch_path = os.path.realpath(os.path.abspath(os.path.expanduser(self.watch.path)))
 
     def on_thread_stop(self):
         _fsevents.remove_watch(self.watch)


### PR DESCRIPTION
See #821

It appears that in `fsevents`, the events will contain the "real" file paths. This will break if fsevents end up generating events with the not-"real" path instead, for which I don't know if it could happen or not. The way around this would be to also use `os.path.realpath()` for the `src_path` in `_is_recursive_event()`.