### PR TITLE
[watchmedo] Lazy loading of the PyYAML module

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -10,6 +10,7 @@ Changelog
 
 - Eliminate timeout in waiting on event queue. (`#861 <https://github.com/gorakhargosh/watchdog/pull/861>`_)
 - [inotify] Fix ``not`` equality implementation for ``InotifyEvent``. (`#848 <https://github.com/gorakhargosh/watchdog/pull/848>`_)
+- [watchmedo] ``PyYAML`` is loaded only when strictly necessary. Simple usages of ``watchmedo`` are possible without the module being installed. (`#847 <https://github.com/gorakhargosh/watchdog/pull/847>`_)
 - Thanks to our beloved contributors: @sattlerc, @JanzenLiu, @BoboTiG
 
 2.1.6

--- a/src/watchdog/watchmedo.py
+++ b/src/watchdog/watchmedo.py
@@ -31,7 +31,6 @@ from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from io import StringIO
 from textwrap import dedent
 
-import yaml
 from watchdog.utils import WatchdogShutdown, load_class
 from watchdog.version import VERSION_STRING
 
@@ -136,6 +135,8 @@ def load_config(tricks_file_pathname):
     :returns:
         A dictionary of configuration information.
     """
+    import yaml
+
     with open(tricks_file_pathname, 'rb') as f:
         return yaml.safe_load(f.read())
 
@@ -309,6 +310,8 @@ def tricks_generate_yaml(args):
     """
     Command to generate Yaml configuration for tricks named on the command line.
     """
+    import yaml
+
     python_paths = path_split(args.python_path)
     add_to_sys_path(python_paths)
     output = StringIO()


### PR DESCRIPTION
The module is loaded only when strictly necessary.
Simple usages of watchmedo are possible without the module being installed.