### PR TITLE
Bugfix/dont add failed emitters on observer schedule

### DIFF
--- a/src/watchdog/observers/api.py
+++ b/src/watchdog/observers/api.py
@@ -298,9 +298,9 @@ class BaseObserver(EventDispatcher):
                 emitter = self._emitter_class(event_queue=self.event_queue,
                                               watch=watch,
                                               timeout=self.timeout)
-                self._add_emitter(emitter)
                 if self.is_alive():
                     emitter.start()
+                self._add_emitter(emitter)
             self._watches.add(watch)
         return watch
 

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -143,3 +143,22 @@ def test_start_failure_should_not_prevent_further_try(monkeypatch, observer):
     # Re-schduling the watch should work
     observer.schedule(None, '')
     assert len(observer.emitters) == 1
+
+
+def test_schedule_failure_should_not_prevent_future_schedules(monkeypatch, observer):
+    observer.start()
+
+    # Make the emitter fail on start(), and subsequently the observer to fail on schedule()
+    def mocked_start(emitter):
+        raise OSError()
+    monkeypatch.setattr(EventEmitter, "start", mocked_start)
+
+    with pytest.raises(OSError):
+        observer.schedule(None, '')
+    # The emitter should not be in the list
+    emitters = observer.emitters
+    assert len(emitters) == 0
+
+    # Re-schduling the watch should work
+    observer.schedule(None, '')
+    assert len(observer.emitters) == 1


### PR DESCRIPTION
If a watch is being scheduled on a started observer, and the emitter `start` functions fails for some reason, future schedules of watches on the same path will "succeed" (won't raise), but no emitter thread will be started and no events will be reported. This is because the emitter is added to the observer's context before it is being started, and isn't removed on failure (it does on `observer.start()`, but not on `observer.schedule()`).
I simply moved the line that adds the emitter to the observer's local context to after the line that starts it, so in case it raises it will be before the emitter was added to the observer context