### PR TITLE
Use Tox to specify the `[watchmedo]` extra

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,4 +1,3 @@
--e ".[watchmedo]"
 eventlet
 flake8
 flaky

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ skip_missing_interpreters = True
 usedevelop = true
 deps =
     -r requirements-tests.txt
+extras =
+    watchmedo
 commands =
     python -bb -m pytest {posargs}
 
@@ -13,6 +15,8 @@ commands =
 usedevelop = true
 deps =
     -r requirements-tests.txt
+extras =
+    watchmedo
 commands =
     python -m flake8 docs tools src tests setup.py
 
@@ -20,5 +24,7 @@ commands =
 usedevelop = true
 deps =
     -r requirements-tests.txt
+extras =
+    watchmedo
 commands =
     sphinx-build -aEWb html docs/source docs/build/html


### PR DESCRIPTION
Windows runners for Python 3.7 through 3.9 cannot handle the `-e .[watchmedo]` line in `requirements-tests.txt`.

This is resolved by migrating that requirement to the Tox configuration.

_Note: This allows all Python versions except Python 3.6 on Ubuntu to run (not all pass yet). Python 3.6 support is addressed in #951._