### PR TITLE
[watchmedo] Exit gracefully on KeyboardInterrupt Exception (Ctrl+C)

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -10,6 +10,7 @@ Changelog
 
 - [inotify] Add support for ``IN_OPEN`` events: a ``FileOpenedEvent`` event will be fired. (`#941 <https://github.com/gorakhargosh/watchdog/pull/941>`__)
 - [watchmedo] Add optional event debouncing for ``auto-restart``, only restarting once if many events happen in quick succession (`#940 <https://github.com/gorakhargosh/watchdog/pull/940>`__)
+- [watchmedo] Exit gracefully on ``KeyboardInterrupt`` exception (Ctrl+C) (`#945 <https://github.com/gorakhargosh/watchdog/pull/945>`__)
 - Thanks to our beloved contributors: @BoboTiG, @dstaple, @taleinat
 
 2.2.1

--- a/src/watchdog/watchmedo.py
+++ b/src/watchdog/watchmedo.py
@@ -679,7 +679,11 @@ def main():
         return 1
     logging.getLogger('watchdog').setLevel(log_level)
 
-    args.func(args)
+    try:
+        args.func(args)
+    except KeyboardInterrupt:
+        return 130
+
     return 0
 
 


### PR DESCRIPTION
This change solves response of `watchmedo` on user's command termination from terminal using Ctrl+C keystroke.
Before:
```bash
$ /Users/user1/Library/Python/3.9/bin/watchmedo shell-command
^CTraceback (most recent call last):
  File "/Users/user1/Library/Python/3.9/bin/watchmedo", line 8, in <module>
    sys.exit(main())
  File "/Users/user1/Library/Python/3.9/lib/python/site-packages/watchdog/watchmedo.py", line 675, in main
    args.func(args)
  File "/Users/user1/Library/Python/3.9/lib/python/site-packages/watchdog/watchmedo.py", line 526, in shell_command
    observe_with(observer, handler, args.directories, args.recursive)
  File "/Users/user1/Library/Python/3.9/lib/python/site-packages/watchdog/watchmedo.py", line 183, in observe_with
    time.sleep(1)
KeyboardInterrupt
```

After proposed change:
```bash
$ /Users/user1/Library/Python/3.9/bin/watchmedo shell-command
^C
```
Returns [exit status code](https://tldp.org/LDP/abs/html/exitcodes.html) No. 130