### PR TITLE
Support setting output verbosity

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -13,6 +13,7 @@ Changelog
 - [watchmedo] Fix broken parsing of boolean arguments. (`#855 <https://github.com/gorakhargosh/watchdog/issues/855>`_)
 - [watchmedo] Fix broken parsing of commands from ``auto-restart``, and ``shell-command``. (`#855 <https://github.com/gorakhargosh/watchdog/issues/855>`_)
 - [inotify] Fix hang when unscheduling watch on a path in an unmounted filesystem. (`#869 <https://github.com/gorakhargosh/watchdog/pull/869>`_)
+- [watchmedo] Support setting verbosity level via ``-q/--quiet`` and ``-v/--verbose`` arguments. (`#889 <https://github.com/gorakhargosh/watchdog/pull/889>`_)
 - Thanks to our beloved contributors: @taleinat, @kianmeng, @palfrey, @IlayRosenberg, @BoboTiG
 
 2.1.7

--- a/src/watchdog/tricks/__init__.py
+++ b/src/watchdog/tricks/__init__.py
@@ -41,6 +41,8 @@ Classes
 
 """
 
+import functools
+import logging
 import os
 import signal
 import subprocess
@@ -48,6 +50,10 @@ import time
 
 from watchdog.utils import echo
 from watchdog.events import PatternMatchingEventHandler
+
+
+logger = logging.getLogger(__name__)
+echo_events = functools.partial(echo.echo, write=lambda msg: logger.info(msg))
 
 
 class Trick(PatternMatchingEventHandler):
@@ -80,19 +86,19 @@ class LoggerTrick(Trick):
     def on_any_event(self, event):
         pass
 
-    @echo.echo
+    @echo_events
     def on_modified(self, event):
         pass
 
-    @echo.echo
+    @echo_events
     def on_deleted(self, event):
         pass
 
-    @echo.echo
+    @echo_events
     def on_created(self, event):
         pass
 
-    @echo.echo
+    @echo_events
     def on_moved(self, event):
         pass
 
@@ -202,7 +208,7 @@ class AutoRestartTrick(Trick):
                     pass
         self.process = None
 
-    @echo.echo
+    @echo_events
     def on_any_event(self, event):
         self.stop()
         self.start()

--- a/src/watchdog/watchmedo.py
+++ b/src/watchdog/watchmedo.py
@@ -640,6 +640,15 @@ def auto_restart(args):
         handler.stop()
 
 
+def _get_log_level_from_args(args):
+    verbosity = sum(args.verbosity or [])
+    if verbosity < -1:
+        raise Exception("-q/--quiet may be specified only once.")
+    if verbosity > 2:
+        raise Exception("-v/--verbose may be specified up to 2 times.")
+    return ['ERROR', 'WARNING', 'INFO', 'DEBUG'][1 + verbosity]
+
+
 def main():
     """Entry-point function."""
     args = cli.parse_args()
@@ -647,16 +656,12 @@ def main():
         cli.print_help()
         return 1
 
-    verbosity = sum(args.verbosity)
-    if verbosity < -1:
-        print("Error: -q/--quiet may be specified only once.", file=sys.stderr)
+    try:
+        log_level = _get_log_level_from_args(args)
+    except Exception as exc:
+        print("Error: " + exc.args[0], file=sys.stderr)
         command_parsers[args.top_command].print_help()
         return 1
-    if verbosity > 2:
-        print("Error: -v/--verbose may be specified up to 2 times.", file=sys.stderr)
-        command_parsers[args.top_command].print_help()
-        return 1
-    log_level = ['ERROR', 'WARNING', 'INFO', 'DEBUG'][1 + verbosity]
     logging.getLogger('watchdog').setLevel(log_level)
 
     args.func(args)

--- a/src/watchdog/watchmedo.py
+++ b/src/watchdog/watchmedo.py
@@ -641,12 +641,16 @@ def auto_restart(args):
         handler.stop()
 
 
+class LogLevelException(Exception):
+    pass
+
+
 def _get_log_level_from_args(args):
     verbosity = sum(args.verbosity or [])
     if verbosity < -1:
-        raise Exception("-q/--quiet may be specified only once.")
+        raise LogLevelException("-q/--quiet may be specified only once.")
     if verbosity > 2:
-        raise Exception("-v/--verbose may be specified up to 2 times.")
+        raise LogLevelException("-v/--verbose may be specified up to 2 times.")
     return ['ERROR', 'WARNING', 'INFO', 'DEBUG'][1 + verbosity]
 
 
@@ -659,7 +663,7 @@ def main():
 
     try:
         log_level = _get_log_level_from_args(args)
-    except Exception as exc:
+    except LogLevelException as exc:
         print("Error: " + exc.args[0], file=sys.stderr)
         command_parsers[args.top_command].print_help()
         return 1

--- a/src/watchdog/watchmedo.py
+++ b/src/watchdog/watchmedo.py
@@ -96,6 +96,7 @@ def command(args=[], parent=subparsers, cmd_aliases=[]):
                                    description=desc,
                                    aliases=cmd_aliases,
                                    formatter_class=HelpFormatter)
+        command_parsers[name] = parser
         verbosity_group = parser.add_mutually_exclusive_group()
         verbosity_group.add_argument('-q', '--quiet', dest='verbosity',
                                      action='append_const', const=-1)

--- a/tests/test_0_watchmedo.py
+++ b/tests/test_0_watchmedo.py
@@ -96,6 +96,52 @@ def test_shell_command_arg_parsing():
     assert args.command == "'cmd'"
 
 
+@pytest.mark.parametrize("cmdline", [
+    ["auto-restart", "-d", ".", "cmd"],
+    ["log", "."]
+])
+@pytest.mark.parametrize("verbosity", [
+    ([], "WARNING"),
+    (["-q"], "ERROR"),
+    (["--quiet"], "ERROR"),
+    (["-v"], "INFO"),
+    (["--verbose"], "INFO"),
+    (["-vv"], "DEBUG"),
+    (["-v", "-v"], "DEBUG"),
+    (["--verbose", "-v"], "DEBUG"),
+])
+def test_valid_verbosity(cmdline, verbosity):
+    (verbosity_cmdline_args, expected_log_level) = verbosity
+    cmd = [cmdline[0], *verbosity_cmdline_args, *cmdline[1:]]
+    args = watchmedo.cli.parse_args(cmd)
+    log_level = watchmedo._get_log_level_from_args(args)
+    assert log_level == expected_log_level
+
+
+@pytest.mark.parametrize("cmdline", [
+    ["auto-restart", "-d", ".", "cmd"],
+    ["log", "."]
+])
+@pytest.mark.parametrize("verbosity_cmdline_args", [
+    ["-q", "-v"],
+    ["-v", "-q"],
+    ["-qq"],
+    ["-q", "-q"],
+    ["--quiet", "--quiet"],
+    ["--quiet", "-q"],
+    ["-vvv"],
+    ["-vvvv"],
+    ["-v", "-v", "-v"],
+    ["-vv", "-v"],
+    ["--verbose", "-vv"],
+])
+def test_invalid_verbosity(cmdline, verbosity_cmdline_args):
+    cmd = [cmdline[0], *verbosity_cmdline_args, *cmdline[1:]]
+    with pytest.raises((Exception, SystemExit)):
+        args = watchmedo.cli.parse_args(cmd)
+        watchmedo._get_log_level_from_args(args)
+
+
 @pytest.mark.parametrize("command", ["tricks-from", "tricks"])
 def test_tricks_from_file(command, tmp_path):
     tricks_file = tmp_path / "tricks.yaml"

--- a/tests/test_0_watchmedo.py
+++ b/tests/test_0_watchmedo.py
@@ -137,7 +137,7 @@ def test_valid_verbosity(cmdline, verbosity):
 ])
 def test_invalid_verbosity(cmdline, verbosity_cmdline_args):
     cmd = [cmdline[0], *verbosity_cmdline_args, *cmdline[1:]]
-    with pytest.raises((Exception, SystemExit)):
+    with pytest.raises((watchmedo.LogLevelException, SystemExit)):
         args = watchmedo.cli.parse_args(cmd)
         watchmedo._get_log_level_from_args(args)
 


### PR DESCRIPTION
This changes the internal use of echo to use a logger instead of `sys.stdout.write`.

This uses the stdlib logging library, with the common convention of `logger = logging.getLogger(__name__)`, so that all watchdog logs are under the "watchdog" logging context. This allows code using watchdog to easily change the logging level of watchdog code via e.g. `logging.getLogger("watchdog").setLevel("ERROR")`.

Finally, this adds -q/--quiet and -v/--verbose command line options to watchmedo.

Fixes #594.

P.S. This also makes watchmedo exit with a nonzero return code when a command is not provided or when -v or -q are supplied too many times.