### PR TITLE
Fix `Observer.unschedule` hang on linux when called with watch of an unmounted path

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -23,7 +23,8 @@ Changelog
 - [inotify] Fix ``not`` equality implementation for ``InotifyEvent``. (`#848 <https://github.com/gorakhargosh/watchdog/pull/848>`_)
 - [watchmedo] Fix calling commands from within a Python script. (`#879 <https://github.com/gorakhargosh/watchdog/pull/879>`_)
 - [watchmedo] ``PyYAML`` is loaded only when strictly necessary. Simple usages of ``watchmedo`` are possible without the module being installed. (`#847 <https://github.com/gorakhargosh/watchdog/pull/847>`_)
-- Thanks to our beloved contributors: @sattlerc, @JanzenLiu, @BoboTiG
+- [inotify] Fix hang when unscheduling watch on a path in an unmounted filesystem. (`#869 <https://github.com/gorakhargosh/watchdog/pull/869>`_)
+- Thanks to our beloved contributors: @sattlerc, @JanzenLiu, @BoboTiG, @IlayRosenberg
 
 2.1.6
 ~~~~~

--- a/changelog.rst
+++ b/changelog.rst
@@ -12,6 +12,7 @@ Changelog
 - [watchmedo] Fix broken parsing of ``--kill-after`` argument for the ``auto-restart`` command. (`#870 <https://github.com/gorakhargosh/watchdog/issues/870>`_)
 - [watchmedo] Fix broken parsing of boolean arguments. (`#855 <https://github.com/gorakhargosh/watchdog/issues/855>`_)
 - [watchmedo] Fix broken parsing of commands from ``auto-restart``, and ``shell-command``. (`#855 <https://github.com/gorakhargosh/watchdog/issues/855>`_)
+- [inotify] Fix hang when unscheduling watch on a path in an unmounted filesystem. (`#869 <https://github.com/gorakhargosh/watchdog/pull/869>`_)
 - Thanks to our beloved contributors: @taleinat, @kianmeng, @palfrey, @IlayRosenberg, @BoboTiG
 
 2.1.7
@@ -23,8 +24,7 @@ Changelog
 - [inotify] Fix ``not`` equality implementation for ``InotifyEvent``. (`#848 <https://github.com/gorakhargosh/watchdog/pull/848>`_)
 - [watchmedo] Fix calling commands from within a Python script. (`#879 <https://github.com/gorakhargosh/watchdog/pull/879>`_)
 - [watchmedo] ``PyYAML`` is loaded only when strictly necessary. Simple usages of ``watchmedo`` are possible without the module being installed. (`#847 <https://github.com/gorakhargosh/watchdog/pull/847>`_)
-- [inotify] Fix hang when unscheduling watch on a path in an unmounted filesystem. (`#869 <https://github.com/gorakhargosh/watchdog/pull/869>`_)
-- Thanks to our beloved contributors: @sattlerc, @JanzenLiu, @BoboTiG, @IlayRosenberg
+- Thanks to our beloved contributors: @sattlerc, @JanzenLiu, @BoboTiG
 
 2.1.6
 ~~~~~

--- a/src/watchdog/observers/inotify_buffer.py
+++ b/src/watchdog/observers/inotify_buffer.py
@@ -88,11 +88,11 @@ class InotifyBuffer(BaseThread):
             inotify_events = self._inotify.read_events()
             grouped_events = self._group_events(inotify_events)
             for inotify_event in grouped_events:
-                if not isinstance(inotify_event, tuple) and inotify_event.is_ignored and \
-                        inotify_event.src_path == self._inotify.path:
-                    # Watch was removed explicitly (inotify_rm_watch(2)) or automatically (file
-                    # was deleted, or filesystem was unmounted), stop watching for events
-                    deleted_self = True
+                if not isinstance(inotify_event, tuple) and inotify_event.is_ignored:
+                    if inotify_event.src_path == self._inotify.path:
+                        # Watch was removed explicitly (inotify_rm_watch(2)) or automatically (file
+                        # was deleted, or filesystem was unmounted), stop watching for events
+                        deleted_self = True
                     continue
 
                 # Only add delay for unmatched move_from events

--- a/src/watchdog/observers/inotify_c.py
+++ b/src/watchdog/observers/inotify_c.py
@@ -323,7 +323,6 @@ class Inotify:
                     path = self._path_for_wd.pop(wd)
                     if self._wd_for_path[path] == wd:
                         del self._wd_for_path[path]
-                    continue
 
                 event_list.append(inotify_event)
 

--- a/tests/shell.py
+++ b/tests/shell.py
@@ -126,8 +126,8 @@ def msize(path):
 
 
 def mount_tmpfs(path):
-    os.system(f'mount -t tmpfs none {path}')
+    os.system(f'sudo mount -t tmpfs none {path}')
 
 
 def unmount(path):
-    os.system(f'umount {path}')
+    os.system(f'sudo umount {path}')

--- a/tests/shell.py
+++ b/tests/shell.py
@@ -123,3 +123,9 @@ def msize(path):
     with open(path, 'w') as w:
         w.write('0')
     os.utime(path, (0, 0))
+
+def mount_tmpfs(path):
+    os.system(f'mount -t tmpfs none {path}')
+
+def unmount(path):
+    os.system(f'umount {path}')

--- a/tests/shell.py
+++ b/tests/shell.py
@@ -124,8 +124,10 @@ def msize(path):
         w.write('0')
     os.utime(path, (0, 0))
 
+
 def mount_tmpfs(path):
     os.system(f'mount -t tmpfs none {path}')
+
 
 def unmount(path):
     os.system(f'umount {path}')


### PR DESCRIPTION
# Description
I experienced a hang on `Observer.unschedule` with the following flow:
1. Scheduling a watch for a folder in a container namespace (`/proc/pid/root/...`), 
2. Removing the container (`docker rm -f ..`)
3. Unscheduling the watch

After some debugging I noticed that the `InotifyBuffer` thread is stuck on `Inotify.read_events`, specifically on `os.read(self._inotify_fd, event_buffer_size)`.
As far as I can tell, usually when a watch is unscheduled, `inotify_rm_watch` is called after the thread stop event is set, which then generates an inotify event that causes `os.read` to return, and eventually the thread to finish its execution (after `should_keep_running` returns false). Otherwise, if the watch folder is deleted, an `IN_DELETE_SELF` event is generated which causes the thread to stop (by setting `deleted_self`).
However, if the entire filesystem containing the watched object was unmounted, an `IN_UNMOUNT` event is generated, which isn't handled the same way (or at all). Additionally, in all these cases, an `IN_IGNORED` event should follow, which is what I ended up handling instead of the specific `IN_UNMOUNT`.

All I did is set `deleted_self` if an `IN_IGNORED` event was received with the Inotify's path, to make sure the thread doesn't hang on the next `os.read` call, and it seem to have fixed the issue.

# TL;DR
`Observer.unschedule` hangs if scheduled on a folder in a removed container. I added handling of `IN_IGNORED` events which should stop the thread on such cases.
