### PR TITLE
Fix pypy CI version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python: [3.6, 3.7, 3.8, 3.9, pypy3]
+        python: [3.6, 3.7, 3.8, 3.9, 'pypy-3.7']
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Fixes the "Error: PyPy 3.6 not found" e.g. in https://github.com/gorakhargosh/watchdog/runs/4621795624?check_suite_focus=true  as per https://github.com/actions/setup-python/issues/296#issuecomment-994556336 but the build still isn't in a great state.