### PR TITLE
[watchmedo] Add option to not auto-restart the command after it exits.

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -11,6 +11,7 @@ Changelog
 - [inotify] Add support for ``IN_OPEN`` events: a ``FileOpenedEvent`` event will be fired. (`#941 <https://github.com/gorakhargosh/watchdog/pull/941>`__)
 - [watchmedo] Add optional event debouncing for ``auto-restart``, only restarting once if many events happen in quick succession (`#940 <https://github.com/gorakhargosh/watchdog/pull/940>`__)
 - [watchmedo] Exit gracefully on ``KeyboardInterrupt`` exception (Ctrl+C) (`#945 <https://github.com/gorakhargosh/watchdog/pull/945>`__)
+- [watchmedo] Add option to not auto-restart the command after it exits. (`#946 <https://github.com/gorakhargosh/watchdog/pull/946>`__)
 - Thanks to our beloved contributors: @BoboTiG, @dstaple, @taleinat
 
 2.2.1

--- a/src/watchdog/watchmedo.py
+++ b/src/watchdog/watchmedo.py
@@ -591,7 +591,12 @@ def shell_command(args):
                    default=0.0,
                    type=float,
                    help='After a file change, Wait until the specified interval (in '
-                   'seconds) passes with no file changes, and only then restart.')])
+                   'seconds) passes with no file changes, and only then restart.'),
+          argument('--no-restart-on-command-exit',
+                   dest='restart_on_command_exit',
+                   default=True,
+                   action='store_false',
+                   help="Don't auto-restart the command after it exits.")])
 def auto_restart(args):
     """
     Command to start a long-running subprocess and restart it on matched events.
@@ -640,7 +645,8 @@ def auto_restart(args):
                                ignore_directories=args.ignore_directories,
                                stop_signal=stop_signal,
                                kill_after=args.kill_after,
-                               debounce_interval_seconds=args.debounce_interval)
+                               debounce_interval_seconds=args.debounce_interval,
+                               restart_on_command_exit=args.restart_on_command_exit)
     handler.start()
     observer = Observer(timeout=args.timeout)
     try:


### PR DESCRIPTION
This adds a new `restart_on_command_exit` argument to `AutoRestartTrick`, and a new `--no-restart-on-command-exit` flag to `watchmedo aut-restart`.

Both the CLI and the trick still default to restarting the command if it exits.

Closes #922.