### PR TITLE
Avoid unintended replacement to _path

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -9,7 +9,7 @@ Changelog
 2021-xx-xx • `full history <https://github.com/gorakhargosh/watchdog/compare/v2.1.6...master>`__
 
 - 
-- Thanks to our beloved contributors: @
+- Thanks to our beloved contributors: @JanzenLiu
 
 2.1.6
 ~~~~~

--- a/src/watchdog/observers/inotify_c.py
+++ b/src/watchdog/observers/inotify_c.py
@@ -312,7 +312,7 @@ class Inotify:
                             for _path, _wd in self._wd_for_path.copy().items():
                                 if _path.startswith(move_src_path + os.path.sep.encode()):
                                     moved_wd = self._wd_for_path.pop(_path)
-                                    _move_to_path = _path.replace(move_src_path, inotify_event.src_path)
+                                    _move_to_path = _path.replace(move_src_path, inotify_event.src_path, 1)
                                     self._wd_for_path[_move_to_path] = moved_wd
                                     self._path_for_wd[moved_wd] = _move_to_path
                     src_path = os.path.join(wd_path, name)

--- a/tests/test_inotify_c.py
+++ b/tests/test_inotify_c.py
@@ -187,3 +187,25 @@ def test_watch_file():
         os.remove(path)
         event, _ = event_queue.get(timeout=5)
         assert repr(event)
+
+
+def test_replace_moved_path():
+    from queue import Empty
+    from .shell import mkfile, mkdir, mv, cd, pwd
+
+    curdir = pwd()
+    tmpdir = p("")
+    cd(tmpdir)
+    mkdir("foo/foo/foo/foo", True)
+
+    with watching("foo"):
+        mv("foo/foo", "foo/bar")
+        while True:
+            try:
+                event_queue.get(timeout=5)
+            except Empty:
+                break
+        assert "foo/bar/foo/foo" in emitter._inotify._inotify._wd_for_path
+        assert "foo/bar/foo/bar" not in emitter._inotify._inotify._wd_for_path
+
+    cd(curdir)


### PR DESCRIPTION
The original code might cause unintended additional replacement if the `move_src_path` appears as a substring in `_path`.
For example, if `move_src_path = "foo"`, `inotify_event.src_path = "bar"`, `_path = "foo/foo_helper.py"`, 
`_path.replace(move_src_path, inotify_event.src_path)` will evaluates to "bar/bar_helper.py", instead of "bar/foo_helper.py"