### PR TITLE
Move mypy test dependencies to the tox config

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -5,6 +5,3 @@ pytest
 pytest-cov
 pytest-timeout
 sphinx
-# mypy testing
-mypy
-types-PyYAML

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,8 @@ commands =
 [testenv:mypy]
 usedevelop = true
 deps =
-    -r requirements-tests.txt
+    mypy
+    pytest
+    types-PyYAML
 commands =
     mypy tools src tests


### PR DESCRIPTION
This is required for PyPy 3.7 in CI.
mypy depends on typed-ast on Python 3.7,
but typed-ast is not compatible with PyPy.

Moving the mypy dependency avoids this incompatibility.

With this change, it appears all test environments are able to _run_. Not all are able to _pass_ yet.