### PR TITLE
Remove unnecessary code of dirsnapshot.py

### DIFF
--- a/src/watchdog/utils/dirsnapshot.py
+++ b/src/watchdog/utils/dirsnapshot.py
@@ -255,8 +255,7 @@ class DirectorySnapshot:
 
     def walk(self, root):
         try:
-            paths = [os.path.join(root, entry if isinstance(entry, str) else entry.name)
-                     for entry in self.listdir(root)]
+            paths = [os.path.join(root, entry.name) for entry in self.listdir(root)]
         except OSError as e:
             # Directory may have been deleted between finding it in the directory
             # list of its parent and trying to delete its contents. If this

--- a/tests/test_snapshot_diff.py
+++ b/tests/test_snapshot_diff.py
@@ -130,7 +130,7 @@ def test_replace_dir_with_file(p):
         if path == p("root", "dir"):
             rm(path, recursive=True)
             touch(path)
-        return os.listdir(path)
+        return os.scandir(path)
 
     mkdir(p('root'))
     mkdir(p('root', 'dir'))


### PR DESCRIPTION
`if isinstance(entry, str)`  is used to distinguish `listdir` from `scandir`. Now `scandir` is used by default, we can delete this code.
