### PR TITLE
return from InotifyEmitter.queue_events() if not launched when thread is inactive

### DIFF
--- a/src/watchdog/observers/inotify.py
+++ b/src/watchdog/observers/inotify.py
@@ -129,7 +129,7 @@ class InotifyEmitter(EventEmitter):
         # If "full_events" is true, then the method will report unmatched move events as separate events
         # This behavior is by default only called by a InotifyFullEmitter
         if self._inotify is None:
-            logger.error("InotifyEmitter.queue_events() called when the thread is inactive"
+            logger.error("InotifyEmitter.queue_events() called when the thread is inactive")
             return
         with self._lock:
             event = self._inotify.read_event()

--- a/src/watchdog/observers/inotify.py
+++ b/src/watchdog/observers/inotify.py
@@ -64,6 +64,7 @@ Some extremely useful articles and documentation:
 
 """
 
+import logging
 import os
 import threading
 from .inotify_buffer import InotifyBuffer
@@ -89,6 +90,9 @@ from watchdog.events import (
     generate_sub_moved_events,
     generate_sub_created_events,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 class InotifyEmitter(EventEmitter):
@@ -124,9 +128,10 @@ class InotifyEmitter(EventEmitter):
     def queue_events(self, timeout, full_events=False):
         # If "full_events" is true, then the method will report unmatched move events as separate events
         # This behavior is by default only called by a InotifyFullEmitter
+        if self._inotify is None:
+            logger.error("InotifyEmitter.queue_events() called when the thread is inactive"
+            return
         with self._lock:
-            if self._inotify is None:
-                return
             event = self._inotify.read_event()
             if event is None:
                 return

--- a/src/watchdog/observers/inotify.py
+++ b/src/watchdog/observers/inotify.py
@@ -125,6 +125,8 @@ class InotifyEmitter(EventEmitter):
         # If "full_events" is true, then the method will report unmatched move events as separate events
         # This behavior is by default only called by a InotifyFullEmitter
         with self._lock:
+            if self._inotify is None:
+                return
             event = self._inotify.read_event()
             if event is None:
                 return


### PR DESCRIPTION
This was pointed out by mypy but I wanted to separate it out for individual consideration.  Existing behavior would have been to raise an `AttributeError`.  Should this return as if there was no read event?  Or raise?  If raising, would `WatchdogShutdown` be appropriate or should we make something else?  For example, this makes a difference to `EventEmitter.run()`