### PR TITLE
Run flake8 only once in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,21 @@ on:
       - "tests/*.py"
 
 jobs:
+  lint:
+    name: Linting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.7"
+      - name: Install test dependencies
+        run: python -m pip install tox
+      - name: Run flake8
+        run: |
+          tox -e flake8
+
   tests:
     name: Run tests for ${{ matrix.os }} for ${{ matrix.python }}
     runs-on: ${{ matrix.os }}

--- a/tox.ini
+++ b/tox.ini
@@ -7,5 +7,11 @@ usedevelop = true
 deps =
     -r requirements-tests.txt
 commands =
-    python -m flake8 docs tools src tests
     python -bb -m pytest {posargs}
+
+[testenv:flake8]
+usedevelop = true
+deps =
+    -r requirements-tests.txt
+commands =
+    python -m flake8 docs tools src tests


### PR DESCRIPTION
This PR moves linting (flake8) to a separate tox environment that is run independently in CI. This prevents us from running flake8 18 times in CI when once is sufficient.