### PR TITLE
Add SIGHUP termination signal to watchmedo

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -10,7 +10,8 @@ Changelog
 
 - [documentation] HTML documentation builds are now tested for errors.
 - [fsevents2] The fsevents2 observer is now deprecated.
-- Thanks to our beloved contributors: @kurtmckee
+- [watchmedo] Handle shutdown events from ``SIGHUP`` (`#912 <https://github.com/gorakhargosh/watchdog/pull/912>`__)
+- Thanks to our beloved contributors: @kurtmckee @babymastodon
 
 2.1.9
 ~~~~~

--- a/src/watchdog/watchmedo.py
+++ b/src/watchdog/watchmedo.py
@@ -610,7 +610,7 @@ def auto_restart(args):
 
     # Handle termination signals by raising a semantic exception which will
     # allow us to gracefully unwind and stop the observer
-    termination_signals = {signal.SIGTERM, signal.SIGINT}
+    termination_signals = {signal.SIGTERM, signal.SIGINT, signal.SIGHUP}
 
     def handler_termination_signal(_signum, _frame):
         # Neuter all signals so that we don't attempt a double shutdown


### PR DESCRIPTION
This PR registers SIGHUP as a termination signal for watchmedo. This is important for people who use watchmedo within terminal multiplexers such as tmux, as tmux causes all shells to send the SIGHUP signal when the session is closed. Since watchmedo ignores the SIGHUP handler, this causes the watchmedo process to continue running in the background, even though the shell running within tmux has been terminated.

As a workaround, I am working on writing a bash script that will convert the SIGHUP into a SIGINT before forwarding to watchmedo. However, I think it would be more intuitive for users if `watchmedo` would gracefully shut down when receiving SIGHUP in the first place.