### PR TITLE
Fix Python 3.6 in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,13 +37,21 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python:
-          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
           - "pypy-3.7"
+        include:
+          # Python 3.6 is unavailable on ubuntu-latest.
+          # It must be included manually for each OS.
+          - os: ubuntu-20.04
+            python: "3.6"
+          - os: windows-latest
+            python: "3.6"
+          - os: macos-latest
+            python: "3.6"
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Python 3.6 is no longer available on the ubuntu-latest runner, which has updated to Ubuntu 22.04.

To fix this, it cannot appear in the default matrix but can be added manually for each runner that supports it: ubuntu-20.04, windows-latest, and macos-latest.

_Note: This allows Python 3.6 to run and pass. Other Python versions are able to run when #952 merges._