### PR TITLE
Warning issues debug helper

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,4 +52,5 @@ def no_warnings(recwarn):
         ):
             continue
         warnings.append("{w.filename}:{w.lineno} {w.message}".format(w=warning))
+    print(warnings)
     assert not warnings


### PR DESCRIPTION
My intention here was to make debugging the "no warnings" issues easier. OTOH, it seems to have fixed at least most of the build issues.... I'm not sure why this one worked. I figured maybe the floating test package versions, but the only change between this and the last failing master build is attrs going from 21.2.0 to 21.3.0, which I don't _think_ should have fixed the build issues.