### PR TITLE
Update tests for FreeBSD and make these more visible by adding a badge

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,18 +1,21 @@
-freebsd_instance:
-  image_family: freebsd-12-1
-
 task:
+  matrix:
+    freebsd_instance:
+      image_family: freebsd-13-0
+    freebsd_instance:
+      image_family: freebsd-12-2
+      
   install_script:
-    - pkg install -y python37 py37-sqlite3
+    - pkg install -y python38 py38-sqlite3
     # Print the Python version, only to be sure we are running the version we want
-    - python3.7 -c 'import platform; print("Python", platform.python_version())'
+    - python3.8 -c 'import platform; print("Python", platform.python_version())'
     # Check SQLite3 is installed
-    - python3.7 -c 'import sqlite3; print("SQLite3", sqlite3.version)'
+    - python3.8 -c 'import sqlite3; print("SQLite3", sqlite3.version)'
   setup_script:
-    - python3.7 -m ensurepip
-    - python3.7 -m pip install -U pip
-    - python3.7 -m pip install -r requirements-tests.txt
+    - python3.8 -m ensurepip
+    - python3.8 -m pip install -U pip
+    - python3.8 -m pip install -r requirements-tests.txt
   lint_script:
-    - python3.7 -m flake8 docs src tests tools
+    - python3.8 -m flake8 docs src tests tools
   tests_script:
-    - python3.7 -bb -m pytest tests
+    - python3.8 -bb -m pytest tests

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,7 @@ Watchdog
 ========
 
 |Build Status|
+|CirrusCI Status|
 
 Python API and shell utilities to monitor file system events.
 
@@ -301,3 +302,5 @@ to do:
 
 .. |Build Status| image:: https://github.com/gorakhargosh/watchdog/workflows/Tests/badge.svg
    :target: https://github.com/gorakhargosh/watchdog/actions?query=workflow%3ATests
+.. |CirrusCI Status| image:: https://api.cirrus-ci.com/github/gorakhargosh/watchdog.svg
+   :target: https://cirrus-ci.com/github/gorakhargosh/watchdog/


### PR DESCRIPTION
Hi,

the Cirrus CI setup is a bit outdated because FreeBSD 12.1 is End-of-Life since 31st January 2021 and Python 3.8 is now the default in the FreeBSD ports tree.

This PR updates the `.cirrus.yml` accordingly and expands the test matrix to test `watchdog` against `FreeBSD` 12.2- and 13.0-RELEASE which are both supported releases.

In addition, a Cirrus CI badge is added in order to be able to access the results more quickly. (However, Cirrus CI doesn't seem to be activated for the repository at the moment.)

At last but not least: Some tests fail, which I noticed while working on the update to the latest version (2.1.5 at the moment) of `watchdog` for `FreeBSD`. I'll make a separate pull request for this.