### PR TITLE
Add `setup.py` to flake8 testing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -152,4 +152,4 @@ setup(name="watchdog",
       ]},
       python_requires='>=3.6',
       zip_safe=False
-)
+      )

--- a/tox.ini
+++ b/tox.ini
@@ -14,4 +14,4 @@ usedevelop = true
 deps =
     -r requirements-tests.txt
 commands =
-    python -m flake8 docs tools src tests
+    python -m flake8 docs tools src tests setup.py


### PR DESCRIPTION
This is a very minor change to include `setup.py` in flake8 linting.

flake8 only reported a single error, and this is now fixed.