### PR TITLE
docs: fix simple typo, schduling -> scheduling

### DIFF
--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -137,7 +137,7 @@ def test_start_failure_should_not_prevent_further_try(observer):
     observer.start()
     assert len(observer.emitters) == 0
 
-    # Re-schduling the watch should work
+    # Re-scheduling the watch should work
     observer.schedule(None, '')
     assert len(observer.emitters) == 1
 


### PR DESCRIPTION
There is a small typo in tests/test_observer.py.

Should read `scheduling` rather than `schduling`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md