### PR TITLE
fixes EventDebouncer not producing events

### DIFF
--- a/src/watchdog/utils/event_debouncer.py
+++ b/src/watchdog/utils/event_debouncer.py
@@ -43,12 +43,10 @@ class EventDebouncer(BaseThread):
     def run(self):
         with self._cond:
             while self.should_keep_running():
-                started = time.monotonic()
                 if self.debounce_interval_seconds:
+                    started = time.monotonic()
                     while self.should_keep_running():
-                        timed_out = not self._cond.wait(
-                            timeout=self.debounce_interval_seconds
-                        )
+                        timed_out = not self._cond.wait(timeout=self.debounce_interval_seconds)
                         if timed_out or self.time_to_flush(started):
                             break
                 else:
@@ -58,6 +56,6 @@ class EventDebouncer(BaseThread):
                 self._events = []
                 self.events_callback(events)
 
-            # send any events before leaving
+            # Send any events before leaving
             if self._events:
                 self.events_callback(events)

--- a/src/watchdog/utils/event_debouncer.py
+++ b/src/watchdog/utils/event_debouncer.py
@@ -37,7 +37,7 @@ class EventDebouncer(BaseThread):
             super().stop()
             self._cond.notify()
 
-    def time_to_flush(self, started) -> bool:
+    def time_to_flush(self, started: float) -> bool:
         return time.monotonic() - started > self.debounce_interval_seconds
 
     def run(self):

--- a/src/watchdog/utils/event_debouncer.py
+++ b/src/watchdog/utils/event_debouncer.py
@@ -37,7 +37,7 @@ class EventDebouncer(BaseThread):
             super().stop()
             self._cond.notify()
 
-    def time_to_flush(self, started):
+    def time_to_flush(self, started) -> bool:
         return time.monotonic() - started > self.debounce_interval_seconds
 
     def run(self):

--- a/tests/test_0_watchmedo.py
+++ b/tests/test_0_watchmedo.py
@@ -170,7 +170,7 @@ def test_auto_restart_on_file_change_debounce(tmpdir, capfd):
     time.sleep(1)
     trick.stop()
     cap = capfd.readouterr()
-    assert cap.out.splitlines(keepends=False).count("+++++ 0") == 3
+    assert cap.out.splitlines(keepends=False).count("+++++ 0") == 4
     assert trick.restart_count == 2
 
 

--- a/tests/test_0_watchmedo.py
+++ b/tests/test_0_watchmedo.py
@@ -170,7 +170,7 @@ def test_auto_restart_on_file_change_debounce(tmpdir, capfd):
     time.sleep(1)
     trick.stop()
     cap = capfd.readouterr()
-    assert cap.out.splitlines(keepends=False).count("+++++ 0") == 4
+    assert cap.out.splitlines(keepends=False).count("+++++ 0") == 3
     assert trick.restart_count == 2
 
 


### PR DESCRIPTION
Resolves #997

The problem is that we can only exit from the loop by timeout and it will never happen if the condition variable is triggered every debounce_interval_seconds or more often. A solution is simple - just add a monotonic timer. 

Update:
Resolves: #999 
Resolves: #1000 