### PR TITLE
[windows] Remove the `WATCHDOG_TRAVERSE_MOVED_DIR_DELAY` hack

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -13,6 +13,7 @@ Changelog
 - [events] Log ``FileOpenedEvent``, and ``FileClosedEvent``, events in ``LoggingEventHandler``
 - [tests] Improve ``FileSystemEvent`` coverage
 - [watchmedo] Log all events in ``LoggerTrick``
+- [windows] The ``observers.read_directory_changes.WATCHDOG_TRAVERSE_MOVED_DIR_DELAY`` hack was removed. The constant will be kept to prevent breaking other softwares.
 - Thanks to our beloved contributors: @BoboTiG
 
 3.0.0


### PR DESCRIPTION
The `observers.read_directory_changes.WATCHDOG_TRAVERSE_MOVED_DIR_DELAY` hack was removed. The constant will be kept to prevent breaking other softwares.

Closes #916.
Related to #978.