### PR TITLE
Eliminate timeout in waiting on event queue

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -60,7 +60,7 @@ Changelog
 
 - [mac] Fix relative path handling for non-recursive watch. (`#797 <https://github.com/gorakhargosh/watchdog/pull/797>`_)
 - [windows] On PyPy, events happening right after ``start()`` were missed. Add a workaround for that. (`#796 <https://github.com/gorakhargosh/watchdog/pull/796>`_)
-w- Thanks to our beloved contributors: @oprypin, @CCP-Aporia, @BoboTiG
+- Thanks to our beloved contributors: @oprypin, @CCP-Aporia, @BoboTiG
 
 2.1.1
 ~~~~~

--- a/changelog.rst
+++ b/changelog.rst
@@ -8,8 +8,8 @@ Changelog
 
 2021-xx-xx • `full history <https://github.com/gorakhargosh/watchdog/compare/v2.1.6...master>`__
 
-- 
-- Thanks to our beloved contributors: @
+- Eliminate timeout in waiting on event queue. (`#861 <https://github.com/gorakhargosh/watchdog/pull/861>`_)
+- Thanks to our beloved contributors: @sattlerc
 
 2.1.6
 ~~~~~
@@ -60,7 +60,7 @@ Changelog
 
 - [mac] Fix relative path handling for non-recursive watch. (`#797 <https://github.com/gorakhargosh/watchdog/pull/797>`_)
 - [windows] On PyPy, events happening right after ``start()`` were missed. Add a workaround for that. (`#796 <https://github.com/gorakhargosh/watchdog/pull/796>`_)
-- Thanks to our beloved contributors: @oprypin, @CCP-Aporia, @BoboTiG
+w- Thanks to our beloved contributors: @oprypin, @CCP-Aporia, @BoboTiG
 
 2.1.1
 ~~~~~

--- a/src/watchdog/observers/api.py
+++ b/src/watchdog/observers/api.py
@@ -154,7 +154,8 @@ class EventDispatcher(BaseThread):
     that dispatch events from an event queue to appropriate event handlers.
 
     :param timeout:
-        Event queue blocking timeout (in seconds).
+        Timeout value (in seconds) passed to emitters
+        constructions in the child class BaseObserver.
     :type timeout:
         ``float``
     """
@@ -169,7 +170,7 @@ class EventDispatcher(BaseThread):
 
     @property
     def timeout(self):
-        """Event queue block timeout."""
+        """Timeout value to construct emitters with."""
         return self._timeout
 
     def stop(self):


### PR DESCRIPTION
The use of a timeout in reading from the event queue in `BaseObserver` is a hack. This causes an unnecessary wake-up every second and causes the following program to take one second:
```python
from watchdog.observers import Observer
observer = Observer()
observer.start()
observer.stop()
observer.join()
```

This pull request gets rid of the timeout by adding a null event to the event queue after a stop is requested.

Note that, contrary to documentation, this timeout value was also used for other things than reading from the event queue. It is also passed to emitters constructed in BaseObserver. I have thus left the timeout attribute in place and instead fixed its documentation.