### PR TITLE
git-ignore `.venv/` virtual environment directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ include/
 lib/
 /bootstrap.py
 venv/
+.venv/


### PR DESCRIPTION
Exactly what it says on the tin. This aligns with the shell scripts that create and activate virtual environments on my system.