### PR TITLE
re-add `>` lost with 54f2cf0

### DIFF
--- a/src/watchdog/events.py
+++ b/src/watchdog/events.py
@@ -144,7 +144,7 @@ class FileSystemEvent:
     def __repr__(self):
         return (
             f"<{type(self).__name__}: event_type={self.event_type}, "
-            f"src_path={self.src_path!r}, is_directory={self.is_directory}"
+            f"src_path={self.src_path!r}, is_directory={self.is_directory}>"
         )
 
     # Used for comparison of events.


### PR DESCRIPTION
fixes #979 