### PR TITLE
Use is_alive() instead of isAlive() in documentation

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -46,7 +46,7 @@ file system changes and simply log them to the console::
         observer.schedule(event_handler, path, recursive=True)
         observer.start()
         try:
-            while observer.isAlive():
+            while observer.is_alive():
                 observer.join(1)
         finally:
             observer.stop()


### PR DESCRIPTION
Using `threading.Thread.isAlive` is [deprecated since python 3.8](https://bugs.python.org/issue37804) and was removed in python 3.9.  
It seems that the codebase uses `is_alive()` internally, only the documentation should be updated.