### PR TITLE
Run black on inotify

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.black]
+target-version = ["py38"]
+line-length = 120
+safe = true
+
+[tool.isort]
+profile = "black"

--- a/src/watchdog/observers/inotify.py
+++ b/src/watchdog/observers/inotify.py
@@ -119,9 +119,7 @@ class InotifyEmitter(EventEmitter):
         Optional[Iterable[:class:`watchdog.events.FileSystemEvent`]]
     """
 
-    def __init__(
-        self, event_queue, watch, timeout=DEFAULT_EMITTER_TIMEOUT, event_filter=None
-    ):
+    def __init__(self, event_queue, watch, timeout=DEFAULT_EMITTER_TIMEOUT, event_filter=None):
         super().__init__(event_queue, watch, timeout, event_filter)
         self._lock = threading.Lock()
         self._inotify = None
@@ -140,15 +138,11 @@ class InotifyEmitter(EventEmitter):
         # If "full_events" is true, then the method will report unmatched move events as separate events
         # This behavior is by default only called by a InotifyFullEmitter
         if self._inotify is None:
-            logger.error(
-                "InotifyEmitter.queue_events() called when the thread is inactive"
-            )
+            logger.error("InotifyEmitter.queue_events() called when the thread is inactive")
             return
         with self._lock:
             if self._inotify is None:
-                logger.error(
-                    "InotifyEmitter.queue_events() called when the thread is inactive"
-                )
+                logger.error("InotifyEmitter.queue_events() called when the thread is inactive")
                 return
             event = self._inotify.read_event()
             if event is None:

--- a/src/watchdog/observers/inotify.py
+++ b/src/watchdog/observers/inotify.py
@@ -86,12 +86,7 @@ from watchdog.events import (
     generate_sub_created_events,
     generate_sub_moved_events,
 )
-from watchdog.observers.api import (
-    DEFAULT_EMITTER_TIMEOUT,
-    DEFAULT_OBSERVER_TIMEOUT,
-    BaseObserver,
-    EventEmitter,
-)
+from watchdog.observers.api import DEFAULT_EMITTER_TIMEOUT, DEFAULT_OBSERVER_TIMEOUT, BaseObserver, EventEmitter
 
 from .inotify_buffer import InotifyBuffer
 from .inotify_c import InotifyConstants

--- a/src/watchdog/observers/inotify.py
+++ b/src/watchdog/observers/inotify.py
@@ -86,7 +86,12 @@ from watchdog.events import (
     generate_sub_created_events,
     generate_sub_moved_events,
 )
-from watchdog.observers.api import DEFAULT_EMITTER_TIMEOUT, DEFAULT_OBSERVER_TIMEOUT, BaseObserver, EventEmitter
+from watchdog.observers.api import (
+    DEFAULT_EMITTER_TIMEOUT,
+    DEFAULT_OBSERVER_TIMEOUT,
+    BaseObserver,
+    EventEmitter,
+)
 
 from .inotify_buffer import InotifyBuffer
 from .inotify_c import InotifyConstants
@@ -114,7 +119,9 @@ class InotifyEmitter(EventEmitter):
         Optional[Iterable[:class:`watchdog.events.FileSystemEvent`]]
     """
 
-    def __init__(self, event_queue, watch, timeout=DEFAULT_EMITTER_TIMEOUT, event_filter=None):
+    def __init__(
+        self, event_queue, watch, timeout=DEFAULT_EMITTER_TIMEOUT, event_filter=None
+    ):
         super().__init__(event_queue, watch, timeout, event_filter)
         self._lock = threading.Lock()
         self._inotify = None
@@ -133,11 +140,15 @@ class InotifyEmitter(EventEmitter):
         # If "full_events" is true, then the method will report unmatched move events as separate events
         # This behavior is by default only called by a InotifyFullEmitter
         if self._inotify is None:
-            logger.error("InotifyEmitter.queue_events() called when the thread is inactive")
+            logger.error(
+                "InotifyEmitter.queue_events() called when the thread is inactive"
+            )
             return
         with self._lock:
             if self._inotify is None:
-                logger.error("InotifyEmitter.queue_events() called when the thread is inactive")
+                logger.error(
+                    "InotifyEmitter.queue_events() called when the thread is inactive"
+                )
                 return
             event = self._inotify.read_event()
             if event is None:
@@ -221,9 +232,13 @@ class InotifyEmitter(EventEmitter):
             elif cls in (DirCreatedEvent, FileCreatedEvent):
                 event_mask |= InotifyConstants.IN_MOVE | InotifyConstants.IN_CREATE
             elif cls is DirModifiedEvent:
-                event_mask |= (InotifyConstants.IN_MOVE | InotifyConstants.IN_ATTRIB |
-                               InotifyConstants.IN_MODIFY | InotifyConstants.IN_CREATE |
-                               InotifyConstants.IN_CLOSE_WRITE)
+                event_mask |= (
+                    InotifyConstants.IN_MOVE
+                    | InotifyConstants.IN_ATTRIB
+                    | InotifyConstants.IN_MODIFY
+                    | InotifyConstants.IN_CREATE
+                    | InotifyConstants.IN_CLOSE_WRITE
+                )
             elif cls is FileModifiedEvent:
                 event_mask |= InotifyConstants.IN_ATTRIB | InotifyConstants.IN_MODIFY
             elif cls in (DirDeletedEvent, FileDeletedEvent):


### PR DESCRIPTION
Run `black` on `src/watchdog/observers/inotify.py`. Fixes failing `flake8` tests (like [this one](https://github.com/gorakhargosh/watchdog/actions/runs/6461887884/job/17542490845#step:5:31)):

Before:
-------

```
(.venv)
abramowi at Marcs-MacBook-Pro-3 in ~/Code/OpenSource/watchdog (master●)
$ python -m tox -e flake8
flake8: install_deps> python -I -m pip install -r requirements-tests.txt
.pkg: _optional_hooks> python /Users/abramowi/Code/OpenSource/watchdog/.venv/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_editable> python /Users/abramowi/Code/OpenSource/watchdog/.venv/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: build_editable> python /Users/abramowi/Code/OpenSource/watchdog/.venv/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
flake8: install_package_deps> python -I -m pip install 'PyYAML>=3.10'
flake8: install_package> python -I -m pip install --force-reinstall --no-deps /Users/abramowi/Code/OpenSource/watchdog/.tox/.tmp/package/12/watchdog-3.0.1-0.editable-cp310-cp310-macosx_12_0_arm64.whl
flake8: commands[0]> python -m flake8 docs tools src tests setup.py
src/watchdog/observers/inotify.py:224:86: W504 line break after binary operator
src/watchdog/observers/inotify.py:225:88: W504 line break after binary operator
flake8: exit 1 (0.40 seconds) /Users/abramowi/Code/OpenSource/watchdog> python -m flake8 docs tools src tests setup.py pid=76654
.pkg: _exit> python /Users/abramowi/Code/OpenSource/watchdog/.venv/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
  flake8: FAIL code 1 (9.23=setup[8.83]+cmd[0.40] seconds)
  evaluation failed :( (10.10 seconds)
```

After:
------

```
(.venv)
abramowi at Marcs-MacBook-Pro-3 in ~/Code/OpenSource/watchdog (master●)
$ python -m tox -e flake8
.pkg: _optional_hooks> python /Users/abramowi/Code/OpenSource/watchdog/.venv/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_editable> python /Users/abramowi/Code/OpenSource/watchdog/.venv/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: build_editable> python /Users/abramowi/Code/OpenSource/watchdog/.venv/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
flake8: install_package> python -I -m pip install --force-reinstall --no-deps /Users/abramowi/Code/OpenSource/watchdog/.tox/.tmp/package/13/watchdog-3.0.1-0.editable-cp310-cp310-macosx_12_0_arm64.whl
flake8: commands[0]> python -m flake8 docs tools src tests setup.py
.pkg: _exit> python /Users/abramowi/Code/OpenSource/watchdog/.venv/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
  flake8: OK (1.59=setup[1.11]+cmd[0.48] seconds)
  congratulations :) (2.45 seconds)
```