### PR TITLE
add job timeouts

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -38,6 +38,7 @@ jobs:
   macos-built-distributions:
     name: Build macOS wheels
     runs-on: macos-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -62,6 +63,7 @@ jobs:
   pure-built-distributions:
     name: Build pure wheels
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -87,6 +89,7 @@ jobs:
   source-distribution:
     name: Build source distribution
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -111,6 +114,7 @@ jobs:
       - pure-built-distributions
       - source-distribution
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Download all the dists
         uses: actions/download-artifact@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,14 +16,17 @@ jobs:
   tox:
     name: ${{ matrix.tox.name }} ${{ matrix.os.emoji }} ${{ matrix.os.name }} ${{ matrix.python }}
     runs-on: ${{ matrix.os.runs-on }}
+    timeout-minutes: ${{ matrix.tox.timeout }}
     strategy:
       fail-fast: false
       matrix:
         tox:
           - name: Test
             environment: py
+            timeout: 15
           - name: mypy
             environment: mypy
+            timeout: 15
         os:
           - name: Linux
             emoji: 🐧
@@ -46,6 +49,7 @@ jobs:
           - tox:
               name: Flake8
               environment: flake8
+              timeout: 5
             python: "3.11"
             os:
               name: Linux
@@ -54,6 +58,7 @@ jobs:
           - tox:
               name: Docs
               environment: docs
+              timeout: 5
             python: "3.11"
             os:
               name: Linux


### PR DESCRIPTION
I noticed some jobs that seemed to get stuck.  Waiting for the full 6 hours to get the 'failure' indication and also for the worker to free up can be annoying.  These limits are just a first guess based on the runs below.

- https://github.com/gorakhargosh/watchdog/actions/runs/4399512047/usage
- https://github.com/gorakhargosh/watchdog/actions/runs/4399512042/usage
