### PR TITLE
Remove handling of threading.Event.isSet spelling

### DIFF
--- a/src/watchdog/utils/__init__.py
+++ b/src/watchdog/utils/__init__.py
@@ -55,9 +55,6 @@ class BaseThread(threading.Thread):
             self.setDaemon(True)
         self._stopped_event = threading.Event()
 
-        if not hasattr(self._stopped_event, "is_set"):
-            self._stopped_event.is_set = self._stopped_event.isSet
-
     @property
     def stopped_event(self):
         return self._stopped_event


### PR DESCRIPTION
Looks like this is a remnant of support for Python versions less than 2.6.

https://docs.python.org/2.7/library/threading.html#threading.Event.is_set
> Changed in version 2.6: Added `is_set()` spelling.