### PR TITLE
cancel previous jobs for pull requests

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -31,7 +31,7 @@ on:
         default: "master"
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'pull_request' && '' || github.sha }}
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name != 'pull_request' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -30,6 +30,10 @@ on:
         required: true
         default: "master"
 
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'pull_request' && '' || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   macos-built-distributions:
     name: Build macOS wheels

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - '**'
 
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'pull_request' && '' || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Linting

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'pull_request' && '' || github.sha }}
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name != 'pull_request' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
In short, this cancels previous jobs for PRs but not for the `master` branch.

An example cancelled run is available at https://github.com/gorakhargosh/watchdog/actions/runs/4399005839/jobs/7703250952.

I very much like having every run ever and letting it complete and always being able to check the results for any commit and...  but sometimes that's not super practical.  This gets you quicker results for your later push at the cost of cancelling in-progress runs for the same PR.

Again, opinions on this topic are understood.  This isn't for everyone.