### PR TITLE
convert regexes of type str to list

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -8,8 +8,8 @@ Changelog
 
 2021-xx-xx • `full history <https://github.com/gorakhargosh/watchdog/compare/v2.1.4...master>`__
 
--
-- Thanks to our beloved contributors: @
+- convert regexes of type str to list. (`#831 <https://github.com/gorakhargosh/watchdog/pull/831>`_)
+- Thanks to our beloved contributors: @unique1o1
 
 2.1.4
 ~~~~~

--- a/src/watchdog/events.py
+++ b/src/watchdog/events.py
@@ -418,6 +418,8 @@ class RegexMatchingEventHandler(FileSystemEventHandler):
 
         if regexes is None:
             regexes = [r".*"]
+        elif isinstance(regexes, str):
+            regexes = [regexes]
         if ignore_regexes is None:
             ignore_regexes = []
         if case_sensitive:

--- a/tests/test_regex_matching_event_handler.py
+++ b/tests/test_regex_matching_event_handler.py
@@ -35,6 +35,7 @@ from watchdog.events import (
 path_1 = '/path/xyz'
 path_2 = '/path/abc'
 g_allowed_regexes = [r".*\.py", r".*\.txt"]
+g_allowed_str_regexes = r".*\.py"
 g_ignore_regexes = [r".*\.pyc"]
 
 
@@ -184,6 +185,12 @@ def test_regexes():
     handler1 = RegexMatchingEventHandler(g_allowed_regexes,
                                          g_ignore_regexes, True)
     assert [r.pattern for r in handler1.regexes] == g_allowed_regexes
+
+
+def test_str_regexes():
+    handler1 = RegexMatchingEventHandler(g_allowed_str_regexes,
+                                         g_ignore_regexes, True)
+    assert [r.pattern for r in handler1.regexes] == [g_allowed_str_regexes]
 
 
 def test_logging_event_handler_dispatch():


### PR DESCRIPTION
when type `str` is passed to the `regexes` argument, convert the `str` to a `list` and iterate through the list instead of iterating through `str`.