### PR TITLE
use a single test/lint/hint/doc matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,16 +15,26 @@ on:
 
 jobs:
   tox:
-    name: ${{ matrix.tox.name }} ${{ matrix.os.name }} ${{ matrix.python }}
+    name: ${{ matrix.tox.name }} ${{ matrix.os.emoji }} ${{ matrix.os.name }} ${{ matrix.python }}
     runs-on: ${{ matrix.os.runs-on }}
     strategy:
       fail-fast: false
       matrix:
         tox:
-          - name: mypy
-            environment: mypy
           - name: Test
             environment: py
+          - name: mypy
+            environment: mypy
+        os:
+          - name: Linux
+            emoji: 🐧
+            runs-on: [ubuntu-latest]
+          - name: macOS
+            emoji: 🍎
+            runs-on: [macos-latest]
+          - name: Windows
+            emoji: 🪟
+            runs-on: [windows-latest]
         python:
           - "3.7"
           - "3.8"
@@ -33,13 +43,6 @@ jobs:
           - "3.11"
           - "pypy-3.8"
           - "pypy-3.9"
-        os:
-          - name: Linux
-            runs-on: [ubuntu-latest]
-          - name: macOS
-            runs-on: [macos-latest]
-          - name: Windows
-            runs-on: [windows-latest]
         include:
           - tox:
               name: Flake8

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,7 @@ jobs:
             python: "3.11"
             os:
               name: Linux
+              emoji: 🐧
               runs-on: [ubuntu-latest]
           - tox:
               name: Docs
@@ -57,6 +58,7 @@ jobs:
             python: "3.11"
             os:
               name: Linux
+              emoji: 🐧
               runs-on: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,30 +14,17 @@ on:
       - "docs/**/*"
 
 jobs:
-  lint:
-    name: Linting
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
-      - name: Install test dependencies
-        run: python -m pip install tox
-      - name: Run flake8
-        run: |
-          tox -e flake8
-      - name: Run mypy
-        run: tox -e mypy
-
-  tests:
-    name: Run tests for ${{ matrix.os }} for ${{ matrix.python }}
-    runs-on: ${{ matrix.os }}
+  tox:
+    name: ${{ matrix.tox.name }} ${{ matrix.os.name }} ${{ matrix.python }}
+    runs-on: ${{ matrix.os.runs-on }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        tox:
+          - name: mypy
+            environment: mypy
+          - name: Test
+            environment: py
         python:
           - "3.7"
           - "3.8"
@@ -46,33 +33,42 @@ jobs:
           - "3.11"
           - "pypy-3.8"
           - "pypy-3.9"
+        os:
+          - name: Linux
+            runs-on: [ubuntu-latest]
+          - name: macOS
+            runs-on: [macos-latest]
+          - name: Windows
+            runs-on: [windows-latest]
+        include:
+          - tox:
+              name: Flake8
+              environment: flake8
+            python: "3.11"
+            os:
+              name: Linux
+              runs-on: [ubuntu-latest]
+          - tox:
+              name: Docs
+              environment: docs
+            python: "3.11"
+            os:
+              name: Linux
+              runs-on: [ubuntu-latest]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.inputs.branch }}
-      - name: Use Python ${{ matrix.python }}
+
+      - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
-      - name: Install test dependencies
-        run: python -m pip install tox
-      - name: Test
-        run: python -m tox -e py
 
-  docs:
-    name: Test documentation builds
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.inputs.branch }}
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
       - name: Install test dependencies
-        run: python -m pip install tox
-      - name: Test
-        run: python -m tox -e docs
+        run: |
+          python -m pip install tox
+
+      - name: Run ${{ matrix.tox.name }} in tox
+        run: |
+          python -m tox -e ${{ matrix.tox.environment }}


### PR DESCRIPTION
This started as just expanding the mypy matrix to cover platforms at least, and Python versions.  It grew to just being a general tox workflow avoiding the steps repetition.  It could be argued that docs and flake8 ought to be run against all the combinations to make sure they can be worked on in any of the situations.  But, I left that out at least for now as I'm not sure if that's a step beyond where this is wanted to go.

I noticed that the docs workflow specifically builds the PR branch instead of the regular automatic merge commit of the PR branch and the target branch.  Is `ref: ${{ github.event.inputs.branch }}` important?

If the overall change here is not preferred, I can make another PR that is more focused on expanding just the mypy matrix.

Draft for:
- [x] ordering and emojis