### PR TITLE
Use SPDX license identifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup(
     long_description_content_type="text/x-rst",
     author="Yesudeep Mangalapilly",
     author_email="yesudeep@gmail.com",
-    license="Apache License 2.0",
+    license="Apache-2.0",
     url="https://github.com/gorakhargosh/watchdog",
     keywords=" ".join(
         [


### PR DESCRIPTION
Use SPDX license identifier: Apache-2.0
This will help tools to produce valid SPDX.