### PR TITLE
make auto-restart restart the sub-process if it terminates

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -9,7 +9,8 @@ Unreleased
 2022-xx-xx • `full history <https://github.com/gorakhargosh/watchdog/compare/v2.1.8...HEAD>`__
 
 - [fsevents] Fix flakey test to assert that there are no errors when stopping the emitter.
-- Thanks to our beloved contributors: @samschott
+- [watchmedo] Make auto-restart restart the sub-process if it terminates. (`#896 <https://github.com/gorakhargosh/watchdog/pull/896>`__)
+- Thanks to our beloved contributors: @samschott, @taleinat
 
 2.1.8
 ~~~~~

--- a/src/watchdog/utils/process_watcher.py
+++ b/src/watchdog/utils/process_watcher.py
@@ -1,0 +1,27 @@
+import logging
+import time
+
+from watchdog.utils import BaseThread
+
+
+logger = logging.getLogger(__name__)
+
+
+class ProcessWatcher(BaseThread):
+    def __init__(self, popen_obj, process_termination_callback):
+        super().__init__()
+        self.popen_obj = popen_obj
+        self.process_termination_callback = process_termination_callback
+
+    def run(self):
+        while True:
+            if self.stopped_event.is_set():
+                return
+            if self.popen_obj.poll() is not None:
+                break
+            time.sleep(0.1)
+
+        try:
+            self.process_termination_callback()
+        except Exception:
+            logger.exception("Error calling process termination callback")

--- a/tests/test_0_watchmedo.py
+++ b/tests/test_0_watchmedo.py
@@ -74,6 +74,19 @@ def test_kill_auto_restart(tmpdir, capfd):
     # assert 'KeyboardInterrupt' in cap.err
 
 
+def test_auto_restart_subprocess_termination(tmpdir, capfd):
+    from watchdog.tricks import AutoRestartTrick
+    import sys
+    import time
+    script = make_dummy_script(tmpdir, n=2)
+    a = AutoRestartTrick([sys.executable, script])
+    a.start()
+    time.sleep(5)
+    a.stop()
+    cap = capfd.readouterr()
+    assert cap.out.splitlines(keepends=False).count('+++++ 0') > 1
+
+
 def test_auto_restart_arg_parsing_basic():
     args = watchmedo.cli.parse_args(["auto-restart", "-d", ".", "--recursive", "--debug-force-polling", "cmd"])
     assert args.func is watchmedo.auto_restart


### PR DESCRIPTION
Currently, when running `watchmedo auto-restart ...`, if the sub-process terminates, it is left as a zombie process and watchmedo continues running and waiting for filesystem events.

With this PR, the sub-process will be monitored for termination, and restarted if it terminates.

Alternatively, we could make this exit upon sub-process termination, possibly with a flag to choose between the two behaviours.

This is related to issue #405.