### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel
         env:
-          CIBW_SKIP: "cp27-* cp35-* pp27-*" # skip 2.7 and 3.5 wheels
+          CIBW_SKIP: "cp36-*" # skip 3.6 wheels
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,15 +45,6 @@ jobs:
           - "3.10"
           - "3.11"
           - "pypy-3.7"
-        include:
-          # Python 3.6 is unavailable on ubuntu-latest.
-          # It must be included manually for each OS.
-          - os: ubuntu-20.04
-            python: "3.6"
-          - os: windows-latest
-            python: "3.6"
-          - os: macos-latest
-            python: "3.6"
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ Watchdog
 
 Python API and shell utilities to monitor file system events.
 
-Works on 3.6+.
+Works on 3.7+.
 
 Example API Usage
 -----------------
@@ -233,7 +233,7 @@ appropriate observer like in the example above, do::
 Dependencies
 ------------
 
-1. Python 3.6 or above.
+1. Python 3.7 or above.
 2. XCode_ (only on macOS when installing from sources)
 3. PyYAML_ (only for ``watchmedo``)
 

--- a/changelog.rst
+++ b/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 
 2023-xx-xx • `full history <https://github.com/gorakhargosh/watchdog/compare/v2.3.1...HEAD>`__
 
+- Drop support for Python 3.6.
 - [testing] watchdog is now PEP 561 compatible and is tested by mypy.
 - Thanks to our beloved contributors: @kurtmckee
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,11 +11,7 @@ Watchdog
 
 Python API library and shell utilities to monitor file system events.
 
-Works on 3.6+.
-
-If you want to use Python 2.6, you should stick with watchdog < 0.10.0.
-
-If you want to use Python 2.7, 3.4 or 3.5, you should stick with watchdog < 1.0.0.
+Works on 3.7+.
 
 Directory monitoring made easy with
 -----------------------------------

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -4,7 +4,7 @@
 
 Installation
 ============
-|project_name| requires 3.6+ to work. See a list of :ref:`installation-dependencies`.
+|project_name| requires 3.7+ to work. See a list of :ref:`installation-dependencies`.
 
 Installing from PyPI using pip
 ------------------------------

--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -155,6 +154,6 @@ setup(
             "watchmedo = watchdog.watchmedo:main [watchmedo]",
         ]
     },
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     zip_safe=False,
 )


### PR DESCRIPTION
This also modifies the CI job that builds macOS wheels. Its previous configuration blocked building of wheels for Python 2.7 and Python 3.5, which are not supported by the `cibuildwheel` package. The configuration is modified to block building of Python 3.6 wheels.

This exclusion may not be necessary because watchdog's `setup.py` states that it requires Python 3.7+, but it is included to avoid learning `cibuildwheel` in the scope of this PR.

This also drops notes in the README that document which unsupported versions of watchdog work with which unsupported versions of Python.