### PR TITLE
Add typing to `dirsnapshot`

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -8,13 +8,15 @@ Changelog
 
 2023-xx-xx • `full history <https://github.com/gorakhargosh/watchdog/compare/v3.0.0...HEAD>`__
 
+
+- [snapshot] Add typing to ``dirsnapshot`` (`#1012 <https://github.com/gorakhargosh/watchdog/pull/1012>`__)
 - [events] ``FileSystemEvent``, and subclasses, are now ``dataclass``es, and their ``repr()`` has changed
 - [windows] ``WinAPINativeEvent`` is now a ``dataclass``, and its ``repr()`` has changed
 - [events] Log ``FileOpenedEvent``, and ``FileClosedEvent``, events in ``LoggingEventHandler``
 - [tests] Improve ``FileSystemEvent`` coverage
 - [watchmedo] Log all events in ``LoggerTrick``
 - [windows] The ``observers.read_directory_changes.WATCHDOG_TRAVERSE_MOVED_DIR_DELAY`` hack was removed. The constant will be kept to prevent breaking other softwares.
-- Thanks to our beloved contributors: @BoboTiG
+- Thanks to our beloved contributors: @BoboTiG, @msabramo
 
 3.0.0
 ~~~~~


### PR DESCRIPTION
Before:

```
(.venv)
abramowi at Marcs-MacBook-Pro-3 in ~/Code/OpenSource/watchdog (master●)
$ mypy --disallow-untyped-defs src/watchdog/utils/dirsnapshot.py
src/watchdog/utils/dirsnapshot.py:82: error: Function is missing a type annotation  [no-untyped-def]
src/watchdog/utils/dirsnapshot.py:88: error: Function is missing a type annotation  [no-untyped-def]
src/watchdog/utils/dirsnapshot.py:93: error: Function is missing a type annotation  [no-untyped-def]
src/watchdog/utils/dirsnapshot.py:141: error: Function is missing a type annotation  [no-untyped-def]
src/watchdog/utils/dirsnapshot.py:144: error: Function is missing a type annotation  [no-untyped-def]
src/watchdog/utils/dirsnapshot.py:162: error: Function is missing a return type annotation  [no-untyped-def]
src/watchdog/utils/dirsnapshot.py:167: error: Function is missing a return type annotation  [no-untyped-def]
src/watchdog/utils/dirsnapshot.py:172: error: Function is missing a return type annotation  [no-untyped-def]
src/watchdog/utils/dirsnapshot.py:177: error: Function is missing a return type annotation  [no-untyped-def]
src/watchdog/utils/dirsnapshot.py:187: error: Function is missing a return type annotation  [no-untyped-def]
src/watchdog/utils/dirsnapshot.py:194: error: Function is missing a return type annotation  [no-untyped-def]
src/watchdog/utils/dirsnapshot.py:204: error: Function is missing a return type annotation  [no-untyped-def]
src/watchdog/utils/dirsnapshot.py:211: error: Function is missing a return type annotation  [no-untyped-def]
src/watchdog/utils/dirsnapshot.py:241: error: Function is missing a type annotation  [no-untyped-def]
src/watchdog/utils/dirsnapshot.py:258: error: Function is missing a type annotation  [no-untyped-def]
src/watchdog/utils/dirsnapshot.py:290: error: Function is missing a return type annotation  [no-untyped-def]
src/watchdog/utils/dirsnapshot.py:296: error: Function is missing a type annotation  [no-untyped-def]
src/watchdog/utils/dirsnapshot.py:302: error: Function is missing a type annotation  [no-untyped-def]
src/watchdog/utils/dirsnapshot.py:307: error: Function is missing a type annotation  [no-untyped-def]
src/watchdog/utils/dirsnapshot.py:310: error: Function is missing a type annotation  [no-untyped-def]
src/watchdog/utils/dirsnapshot.py:313: error: Function is missing a type annotation  [no-untyped-def]
src/watchdog/utils/dirsnapshot.py:316: error: Function is missing a type annotation  [no-untyped-def]
src/watchdog/utils/dirsnapshot.py:331: error: Function is missing a type annotation  [no-untyped-def]
src/watchdog/utils/dirsnapshot.py:340: error: Function is missing a type annotation  [no-untyped-def]
src/watchdog/utils/dirsnapshot.py:343: error: Function is missing a type annotation  [no-untyped-def]
src/watchdog/utils/dirsnapshot.py:354: error: Function is missing a type annotation  [no-untyped-def]
src/watchdog/utils/dirsnapshot.py:364: error: Function is missing a return type annotation  [no-untyped-def]
Found 27 errors in 1 file (checked 1 source file)
```

After:

```
(.venv)
abramowi at Marcs-MacBook-Pro-3 in ~/Code/OpenSource/watchdog (master●●)
$ mypy --disallow-untyped-defs src/watchdog/utils/dirsnapshot.py
Success: no issues found in 1 source file
```