### PR TITLE
parse auto-restart's --kill-after parameter as a float

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -8,8 +8,8 @@ Changelog
 
 2022-xx-xx • `full history <https://github.com/gorakhargosh/watchdog/compare/v2.1.7...master>`__
 
-- 
-- Thanks to our beloved contributors: @
+- [watchmedo] Fix broken parsing of ``--kill-after`` argument for the ``auto-restart`` command. (`#870 <https://github.com/gorakhargosh/watchdog/issues/870>`_)
+- Thanks to our beloved contributors: @taleinat
 
 2.1.7
 ~~~~~

--- a/src/watchdog/watchmedo.py
+++ b/src/watchdog/watchmedo.py
@@ -579,6 +579,7 @@ def shell_command(args):
           argument('--kill-after',
                    dest='kill_after',
                    default=10.0,
+                   type=float,
                    help='When stopping, kill the subprocess after the specified timeout '
                    'in seconds (default 10.0).')])
 def auto_restart(args):

--- a/tests/test_0_watchmedo.py
+++ b/tests/test_0_watchmedo.py
@@ -74,6 +74,21 @@ def test_kill_auto_restart(tmpdir, capfd):
     # assert 'KeyboardInterrupt' in cap.err
 
 
+def test_auto_restart_arg_parsing_basic():
+    args = watchmedo.cli.parse_args(["auto-restart", "-d", ".", "cmd"])
+    assert args.func is watchmedo.auto_restart
+    assert args.command == "cmd"
+    assert args.directories == ["."]
+
+
+def test_auto_restart_arg_parsing_kill_after():
+    args = watchmedo.cli.parse_args(["auto-restart", "-d", ".", "--kill-after", "12.5", "cmd"])
+    assert args.func is watchmedo.auto_restart
+    assert args.command == "cmd"
+    assert args.directories == ["."]
+    assert args.kill_after == pytest.approx(12.5)
+
+
 @pytest.mark.parametrize("command", ["tricks-from", "tricks"])
 def test_tricks_from_file(command, tmp_path):
     tricks_file = tmp_path / "tricks.yaml"


### PR DESCRIPTION
This appears to be the originally intended behavior.

Fixes #870.