### PR TITLE
Add `DirectorySnapshotDiff.ContextManager`

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -8,8 +8,8 @@ Changelog
 
 2023-xx-xx • `full history <https://github.com/gorakhargosh/watchdog/compare/v3.0.0...HEAD>`__
 
-
 - [snapshot] Add typing to ``dirsnapshot`` (`#1012 <https://github.com/gorakhargosh/watchdog/pull/1012>`__)
+- [snapshot] Added ``DirectorySnapshotDiff.ContextManager`` (`#1011 <https://github.com/gorakhargosh/watchdog/pull/1011>`__)
 - [events] ``FileSystemEvent``, and subclasses, are now ``dataclass``es, and their ``repr()`` has changed
 - [windows] ``WinAPINativeEvent`` is now a ``dataclass``, and its ``repr()`` has changed
 - [events] Log ``FileOpenedEvent``, and ``FileClosedEvent``, events in ``LoggingEventHandler``

--- a/src/watchdog/utils/dirsnapshot.py
+++ b/src/watchdog/utils/dirsnapshot.py
@@ -256,11 +256,11 @@ class DirectorySnapshotDiff:
 
         def __init__(
             self,
-            path,
-            recursive=True,
-            stat=os.stat,
-            listdir=os.scandir,
-            ignore_device=False,
+            path: str,
+            recursive: bool = True,
+            stat: Callable[[str], os.stat_result] = os.stat,
+            listdir: Callable[[Optional[str]], Iterator[os.DirEntry]] = os.scandir,
+            ignore_device: bool = False,
         ):
             self.path = path
             self.recursive = recursive

--- a/tests/test_snapshot_diff.py
+++ b/tests/test_snapshot_diff.py
@@ -55,6 +55,20 @@ def test_move_to(p):
     assert diff.files_created == [p("dir2", "b")]
 
 
+def test_move_to_with_context_manager(p):
+    mkdir(p("dir1"))
+    touch(p("dir1", "a"))
+    mkdir(p("dir2"))
+
+    dir1_cm = DirectorySnapshotDiff.ContextManager(p("dir1"))
+    dir2_cm = DirectorySnapshotDiff.ContextManager(p("dir2"))
+    with dir1_cm, dir2_cm:
+        mv(p("dir1", "a"), p("dir2", "b"))
+
+    assert dir1_cm.diff.files_deleted == [p("dir1", "a")]
+    assert dir2_cm.diff.files_created == [p("dir2", "b")]
+
+
 def test_move_from(p):
     mkdir(p("dir1"))
     mkdir(p("dir2"))


### PR DESCRIPTION
A context manager that creates two directory snapshots and a diff object that represents the difference between the two snapshots.

```python
dir_snapshot_diff_context_manager = DirectorySnapshotDiff.ContextManager("some_path")
with dir_snapshot_diff_context_manager:
    # Do some things that change files...
    ...

print(dir_snapshot_diff_context_manager.diff.files_created)
print(dir_snapshot_diff_context_manager.diff.files_deleted)
```