### PR TITLE
drop pull_request: paths: constraints

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -20,9 +20,8 @@ on:
     branches:
       - master
   pull_request:
-    paths:
-      - ".github/workflows/build-and-publish.yml"
-      - "setup.*"
+    branches:
+      - '**'
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,13 +5,8 @@ on:
     branches:
       - master
   pull_request:
-    paths:
-      - ".github/workflows/tests.yml"
-      - "requirements-tests.txt"
-      - "setup.*"
-      - "src/**/*"
-      - "tests/*.py"
-      - "docs/**/*"
+    branches:
+      - '**'
 
 jobs:
   lint:


### PR DESCRIPTION
This is open to much opinion.  I find it a hassle to maintain and also risky.  For example, `tests.yml` uses tox and thus `tox.ini` but as is editing that file wouldn't trigger a run.  Let me know how you feel about this.
