### PR TITLE
Fix flakey watch deletion test for FSEvents

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -8,8 +8,8 @@ Unreleased
 
 2022-xx-xx • `full history <https://github.com/gorakhargosh/watchdog/compare/v2.1.8...HEAD>`__
 
-- 
-- Thanks to our beloved contributors: @
+- [fsevents] Fix flakey test to assert that there are no errors when stopping the emitter.
+- Thanks to our beloved contributors: @samschott
 
 2.1.8
 ~~~~~

--- a/tests/test_fsevents.py
+++ b/tests/test_fsevents.py
@@ -169,19 +169,20 @@ def test_watcher_deletion_while_receiving_events_2(caplog):
         th2 = Thread(target=stop, args=(emitter,))
 
         try:
-            with caplog.at_level(logging.ERROR):
-                th1.start()
-                th2.start()
-                th1.join()
-                th2.join()
-                assert not caplog.records
+            th1.start()
+            th2.start()
+            th1.join()
+            th2.join()
         finally:
             emitter.stop()
 
     # 20 attempts to make the random failure happen
-    for _ in range(20):
-        try_to_fail()
-        sleep(random())
+    with caplog.at_level(logging.ERROR):
+        for _ in range(20):
+            try_to_fail()
+            sleep(random())
+
+        assert not caplog.records
 
 
 def test_remove_watch_twice():


### PR DESCRIPTION
Fixes the occasional failures of `tests/test_fsevents.py::test_watcher_deletion_while_receiving_events_2`.

The test would fail not because of error messages in the captured log output (what it's aiming to test) but rather due to DEBUG messages in the log output despite the log level being set to ERROR. This is because file system events are logged at DEBUG and make enter the log after exiting the `caplog` context from the previous run and before entering the context in the next run.

This PR fixes this by staying in the `caplog` context with level ERROR throughout the test.

