### PR TITLE
Check top_command instead of command in watchmedo.main()

### DIFF
--- a/src/watchdog/watchmedo.py
+++ b/src/watchdog/watchmedo.py
@@ -635,7 +635,7 @@ def auto_restart(args):
 def main():
     """Entry-point function."""
     args = cli.parse_args()
-    if args.command is None:
+    if args.top_command is None:
         cli.print_help()
     else:
         args.func(args)


### PR DESCRIPTION
This is a small fix following the recent merge of PR #888.