### PR TITLE
add isort

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
               runs-on: [ubuntu-latest]
           - tox:
               name: isort
-              environment: isort
+              environment: isort-ci
               timeout: 5
             python: "3.11"
             os:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,6 +56,15 @@ jobs:
               emoji: 🐧
               runs-on: [ubuntu-latest]
           - tox:
+              name: isort
+              environment: isort
+              timeout: 5
+            python: "3.11"
+            os:
+              name: Linux
+              emoji: 🐧
+              runs-on: [ubuntu-latest]
+          - tox:
               name: Docs
               environment: docs
               timeout: 5

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,5 @@
+[settings]
+line_length = 120
+profile=black
+skip_gitignore=true
+add_imports=from __future__ import annotations

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,6 +1,7 @@
 eventlet
 flake8
 flaky
+isort
 pytest
 pytest-cov
 pytest-timeout

--- a/src/watchdog/events.py
+++ b/src/watchdog/events.py
@@ -91,11 +91,13 @@ Event Handler Classes
 
 """
 
-import os.path
-import logging
-import re
-from watchdog.utils.patterns import match_any_paths
+from __future__ import annotations
 
+import logging
+import os.path
+import re
+
+from watchdog.utils.patterns import match_any_paths
 
 EVENT_TYPE_MOVED = "moved"
 EVENT_TYPE_DELETED = "deleted"

--- a/src/watchdog/observers/__init__.py
+++ b/src/watchdog/observers/__init__.py
@@ -50,11 +50,14 @@ Class          Platforms                        Note
 
 """
 
+from __future__ import annotations
+
 import sys
 import warnings
 from typing import Type
 
 from watchdog.utils import UnsupportedLibc
+
 from .api import BaseObserver
 
 Observer: Type[BaseObserver]

--- a/src/watchdog/observers/api.py
+++ b/src/watchdog/observers/api.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import queue
 import threading
 from pathlib import Path

--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -21,32 +21,29 @@
 :platforms: macOS
 """
 
-import time
+from __future__ import annotations
+
 import logging
 import os
 import threading
+import time
 import unicodedata
+
 import _watchdog_fsevents as _fsevents  # type: ignore[import]
 
 from watchdog.events import (
-    FileDeletedEvent,
-    FileModifiedEvent,
-    FileCreatedEvent,
-    FileMovedEvent,
+    DirCreatedEvent,
     DirDeletedEvent,
     DirModifiedEvent,
-    DirCreatedEvent,
     DirMovedEvent,
+    FileCreatedEvent,
+    FileDeletedEvent,
+    FileModifiedEvent,
+    FileMovedEvent,
     generate_sub_created_events,
     generate_sub_moved_events,
 )
-
-from watchdog.observers.api import (
-    BaseObserver,
-    EventEmitter,
-    DEFAULT_EMITTER_TIMEOUT,
-    DEFAULT_OBSERVER_TIMEOUT,
-)
+from watchdog.observers.api import DEFAULT_EMITTER_TIMEOUT, DEFAULT_OBSERVER_TIMEOUT, BaseObserver, EventEmitter
 from watchdog.utils.dirsnapshot import DirectorySnapshot
 
 logger = logging.getLogger("fsevents")

--- a/src/watchdog/observers/fsevents2.py
+++ b/src/watchdog/observers/fsevents2.py
@@ -18,61 +18,55 @@
 :platforms: macOS
 """
 
-import os
+from __future__ import annotations
+
 import logging
+import os
 import queue
 import unicodedata
 import warnings
 from threading import Thread
 
-from watchdog.events import (
-    FileDeletedEvent,
-    FileModifiedEvent,
-    FileCreatedEvent,
-    FileMovedEvent,
-    DirDeletedEvent,
-    DirModifiedEvent,
-    DirCreatedEvent,
-    DirMovedEvent,
-)
-from watchdog.observers.api import (
-    BaseObserver,
-    EventEmitter,
-    DEFAULT_EMITTER_TIMEOUT,
-    DEFAULT_OBSERVER_TIMEOUT,
-)
-
 # pyobjc
 import AppKit  # type: ignore[import]
 from FSEvents import (  # type: ignore[import]
-    FSEventStreamCreate,
     CFRunLoopGetCurrent,
-    FSEventStreamScheduleWithRunLoop,
-    FSEventStreamStart,
     CFRunLoopRun,
     CFRunLoopStop,
-    FSEventStreamStop,
+    FSEventStreamCreate,
     FSEventStreamInvalidate,
     FSEventStreamRelease,
-)
-
-from FSEvents import (
+    FSEventStreamScheduleWithRunLoop,
+    FSEventStreamStart,
+    FSEventStreamStop,
     kCFAllocatorDefault,
     kCFRunLoopDefaultMode,
-    kFSEventStreamEventIdSinceNow,
-    kFSEventStreamCreateFlagNoDefer,
     kFSEventStreamCreateFlagFileEvents,
-    kFSEventStreamEventFlagItemCreated,
-    kFSEventStreamEventFlagItemRemoved,
-    kFSEventStreamEventFlagItemInodeMetaMod,
-    kFSEventStreamEventFlagItemRenamed,
-    kFSEventStreamEventFlagItemModified,
-    kFSEventStreamEventFlagItemFinderInfoMod,
+    kFSEventStreamCreateFlagNoDefer,
     kFSEventStreamEventFlagItemChangeOwner,
-    kFSEventStreamEventFlagItemXattrMod,
+    kFSEventStreamEventFlagItemCreated,
+    kFSEventStreamEventFlagItemFinderInfoMod,
+    kFSEventStreamEventFlagItemInodeMetaMod,
     kFSEventStreamEventFlagItemIsDir,
     kFSEventStreamEventFlagItemIsSymlink,
+    kFSEventStreamEventFlagItemModified,
+    kFSEventStreamEventFlagItemRemoved,
+    kFSEventStreamEventFlagItemRenamed,
+    kFSEventStreamEventFlagItemXattrMod,
+    kFSEventStreamEventIdSinceNow,
 )
+
+from watchdog.events import (
+    DirCreatedEvent,
+    DirDeletedEvent,
+    DirModifiedEvent,
+    DirMovedEvent,
+    FileCreatedEvent,
+    FileDeletedEvent,
+    FileModifiedEvent,
+    FileMovedEvent,
+)
+from watchdog.observers.api import DEFAULT_EMITTER_TIMEOUT, DEFAULT_OBSERVER_TIMEOUT, BaseObserver, EventEmitter
 
 logger = logging.getLogger(__name__)
 

--- a/src/watchdog/observers/inotify.py
+++ b/src/watchdog/observers/inotify.py
@@ -88,7 +88,6 @@ from watchdog.observers.api import DEFAULT_EMITTER_TIMEOUT, DEFAULT_OBSERVER_TIM
 
 from .inotify_buffer import InotifyBuffer
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/watchdog/observers/inotify.py
+++ b/src/watchdog/observers/inotify.py
@@ -64,31 +64,28 @@ Some extremely useful articles and documentation:
 
 """
 
+from __future__ import annotations
+
 import os
 import threading
-from .inotify_buffer import InotifyBuffer
-
-from watchdog.observers.api import (
-    EventEmitter,
-    BaseObserver,
-    DEFAULT_EMITTER_TIMEOUT,
-    DEFAULT_OBSERVER_TIMEOUT,
-)
 
 from watchdog.events import (
+    DirCreatedEvent,
     DirDeletedEvent,
     DirModifiedEvent,
     DirMovedEvent,
-    DirCreatedEvent,
+    FileClosedEvent,
+    FileCreatedEvent,
     FileDeletedEvent,
     FileModifiedEvent,
     FileMovedEvent,
-    FileCreatedEvent,
-    FileClosedEvent,
     FileOpenedEvent,
-    generate_sub_moved_events,
     generate_sub_created_events,
+    generate_sub_moved_events,
 )
+from watchdog.observers.api import DEFAULT_EMITTER_TIMEOUT, DEFAULT_OBSERVER_TIMEOUT, BaseObserver, EventEmitter
+
+from .inotify_buffer import InotifyBuffer
 
 
 class InotifyEmitter(EventEmitter):

--- a/src/watchdog/observers/inotify_buffer.py
+++ b/src/watchdog/observers/inotify_buffer.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import logging
+
+from watchdog.observers.inotify_c import Inotify
 from watchdog.utils import BaseThread
 from watchdog.utils.delayed_queue import DelayedQueue
-from watchdog.observers.inotify_c import Inotify
 
 logger = logging.getLogger(__name__)
 

--- a/src/watchdog/observers/inotify_c.py
+++ b/src/watchdog/observers/inotify_c.py
@@ -13,14 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import errno
-import struct
-import threading
+from __future__ import annotations
+
 import ctypes
 import ctypes.util
+import errno
+import os
+import struct
+import threading
+from ctypes import c_char_p, c_int, c_uint32
 from functools import reduce
-from ctypes import c_int, c_char_p, c_uint32
+
 from watchdog.utils import UnsupportedLibc
 
 libc = ctypes.CDLL(None)

--- a/src/watchdog/observers/kqueue.py
+++ b/src/watchdog/observers/kqueue.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 # The `select` module varies between platforms.
 # mypy may complain about missing module attributes
 # depending on which platform it's running on.
@@ -20,7 +22,6 @@
 #
 # mypy: disable-error-code=attr-defined
 #
-
 """
 :module: watchdog.observers.kqueue
 :synopsis: ``kqueue(2)`` based emitter implementation.
@@ -73,38 +74,30 @@ Collections and Utility Classes
 
 """
 
-from watchdog.utils import platform
-
-import threading
 import errno
-from stat import S_ISDIR
 import os
 import os.path
 import select
-
-from watchdog.observers.api import (
-    BaseObserver,
-    EventEmitter,
-    DEFAULT_OBSERVER_TIMEOUT,
-    DEFAULT_EMITTER_TIMEOUT,
-)
-
-from watchdog.utils.dirsnapshot import DirectorySnapshot
+import threading
+from stat import S_ISDIR
 
 from watchdog.events import (
-    DirMovedEvent,
-    DirDeletedEvent,
-    DirCreatedEvent,
-    DirModifiedEvent,
-    FileMovedEvent,
-    FileDeletedEvent,
-    FileCreatedEvent,
-    FileModifiedEvent,
-    EVENT_TYPE_MOVED,
-    EVENT_TYPE_DELETED,
     EVENT_TYPE_CREATED,
+    EVENT_TYPE_DELETED,
+    EVENT_TYPE_MOVED,
+    DirCreatedEvent,
+    DirDeletedEvent,
+    DirModifiedEvent,
+    DirMovedEvent,
+    FileCreatedEvent,
+    FileDeletedEvent,
+    FileModifiedEvent,
+    FileMovedEvent,
     generate_sub_moved_events,
 )
+from watchdog.observers.api import DEFAULT_EMITTER_TIMEOUT, DEFAULT_OBSERVER_TIMEOUT, BaseObserver, EventEmitter
+from watchdog.utils import platform
+from watchdog.utils.dirsnapshot import DirectorySnapshot
 
 # Maximum number of events to process.
 MAX_EVENTS = 4096

--- a/src/watchdog/observers/polling.py
+++ b/src/watchdog/observers/polling.py
@@ -32,28 +32,24 @@ Classes
    :special-members:
 """
 
+from __future__ import annotations
+
 import os
 import threading
 from functools import partial
 
-from watchdog.utils.dirsnapshot import DirectorySnapshot, DirectorySnapshotDiff
-from watchdog.observers.api import (
-    EventEmitter,
-    BaseObserver,
-    DEFAULT_OBSERVER_TIMEOUT,
-    DEFAULT_EMITTER_TIMEOUT,
-)
-
 from watchdog.events import (
-    DirMovedEvent,
-    DirDeletedEvent,
     DirCreatedEvent,
+    DirDeletedEvent,
     DirModifiedEvent,
-    FileMovedEvent,
-    FileDeletedEvent,
+    DirMovedEvent,
     FileCreatedEvent,
+    FileDeletedEvent,
     FileModifiedEvent,
+    FileMovedEvent,
 )
+from watchdog.observers.api import DEFAULT_EMITTER_TIMEOUT, DEFAULT_OBSERVER_TIMEOUT, BaseObserver, EventEmitter
+from watchdog.utils.dirsnapshot import DirectorySnapshot, DirectorySnapshotDiff
 
 
 class PollingEmitter(EventEmitter):

--- a/src/watchdog/observers/read_directory_changes.py
+++ b/src/watchdog/observers/read_directory_changes.py
@@ -14,40 +14,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
+import os.path
+import platform
 import sys
 import threading
-import os.path
 import time
-import platform
 
 from watchdog.events import (
     DirCreatedEvent,
     DirDeletedEvent,
-    DirMovedEvent,
     DirModifiedEvent,
+    DirMovedEvent,
     FileCreatedEvent,
     FileDeletedEvent,
-    FileMovedEvent,
     FileModifiedEvent,
-    generate_sub_moved_events,
+    FileMovedEvent,
     generate_sub_created_events,
+    generate_sub_moved_events,
 )
-
-from watchdog.observers.api import (
-    EventEmitter,
-    BaseObserver,
-    DEFAULT_OBSERVER_TIMEOUT,
-    DEFAULT_EMITTER_TIMEOUT,
-)
+from watchdog.observers.api import DEFAULT_EMITTER_TIMEOUT, DEFAULT_OBSERVER_TIMEOUT, BaseObserver, EventEmitter
 
 assert sys.platform.startswith("win"), f"{__name__} requires Windows"
 
-from watchdog.observers.winapi import (  # noqa: E402
-    read_events,
-    get_directory_handle,
-    close_directory_handle,
-)
-
+from watchdog.observers.winapi import close_directory_handle, get_directory_handle, read_events  # noqa: E402
 
 # HACK:
 WATCHDOG_TRAVERSE_MOVED_DIR_DELAY = 1  # seconds

--- a/src/watchdog/observers/winapi.py
+++ b/src/watchdog/observers/winapi.py
@@ -34,6 +34,8 @@
 # Portions of this code were taken from pyfilesystem, which uses the above
 # new BSD license.
 
+from __future__ import annotations
+
 import sys
 from functools import reduce
 

--- a/src/watchdog/tricks/__init__.py
+++ b/src/watchdog/tricks/__init__.py
@@ -39,6 +39,8 @@ Classes
 
 """
 
+from __future__ import annotations
+
 import functools
 import logging
 import os
@@ -47,7 +49,7 @@ import subprocess
 import threading
 import time
 
-from watchdog.events import PatternMatchingEventHandler, EVENT_TYPE_OPENED
+from watchdog.events import EVENT_TYPE_OPENED, PatternMatchingEventHandler
 from watchdog.utils import echo
 from watchdog.utils.event_debouncer import EventDebouncer
 from watchdog.utils.process_watcher import ProcessWatcher

--- a/src/watchdog/utils/__init__.py
+++ b/src/watchdog/utils/__init__.py
@@ -28,6 +28,8 @@ Classes
    :inherited-members:
 
 """
+from __future__ import annotations
+
 import sys
 import threading
 

--- a/src/watchdog/utils/bricks.py
+++ b/src/watchdog/utils/bricks.py
@@ -34,6 +34,8 @@ Classes
 
 """
 
+from __future__ import annotations
+
 import queue
 
 

--- a/src/watchdog/utils/delayed_queue.py
+++ b/src/watchdog/utils/delayed_queue.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
+from __future__ import annotations
+
 import threading
+import time
 from collections import deque
 
 

--- a/src/watchdog/utils/dirsnapshot.py
+++ b/src/watchdog/utils/dirsnapshot.py
@@ -46,6 +46,8 @@ Classes
 
 """
 
+from __future__ import annotations
+
 import errno
 import os
 from stat import S_ISDIR

--- a/src/watchdog/utils/echo.py
+++ b/src/watchdog/utils/echo.py
@@ -30,6 +30,8 @@ Example:
   def my_function(args):
       pass
 """
+from __future__ import annotations
+
 import inspect
 import sys
 

--- a/src/watchdog/utils/event_debouncer.py
+++ b/src/watchdog/utils/event_debouncer.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import logging
 import threading
 
 from watchdog.utils import BaseThread
-
 
 logger = logging.getLogger(__name__)
 

--- a/src/watchdog/utils/patterns.py
+++ b/src/watchdog/utils/patterns.py
@@ -4,6 +4,8 @@
 #
 # Written by Boris Staletic <boris.staletic@gmail.com>
 
+from __future__ import annotations
+
 # Non-pure path objects are only allowed on their respective OS's.
 # Thus, these utilities require "pure" path objects that don't access the filesystem.
 # Since pathlib doesn't have a `case_sensitive` parameter, we have to approximate it
@@ -11,7 +13,7 @@
 #   - `PureWindowsPath` is always case-insensitive.
 #   - `PurePosixPath` is always case-sensitive.
 # Reference: https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.match
-from pathlib import PureWindowsPath, PurePosixPath
+from pathlib import PurePosixPath, PureWindowsPath
 
 
 def _match_path(path, included_patterns, excluded_patterns, case_sensitive):

--- a/src/watchdog/utils/platform.py
+++ b/src/watchdog/utils/platform.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 
+from __future__ import annotations
+
 import sys
 
 PLATFORM_WINDOWS = "windows"

--- a/src/watchdog/utils/process_watcher.py
+++ b/src/watchdog/utils/process_watcher.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import logging
 
 from watchdog.utils import BaseThread
-
 
 logger = logging.getLogger(__name__)
 

--- a/src/watchdog/version.py
+++ b/src/watchdog/version.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 
+from __future__ import annotations
+
 # When updating this version number, please update the
 # ``docs/source/global.rst.inc`` file as well.
 VERSION_MAJOR = 2

--- a/src/watchdog/watchmedo.py
+++ b/src/watchdog/watchmedo.py
@@ -21,6 +21,8 @@
 :synopsis: ``watchmedo`` shell script utility.
 """
 
+from __future__ import annotations
+
 import errno
 import logging
 import os
@@ -268,9 +270,7 @@ def tricks_from(args):
     elif args.debug_force_kqueue:
         from watchdog.observers.kqueue import KqueueObserver as Observer
     elif args.debug_force_winapi:
-        from watchdog.observers.read_directory_changes import (
-            WindowsApiObserver as Observer,
-        )
+        from watchdog.observers.read_directory_changes import WindowsApiObserver as Observer
     elif args.debug_force_inotify:
         from watchdog.observers.inotify import InotifyObserver as Observer
     elif args.debug_force_fsevents:
@@ -458,8 +458,8 @@ def log(args):
     """
     Command to log file system events to the console.
     """
-    from watchdog.utils import echo
     from watchdog.tricks import LoggerTrick
+    from watchdog.utils import echo
 
     if args.trace:
         class_module_logger = logging.getLogger(LoggerTrick.__module__)
@@ -476,9 +476,7 @@ def log(args):
     elif args.debug_force_kqueue:
         from watchdog.observers.kqueue import KqueueObserver as Observer
     elif args.debug_force_winapi:
-        from watchdog.observers.read_directory_changes import (
-            WindowsApiObserver as Observer,
-        )
+        from watchdog.observers.read_directory_changes import WindowsApiObserver as Observer
     elif args.debug_force_inotify:
         from watchdog.observers.inotify import InotifyObserver as Observer
     elif args.debug_force_fsevents:
@@ -711,8 +709,9 @@ def auto_restart(args):
     else:
         from watchdog.observers import Observer
 
-    from watchdog.tricks import AutoRestartTrick
     import signal
+
+    from watchdog.tricks import AutoRestartTrick
 
     if not args.directories:
         args.directories = ["."]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,12 @@
-from functools import partial
+from __future__ import annotations
+
 import gc
 import os
 import threading
+from functools import partial
+
 import pytest
+
 from . import shell
 
 

--- a/tests/markers.py
+++ b/tests/markers.py
@@ -1,6 +1,8 @@
-from platform import python_implementation
-import pytest
+from __future__ import annotations
 
+from platform import python_implementation
+
+import pytest
 
 cpython_only = pytest.mark.skipif(
     python_implementation() != "CPython", reason="CPython only."

--- a/tests/shell.py
+++ b/tests/shell.py
@@ -19,13 +19,14 @@
     :author: yesudeep@google.com (Yesudeep Mangalapilly)
 """
 
+from __future__ import annotations
+
+import errno
 import os
 import os.path
-import tempfile
 import shutil
-import errno
+import tempfile
 import time
-
 
 # def tree(path='.', show_files=False):
 #    print(path)

--- a/tests/test_0_watchmedo.py
+++ b/tests/test_0_watchmedo.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 import time
@@ -5,19 +7,19 @@ from unittest.mock import patch
 
 import pytest
 
-
 # Skip if import PyYAML failed. PyYAML missing possible because
 # watchdog installed without watchmedo. See Installation section
 # in README.rst
 yaml = pytest.importorskip("yaml")  # noqa
 
 
+from yaml.constructor import ConstructorError  # noqa
+from yaml.scanner import ScannerError  # noqa
+
 from watchdog import watchmedo  # noqa
 from watchdog.events import FileModifiedEvent, FileOpenedEvent  # noqa
 from watchdog.tricks import AutoRestartTrick, ShellCommandTrick  # noqa
 from watchdog.utils import WatchdogShutdown  # noqa
-from yaml.constructor import ConstructorError  # noqa
-from yaml.scanner import ScannerError  # noqa
 
 
 def test_load_config_valid(tmpdir):

--- a/tests/test_delayed_queue.py
+++ b/tests/test_delayed_queue.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from time import time
 
 import pytest
+
 from watchdog.utils.delayed_queue import DelayedQueue
 
 

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -12,47 +12,47 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
+import logging
 import os
 import stat
 import sys
 import time
-import pytest
-import logging
 from functools import partial
-from queue import Queue, Empty
+from queue import Empty, Queue
 from typing import Type
 
-from .shell import mkfile, mkdir, touch, mv, rm
-from watchdog.utils import platform
+import pytest
+
 from watchdog.events import (
-    FileDeletedEvent,
-    FileModifiedEvent,
-    FileCreatedEvent,
-    FileMovedEvent,
+    DirCreatedEvent,
     DirDeletedEvent,
     DirModifiedEvent,
-    DirCreatedEvent,
     DirMovedEvent,
     FileClosedEvent,
+    FileCreatedEvent,
+    FileDeletedEvent,
+    FileModifiedEvent,
+    FileMovedEvent,
     FileOpenedEvent,
 )
 from watchdog.observers.api import EventEmitter, ObservedWatch
+from watchdog.utils import platform
+
+from .shell import mkdir, mkfile, mv, rm, touch
 
 Emitter: Type[EventEmitter]
 
 if sys.platform.startswith("linux"):
-    from watchdog.observers.inotify import (
-        InotifyEmitter as Emitter,
-        InotifyFullEmitter,
-    )
+    from watchdog.observers.inotify import InotifyEmitter as Emitter
+    from watchdog.observers.inotify import InotifyFullEmitter
 elif sys.platform.startswith("darwin"):
     from watchdog.observers.fsevents import FSEventsEmitter as Emitter
 elif sys.platform.startswith("win"):
     from watchdog.observers.read_directory_changes import WindowsApiEmitter as Emitter
 elif sys.platform.startswith(("dragonfly", "freebsd", "netbsd", "openbsd", "bsd")):
-    from watchdog.observers.kqueue import (
-        KqueueEmitter as Emitter
-    )
+    from watchdog.observers.kqueue import KqueueEmitter as Emitter
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -13,24 +13,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from watchdog.events import (
-    FileDeletedEvent,
-    FileModifiedEvent,
-    FileCreatedEvent,
-    FileClosedEvent,
-    FileOpenedEvent,
-    DirDeletedEvent,
-    DirModifiedEvent,
-    DirCreatedEvent,
-    FileMovedEvent,
-    DirMovedEvent,
-    FileSystemEventHandler,
-    EVENT_TYPE_MODIFIED,
+    EVENT_TYPE_CLOSED,
     EVENT_TYPE_CREATED,
     EVENT_TYPE_DELETED,
+    EVENT_TYPE_MODIFIED,
     EVENT_TYPE_MOVED,
-    EVENT_TYPE_CLOSED,
     EVENT_TYPE_OPENED,
+    DirCreatedEvent,
+    DirDeletedEvent,
+    DirModifiedEvent,
+    DirMovedEvent,
+    FileClosedEvent,
+    FileCreatedEvent,
+    FileDeletedEvent,
+    FileModifiedEvent,
+    FileMovedEvent,
+    FileOpenedEvent,
+    FileSystemEventHandler,
 )
 
 path_1 = "/path/xyz"

--- a/tests/test_fsevents.py
+++ b/tests/test_fsevents.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import pytest
+
 from watchdog.utils import platform
 
 if not platform.is_darwin():  # noqa
@@ -16,6 +19,7 @@ from time import sleep
 from unittest.mock import patch
 
 import _watchdog_fsevents as _fsevents  # type: ignore[import]
+
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 from watchdog.observers.api import ObservedWatch
@@ -269,11 +273,7 @@ def test_recursive_check_accepts_relative_paths():
     using ".". Since the watch path wasn't normalized then that failed.
     This test emulates the scenario.
     """
-    from watchdog.events import (
-        PatternMatchingEventHandler,
-        FileCreatedEvent,
-        FileModifiedEvent,
-    )
+    from watchdog.events import FileCreatedEvent, FileModifiedEvent, PatternMatchingEventHandler
 
     class TestEventHandler(PatternMatchingEventHandler):
         def __init__(self, *args, **kwargs):
@@ -318,9 +318,10 @@ def test_recursive_check_accepts_relative_paths():
 
 def test_watchdog_recursive():
     """See https://github.com/gorakhargosh/watchdog/issues/706"""
-    from watchdog.observers import Observer
-    from watchdog.events import FileSystemEventHandler
     import os.path
+
+    from watchdog.events import FileSystemEventHandler
+    from watchdog.observers import Observer
 
     class Handler(FileSystemEventHandler):
         def __init__(self):

--- a/tests/test_inotify_buffer.py
+++ b/tests/test_inotify_buffer.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
+
 from watchdog.utils import platform
 
 if not platform.is_linux():  # noqa
@@ -24,7 +27,7 @@ import time
 
 from watchdog.observers.inotify_buffer import InotifyBuffer
 
-from .shell import mkdir, touch, mv, rm, mount_tmpfs, unmount
+from .shell import mkdir, mount_tmpfs, mv, rm, touch, unmount
 
 
 def wait_for_move_event(read_event):

--- a/tests/test_inotify_c.py
+++ b/tests/test_inotify_c.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import pytest
+
 from watchdog.utils import platform
 
 if not platform.is_linux():  # noqa
@@ -16,11 +19,10 @@ from unittest.mock import patch
 
 from watchdog.events import DirCreatedEvent, DirDeletedEvent, DirModifiedEvent
 from watchdog.observers.api import ObservedWatch
-from watchdog.observers.inotify import InotifyFullEmitter, InotifyEmitter
+from watchdog.observers.inotify import InotifyEmitter, InotifyFullEmitter
 from watchdog.observers.inotify_c import Inotify, InotifyConstants, InotifyEvent
 
 from .shell import mkdtemp, rm
-
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)

--- a/tests/test_logging_event_handler.py
+++ b/tests/test_logging_event_handler.py
@@ -13,20 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from watchdog.events import (
-    FileDeletedEvent,
-    FileModifiedEvent,
-    FileCreatedEvent,
-    DirDeletedEvent,
-    DirModifiedEvent,
-    DirCreatedEvent,
-    FileMovedEvent,
-    DirMovedEvent,
-    LoggingEventHandler,
-    EVENT_TYPE_MODIFIED,
     EVENT_TYPE_CREATED,
     EVENT_TYPE_DELETED,
+    EVENT_TYPE_MODIFIED,
     EVENT_TYPE_MOVED,
+    DirCreatedEvent,
+    DirDeletedEvent,
+    DirModifiedEvent,
+    DirMovedEvent,
+    FileCreatedEvent,
+    FileDeletedEvent,
+    FileModifiedEvent,
+    FileMovedEvent,
+    LoggingEventHandler,
 )
 
 path_1 = "/path/xyz"

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -12,14 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import contextlib
 import threading
 from unittest.mock import patch
 
 import pytest
 
-from watchdog.events import FileSystemEventHandler, FileModifiedEvent
-from watchdog.observers.api import EventEmitter, BaseObserver
+from watchdog.events import FileModifiedEvent, FileSystemEventHandler
+from watchdog.observers.api import BaseObserver, EventEmitter
 
 
 @pytest.fixture

--- a/tests/test_observers_api.py
+++ b/tests/test_observers_api.py
@@ -13,19 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import time
 from pathlib import Path
 
 import pytest
 
-from watchdog.events import LoggingEventHandler, FileModifiedEvent
-from watchdog.observers.api import (
-    BaseObserver,
-    EventEmitter,
-    ObservedWatch,
-    EventDispatcher,
-    EventQueue,
-)
+from watchdog.events import FileModifiedEvent, LoggingEventHandler
+from watchdog.observers.api import BaseObserver, EventDispatcher, EventEmitter, EventQueue, ObservedWatch
 
 
 def test_observer_constructor():

--- a/tests/test_observers_polling.py
+++ b/tests/test_observers_polling.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 
+from __future__ import annotations
+
 import os
 from queue import Empty, Queue
 from time import sleep
@@ -21,20 +23,19 @@ from time import sleep
 import pytest
 
 from watchdog.events import (
-    DirModifiedEvent,
     DirCreatedEvent,
-    FileCreatedEvent,
-    FileMovedEvent,
-    FileModifiedEvent,
-    DirMovedEvent,
-    FileDeletedEvent,
     DirDeletedEvent,
+    DirModifiedEvent,
+    DirMovedEvent,
+    FileCreatedEvent,
+    FileDeletedEvent,
+    FileModifiedEvent,
+    FileMovedEvent,
 )
 from watchdog.observers.api import ObservedWatch
 from watchdog.observers.polling import PollingEmitter as Emitter
 
-from .shell import mkdir, mkdtemp, touch, rm, mv, msize
-
+from .shell import mkdir, mkdtemp, msize, mv, rm, touch
 
 temp_dir = mkdtemp()
 

--- a/tests/test_observers_winapi.py
+++ b/tests/test_observers_winapi.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import os
 import os.path
 import sys
@@ -21,10 +23,7 @@ from time import sleep
 
 import pytest
 
-from watchdog.events import (
-    DirCreatedEvent,
-    DirMovedEvent,
-)
+from watchdog.events import DirCreatedEvent, DirMovedEvent
 from watchdog.observers.api import ObservedWatch
 
 from .shell import mkdir, mkdtemp, mv, rm
@@ -37,7 +36,6 @@ if not sys.platform.startswith("win"):
 assert sys.platform.startswith("win"), f"{__name__} requires Windows"
 
 from watchdog.observers.read_directory_changes import WindowsApiEmitter  # noqa: E402
-
 
 SLEEP_TIME = 2
 

--- a/tests/test_pattern_matching_event_handler.py
+++ b/tests/test_pattern_matching_event_handler.py
@@ -13,20 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from watchdog.events import (
-    FileDeletedEvent,
-    FileModifiedEvent,
-    FileCreatedEvent,
-    DirDeletedEvent,
-    DirModifiedEvent,
-    DirCreatedEvent,
-    FileMovedEvent,
-    DirMovedEvent,
-    PatternMatchingEventHandler,
-    EVENT_TYPE_MODIFIED,
     EVENT_TYPE_CREATED,
     EVENT_TYPE_DELETED,
+    EVENT_TYPE_MODIFIED,
     EVENT_TYPE_MOVED,
+    DirCreatedEvent,
+    DirDeletedEvent,
+    DirModifiedEvent,
+    DirMovedEvent,
+    FileCreatedEvent,
+    FileDeletedEvent,
+    FileModifiedEvent,
+    FileMovedEvent,
+    PatternMatchingEventHandler,
 )
 from watchdog.utils.patterns import filter_paths
 

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -1,7 +1,10 @@
 # Copyright (C) 2010 Yesudeep Mangalapilly <yesudeep@gmail.com>
 # Copyright 2020 Boris Staletic <boris.staletic@gmail.com>
 
+from __future__ import annotations
+
 import pytest
+
 from watchdog.utils.patterns import _match_path, filter_paths, match_any_paths
 
 

--- a/tests/test_regex_matching_event_handler.py
+++ b/tests/test_regex_matching_event_handler.py
@@ -13,21 +13,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from watchdog.events import (
-    FileDeletedEvent,
-    FileModifiedEvent,
-    FileCreatedEvent,
-    DirDeletedEvent,
-    DirModifiedEvent,
-    DirCreatedEvent,
-    FileMovedEvent,
-    DirMovedEvent,
-    RegexMatchingEventHandler,
-    LoggingEventHandler,
-    EVENT_TYPE_MODIFIED,
     EVENT_TYPE_CREATED,
     EVENT_TYPE_DELETED,
+    EVENT_TYPE_MODIFIED,
     EVENT_TYPE_MOVED,
+    DirCreatedEvent,
+    DirDeletedEvent,
+    DirModifiedEvent,
+    DirMovedEvent,
+    FileCreatedEvent,
+    FileDeletedEvent,
+    FileModifiedEvent,
+    FileMovedEvent,
+    LoggingEventHandler,
+    RegexMatchingEventHandler,
 )
 
 path_1 = "/path/xyz"

--- a/tests/test_skip_repeats_queue.py
+++ b/tests/test_skip_repeats_queue.py
@@ -13,7 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
+
 import watchdog.events as events
 from watchdog.utils.bricks import SkipRepeatsQueue
 

--- a/tests/test_snapshot_diff.py
+++ b/tests/test_snapshot_diff.py
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import errno
 import os
 import pickle
 import time
 from unittest.mock import patch
 
-from watchdog.utils.dirsnapshot import DirectorySnapshot
-from watchdog.utils.dirsnapshot import DirectorySnapshotDiff
-from watchdog.utils.dirsnapshot import EmptyDirectorySnapshot
 from watchdog.utils import platform
+from watchdog.utils.dirsnapshot import DirectorySnapshot, DirectorySnapshotDiff, EmptyDirectorySnapshot
 
-from .shell import mkdir, touch, mv, rm
+from .shell import mkdir, mv, rm, touch
 
 
 def wait():

--- a/tox.ini
+++ b/tox.ini
@@ -38,3 +38,10 @@ deps =
     -r requirements-tests.txt
 commands =
     mypy
+
+[testenv:isort]
+usedevelop = true
+deps =
+    -r requirements-tests.txt
+commands =
+    isort src/watchdog/ tests/ *.py

--- a/tox.ini
+++ b/tox.ini
@@ -45,3 +45,9 @@ deps =
     -r requirements-tests.txt
 commands =
     isort src/watchdog/ tests/ *.py
+
+[testenv:isort-ci]
+usedevelop = {[testenv:isort]usedevelop}
+deps = {[testenv:isort]deps}
+commands =
+    isort --diff --check-only src/watchdog/ tests/ *.py


### PR DESCRIPTION
Mostly I wanted the `from __future__ import annotations` so that the runtime didn't have to process the annotations, but figured I would just let isort enforce that along with other tidying.

See https://github.com/gorakhargosh/watchdog/actions/runs/4417784793/jobs/7743988675#step:5:24 for an example failure (correct detection of dirty files).