### PR TITLE
Fix mypy errors introduced by GH-1012

### DIFF
--- a/src/watchdog/observers/polling.py
+++ b/src/watchdog/observers/polling.py
@@ -49,7 +49,7 @@ from watchdog.events import (
     FileMovedEvent,
 )
 from watchdog.observers.api import DEFAULT_EMITTER_TIMEOUT, DEFAULT_OBSERVER_TIMEOUT, BaseObserver, EventEmitter
-from watchdog.utils.dirsnapshot import DirectorySnapshot, DirectorySnapshotDiff
+from watchdog.utils.dirsnapshot import DirectorySnapshot, DirectorySnapshotDiff, EmptyDirectorySnapshot
 
 
 class PollingEmitter(EventEmitter):
@@ -68,7 +68,7 @@ class PollingEmitter(EventEmitter):
         listdir=os.scandir,
     ):
         super().__init__(event_queue, watch, timeout, event_filter)
-        self._snapshot = None
+        self._snapshot: DirectorySnapshot = EmptyDirectorySnapshot()
         self._lock = threading.Lock()
         self._take_snapshot = lambda: DirectorySnapshot(
             self.watch.path, self.watch.is_recursive, stat=stat, listdir=listdir

--- a/src/watchdog/utils/dirsnapshot.py
+++ b/src/watchdog/utils/dirsnapshot.py
@@ -356,11 +356,14 @@ class DirectorySnapshot:
         return str(self._stat_info)
 
 
-class EmptyDirectorySnapshot:
+class EmptyDirectorySnapshot(DirectorySnapshot):
     """Class to implement an empty snapshot. This is used together with
     DirectorySnapshot and DirectorySnapshotDiff in order to get all the files/folders
     in the directory as created.
     """
+
+    def __init__(self):
+        pass
 
     @staticmethod
     def path(_: Any) -> None:


### PR DESCRIPTION
Fix mypy errors introduced by GH-1012

```
(.venv)
abramowi at Marcs-MacBook-Pro-3 in ~/Code/OpenSource/watchdog (fix-mypy-errors●)
$ tox -e mypy
.pkg: _optional_hooks> python /Users/abramowi/Code/OpenSource/watchdog/.venv/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_editable> python /Users/abramowi/Code/OpenSource/watchdog/.venv/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: build_editable> python /Users/abramowi/Code/OpenSource/watchdog/.venv/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
mypy: install_package> python -I -m pip install --force-reinstall --no-deps /Users/abramowi/Code/OpenSource/watchdog/.tox/.tmp/package/11/watchdog-3.0.1-0.editable-cp310-cp310-macosx_12_0_arm64.whl
mypy: commands[0]> mypy
Success: no issues found in 48 source files
.pkg: _exit> python /Users/abramowi/Code/OpenSource/watchdog/.venv/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
  mypy: OK (1.61=setup[1.39]+cmd[0.23] seconds)
  congratulations :) (2.70 seconds)
```