### PR TITLE
Add optional event debouncing for auto-restart

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -8,8 +8,8 @@ Changelog
 
 2023-xx-xx • `full history <https://github.com/gorakhargosh/watchdog/compare/v2.2.1...HEAD>`__
 
-- 
-- Thanks to our beloved contributors: @BoboTiG
+- [watchmedo] Add optional event debouncing for ``auto-restart``, only restarting once if many events happen in quick succession (`#940 <https://github.com/gorakhargosh/watchdog/pull/940>`__)
+- Thanks to our beloved contributors: @BoboTiG, @taleinat
 
 2.2.1
 ~~~~~

--- a/src/watchdog/tricks/__init__.py
+++ b/src/watchdog/tricks/__init__.py
@@ -180,14 +180,14 @@ class AutoRestartTrick(Trick):
     def __init__(self, command, patterns=None, ignore_patterns=None,
                  ignore_directories=False, stop_signal=signal.SIGINT,
                  kill_after=10, debounce_interval_seconds=0):
-        super().__init__(
-            patterns=patterns, ignore_patterns=ignore_patterns,
-            ignore_directories=ignore_directories)
-
         if kill_after < 0:
             raise ValueError("kill_after must be non-negative.")
         if debounce_interval_seconds < 0:
             raise ValueError("debounce_interval_seconds must be non-negative.")
+
+        super().__init__(
+            patterns=patterns, ignore_patterns=ignore_patterns,
+            ignore_directories=ignore_directories)
 
         self.command = command
         self.stop_signal = stop_signal

--- a/src/watchdog/tricks/__init__.py
+++ b/src/watchdog/tricks/__init__.py
@@ -197,6 +197,7 @@ class AutoRestartTrick(Trick):
         self.process = None
         self.process_watcher = None
         self.event_debouncer = None
+        self.restart_count = 0
 
         self._is_process_stopping = False
         self._is_trick_stopping = False
@@ -274,6 +275,7 @@ class AutoRestartTrick(Trick):
             return
         self._stop_process()
         self._start_process()
+        self.restart_count += 1
 
 
 if hasattr(os, 'getpgid') and hasattr(os, 'killpg'):

--- a/src/watchdog/tricks/__init__.py
+++ b/src/watchdog/tricks/__init__.py
@@ -205,7 +205,10 @@ class AutoRestartTrick(Trick):
 
     def start(self):
         if self.debounce_interval_seconds:
-            self.event_debouncer = EventDebouncer(self.debounce_interval_seconds, lambda events: self._restart_process())
+            self.event_debouncer = EventDebouncer(
+                debounce_interval_seconds=self.debounce_interval_seconds,
+                events_callback=lambda events: self._restart_process(),
+            )
             self.event_debouncer.start()
         self._start_process()
 

--- a/src/watchdog/utils/event_debouncer.py
+++ b/src/watchdog/utils/event_debouncer.py
@@ -1,0 +1,47 @@
+import logging
+import queue
+
+from watchdog.utils import BaseThread
+
+
+logger = logging.getLogger(__name__)
+
+
+class EventDebouncer(BaseThread):
+    """Background thread for debouncing event handling.
+
+    When an event is received, wait until the configured debounce interval
+    passes before calling the callback.  If additional events are received
+    before the interval passes, reset the timer and keep waiting.  When the
+    debouncing interval passes, the callback will be called with a list of
+    events in the order in which they were received.
+    """
+    def __init__(self, debounce_interval_seconds, events_callback):
+        super().__init__()
+        self.debounce_interval_seconds = debounce_interval_seconds
+        self.events_callback = events_callback
+
+        self._event_queue = queue.Queue()
+
+    def handle_event(self, event):
+        self._event_queue.put(event)
+
+    def run(self):
+        while self.should_keep_running():
+            events = []
+
+            # Get first event.
+            try:
+                events.append(self._event_queue.get(timeout=0.2))
+            except queue.Empty:
+                continue
+
+            if self.debounce_interval_seconds:
+                # Collect additional events until the debounce interval passes.
+                while self.should_keep_running():
+                    try:
+                        events.append(self._event_queue.get(timeout=self.debounce_interval_seconds))
+                    except queue.Empty:
+                        break
+
+            self.events_callback(events)

--- a/src/watchdog/watchmedo.py
+++ b/src/watchdog/watchmedo.py
@@ -585,7 +585,13 @@ def shell_command(args):
                    default=10.0,
                    type=float,
                    help='When stopping, kill the subprocess after the specified timeout '
-                   'in seconds (default 10.0).')])
+                   'in seconds (default 10.0).'),
+          argument('--debounce-interval',
+                   dest='debounce_interval',
+                   default=0.0,
+                   type=float,
+                   help='After a file change, Wait until the specified interval (in '
+                   'seconds) passes with no file changes, and only then restart.')])
 def auto_restart(args):
     """
     Command to start a long-running subprocess and restart it on matched events.
@@ -633,7 +639,8 @@ def auto_restart(args):
                                ignore_patterns=ignore_patterns,
                                ignore_directories=args.ignore_directories,
                                stop_signal=stop_signal,
-                               kill_after=args.kill_after)
+                               kill_after=args.kill_after,
+                               debounce_interval_seconds=args.debounce_interval)
     handler.start()
     observer = Observer(timeout=args.timeout)
     try:

--- a/tests/test_0_watchmedo.py
+++ b/tests/test_0_watchmedo.py
@@ -106,6 +106,21 @@ def test_shell_command_subprocess_termination_nowait(tmpdir):
     assert not trick.is_process_running()
 
 
+def test_auto_restart_on_file_change(tmpdir, capfd):
+    from watchdog.tricks import AutoRestartTrick
+    import sys
+    import time
+    script = make_dummy_script(tmpdir, n=2)
+    trick = AutoRestartTrick([sys.executable, script])
+    trick.start()
+    time.sleep(1)
+    trick.on_any_event("foo/bar.baz")
+    time.sleep(1)
+    trick.stop()
+    cap = capfd.readouterr()
+    assert cap.out.splitlines(keepends=False).count('+++++ 0') == 2
+
+
 def test_auto_restart_subprocess_termination(tmpdir, capfd):
     from watchdog.tricks import AutoRestartTrick
     import sys

--- a/tests/test_0_watchmedo.py
+++ b/tests/test_0_watchmedo.py
@@ -107,6 +107,10 @@ def test_shell_command_subprocess_termination_nowait(tmpdir):
 
 
 def test_auto_restart_on_file_change(tmpdir, capfd):
+    """Simulate changing 3 files.
+
+    Expect 3 restarts.
+    """
     from watchdog.tricks import AutoRestartTrick
     import sys
     import time
@@ -125,6 +129,10 @@ def test_auto_restart_on_file_change(tmpdir, capfd):
 
 
 def test_auto_restart_on_file_change_debounce(tmpdir, capfd):
+    """Simulate changing 3 files quickly and then another change later.
+
+    Expect 2 restarts due to debouncing.
+    """
     from watchdog.tricks import AutoRestartTrick
     import sys
     import time
@@ -145,6 +153,10 @@ def test_auto_restart_on_file_change_debounce(tmpdir, capfd):
 
 
 def test_auto_restart_subprocess_termination(tmpdir, capfd):
+    """Run auto-restart with a script that terminates in about 2 seconds.
+
+    After 5 seconds, expect it to have been restarted at least once.
+    """
     from watchdog.tricks import AutoRestartTrick
     import sys
     import time

--- a/tests/test_0_watchmedo.py
+++ b/tests/test_0_watchmedo.py
@@ -121,6 +121,7 @@ def test_auto_restart_on_file_change(tmpdir, capfd):
     trick.stop()
     cap = capfd.readouterr()
     assert cap.out.splitlines(keepends=False).count('+++++ 0') >= 2
+    assert trick.restart_count == 3
 
 
 def test_auto_restart_on_file_change_debounce(tmpdir, capfd):
@@ -148,12 +149,13 @@ def test_auto_restart_subprocess_termination(tmpdir, capfd):
     import sys
     import time
     script = make_dummy_script(tmpdir, n=2)
-    a = AutoRestartTrick([sys.executable, script])
-    a.start()
+    trick = AutoRestartTrick([sys.executable, script])
+    trick.start()
     time.sleep(5)
-    a.stop()
+    trick.stop()
     cap = capfd.readouterr()
     assert cap.out.splitlines(keepends=False).count('+++++ 0') > 1
+    assert trick.restart_count >= 1
 
 
 def test_auto_restart_arg_parsing_basic():

--- a/tests/test_0_watchmedo.py
+++ b/tests/test_0_watchmedo.py
@@ -150,6 +150,7 @@ def test_auto_restart_on_file_change_debounce(tmpdir, capfd):
     trick.stop()
     cap = capfd.readouterr()
     assert cap.out.splitlines(keepends=False).count('+++++ 0') == 3
+    assert trick.restart_count == 2
 
 
 def test_auto_restart_subprocess_termination(tmpdir, capfd):

--- a/tests/test_0_watchmedo.py
+++ b/tests/test_0_watchmedo.py
@@ -166,7 +166,9 @@ def test_auto_restart_arg_parsing_basic():
 
 
 def test_auto_restart_arg_parsing():
-    args = watchmedo.cli.parse_args(["auto-restart", "-d", ".", "--kill-after", "12.5", "--debounce-interval=0.2", "cmd"])
+    args = watchmedo.cli.parse_args(
+        ["auto-restart", "-d", ".", "--kill-after", "12.5", "--debounce-interval=0.2", "cmd"]
+    )
     assert args.func is watchmedo.auto_restart
     assert args.command == "cmd"
     assert args.directories == ["."]


### PR DESCRIPTION
If a debounce interval is specified, upon receiving events, collect events until the interval passes with no incoming events, and only then trigger a restart.

Closes #542.

Note to reviewers: The more involved start and stop mechanisms in AutoRestartTrick are needed to avoid restarting the debouncer when restart the process, and to ensure that the debouncer is properly stopped when stopping the trick.