### PR TITLE
Add FileOpenedEvent

### DIFF
--- a/src/watchdog/events.py
+++ b/src/watchdog/events.py
@@ -56,6 +56,10 @@ Event Classes
    :members:
    :show-inheritance:
 
+.. autoclass:: FileOpenedEvent
+   :members:
+   :show-inheritance:
+
 .. autoclass:: DirCreatedEvent
    :members:
    :show-inheritance:
@@ -100,6 +104,7 @@ EVENT_TYPE_DELETED = 'deleted'
 EVENT_TYPE_CREATED = 'created'
 EVENT_TYPE_MODIFIED = 'modified'
 EVENT_TYPE_CLOSED = 'closed'
+EVENT_TYPE_OPENED = 'opened'
 
 
 class FileSystemEvent:
@@ -223,6 +228,12 @@ class FileClosedEvent(FileSystemEvent):
     event_type = EVENT_TYPE_CLOSED
 
 
+class FileOpenedEvent(FileSystemEvent):
+    """File system event representing file close on the file system."""
+
+    event_type = EVENT_TYPE_OPENED
+
+
 # Directory events.
 
 
@@ -275,6 +286,7 @@ class FileSystemEventHandler:
             EVENT_TYPE_MODIFIED: self.on_modified,
             EVENT_TYPE_MOVED: self.on_moved,
             EVENT_TYPE_CLOSED: self.on_closed,
+            EVENT_TYPE_OPENED: self.on_opened,
         }[event.event_type](event)
 
     def on_any_event(self, event):
@@ -329,6 +341,15 @@ class FileSystemEventHandler:
             Event representing file closing.
         :type event:
             :class:`FileClosedEvent`
+        """
+
+    def on_opened(self, event):
+        """Called when a file is opened.
+
+        :param event:
+            Event representing file opening.
+        :type event:
+            :class:`FileOpenedEvent`
         """
 
 

--- a/src/watchdog/observers/inotify.py
+++ b/src/watchdog/observers/inotify.py
@@ -87,6 +87,7 @@ from watchdog.events import (
     FileMovedEvent,
     FileCreatedEvent,
     FileClosedEvent,
+    FileOpenedEvent,
     generate_sub_moved_events,
     generate_sub_created_events,
 )
@@ -176,6 +177,9 @@ class InotifyEmitter(EventEmitter):
                 cls = FileClosedEvent
                 self.queue_event(cls(src_path))
                 self.queue_event(DirModifiedEvent(os.path.dirname(src_path)))
+            elif event.is_open and not event.is_directory:
+                cls = FileOpenedEvent
+                self.queue_event(cls(src_path))
             # elif event.is_close_nowrite and not event.is_directory:
             #     cls = FileClosedEvent
             #     self.queue_event(cls(src_path))

--- a/src/watchdog/observers/inotify_c.py
+++ b/src/watchdog/observers/inotify_c.py
@@ -108,6 +108,7 @@ WATCHDOG_ALL_EVENTS = reduce(
         InotifyConstants.IN_DELETE_SELF,
         InotifyConstants.IN_DONT_FOLLOW,
         InotifyConstants.IN_CLOSE_WRITE,
+        InotifyConstants.IN_OPEN,
     ])
 
 
@@ -485,6 +486,10 @@ class InotifyEvent:
     @property
     def is_close_nowrite(self):
         return self._mask & InotifyConstants.IN_CLOSE_NOWRITE > 0
+
+    @property
+    def is_open(self):
+        return self._mask & InotifyConstants.IN_OPEN > 0
 
     @property
     def is_access(self):

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -20,6 +20,7 @@ from watchdog.events import (
     FileModifiedEvent,
     FileCreatedEvent,
     FileClosedEvent,
+    FileOpenedEvent,
     DirDeletedEvent,
     DirModifiedEvent,
     DirCreatedEvent,
@@ -31,6 +32,7 @@ from watchdog.events import (
     EVENT_TYPE_DELETED,
     EVENT_TYPE_MOVED,
     EVENT_TYPE_CLOSED,
+    EVENT_TYPE_OPENED,
 )
 
 path_1 = '/path/xyz'
@@ -92,6 +94,14 @@ def test_file_closed_event():
     assert not event.is_synthetic
 
 
+def test_file_opened_event():
+    event = FileOpenedEvent(path_1)
+    assert path_1 == event.src_path
+    assert EVENT_TYPE_OPENED == event.event_type
+    assert not event.is_directory
+    assert not event.is_synthetic
+
+
 def test_dir_deleted_event():
     event = DirDeletedEvent(path_1)
     assert path_1 == event.src_path
@@ -122,6 +132,7 @@ def test_file_system_event_handler_dispatch():
     dir_cre_event = DirCreatedEvent('/path/blah.py')
     file_cre_event = FileCreatedEvent('/path/blah.txt')
     file_cls_event = FileClosedEvent('/path/blah.txt')
+    file_opened_event = FileOpenedEvent('/path/blah.txt')
     dir_mod_event = DirModifiedEvent('/path/blah.py')
     file_mod_event = FileModifiedEvent('/path/blah.txt')
     dir_mov_event = DirMovedEvent('/path/blah.py', '/path/blah')
@@ -158,6 +169,9 @@ def test_file_system_event_handler_dispatch():
 
         def on_closed(self, event):
             assert event.event_type == EVENT_TYPE_CLOSED
+
+        def on_opened(self, event):
+            assert event.event_type == EVENT_TYPE_OPENED
 
     handler = TestableEventHandler()
 


### PR DESCRIPTION
As per https://github.com/gorakhargosh/watchdog/issues/901 , this adds support to detect file open events on supported OSes.

I have tested this in Linux using Python 3.7 and Python 3.11. I could use help testing it on other OSes, in particular, changes may be needed in order to fail gracefully on OSes where FileOpenEvents are not supported.