### PR TITLE
fix: mypy `Unused "type: ignore" comment, use narrower...` errors

### DIFF
--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -29,7 +29,7 @@ import threading
 import time
 import unicodedata
 
-import _watchdog_fsevents as _fsevents  # type: ignore[import]
+import _watchdog_fsevents as _fsevents  # type: ignore[import-not-found]
 
 from watchdog.events import (
     DirCreatedEvent,

--- a/src/watchdog/observers/fsevents2.py
+++ b/src/watchdog/observers/fsevents2.py
@@ -29,8 +29,8 @@ from threading import Thread
 from typing import List, Optional, Type
 
 # pyobjc
-import AppKit  # type: ignore[import]
-from FSEvents import (  # type: ignore[import]
+import AppKit  # type: ignore[import-not-found]
+from FSEvents import (  # type: ignore[import-not-found]
     CFRunLoopGetCurrent,
     CFRunLoopRun,
     CFRunLoopStop,

--- a/tests/test_fsevents.py
+++ b/tests/test_fsevents.py
@@ -16,7 +16,7 @@ from threading import Thread
 from time import sleep
 from unittest.mock import patch
 
-import _watchdog_fsevents as _fsevents  # type: ignore[import]
+import _watchdog_fsevents as _fsevents  # type: ignore[import-not-found]
 
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer

--- a/tests/test_skip_repeats_queue.py
+++ b/tests/test_skip_repeats_queue.py
@@ -106,7 +106,7 @@ def test_consecutives_allowed_across_empties():
 @cpython_only
 def test_eventlet_monkey_patching():
     try:
-        import eventlet  # type: ignore[import]
+        import eventlet  # type: ignore[import-untyped]
     except Exception:
         pytest.skip("eventlet not installed")
 


### PR DESCRIPTION
Before:
-------

```
(.venv)
abramowi at Marcs-MacBook-Pro-3 in ~/Code/OpenSource/watchdog (master)
$ python -m tox -e mypy
.pkg: _optional_hooks> python /Users/abramowi/Code/OpenSource/watchdog/.venv/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_editable> python /Users/abramowi/Code/OpenSource/watchdog/.venv/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: build_editable> python /Users/abramowi/Code/OpenSource/watchdog/.venv/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
mypy: install_package> python -I -m pip install --force-reinstall --no-deps /Users/abramowi/Code/OpenSource/watchdog/.tox/.tmp/package/27/watchdog-3.0.1-0.editable-cp310-cp310-macosx_12_0_arm64.whl
mypy: commands[0]> mypy
src/watchdog/observers/fsevents2.py:32: error: Unused "type: ignore" comment, use narrower [import-not-found] instead of [import] code  [unused-ignore]
src/watchdog/observers/fsevents2.py:33: error: Unused "type: ignore" comment, use narrower [import-not-found] instead of [import] code  [unused-ignore]
src/watchdog/observers/fsevents.py:32: error: Unused "type: ignore" comment, use narrower [import-not-found] instead of [import] code  [unused-ignore]
tests/test_fsevents.py:19: error: Unused "type: ignore" comment, use narrower [import-not-found] instead of [import] code  [unused-ignore]
tests/test_skip_repeats_queue.py:109: error: Unused "type: ignore" comment, use narrower [import-untyped] instead of [import] code  [unused-ignore]
Found 5 errors in 4 files (checked 48 source files)
mypy: exit 1 (0.63 seconds) /Users/abramowi/Code/OpenSource/watchdog> mypy pid=24917
.pkg: _exit> python /Users/abramowi/Code/OpenSource/watchdog/.venv/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
  mypy: FAIL code 1 (1.67=setup[1.04]+cmd[0.63] seconds)
  evaluation failed :( (2.49 seconds)
```

After:
------

```
(.venv)
abramowi at Marcs-MacBook-Pro-3 in ~/Code/OpenSource/watchdog (fix-mypy-type-ignore-import-errors)
$ python -m tox -e mypy
.pkg: _optional_hooks> python /Users/abramowi/Code/OpenSource/watchdog/.venv/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_editable> python /Users/abramowi/Code/OpenSource/watchdog/.venv/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: build_editable> python /Users/abramowi/Code/OpenSource/watchdog/.venv/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
mypy: install_package> python -I -m pip install --force-reinstall --no-deps /Users/abramowi/Code/OpenSource/watchdog/.tox/.tmp/package/28/watchdog-3.0.1-0.editable-cp310-cp310-macosx_12_0_arm64.whl
mypy: commands[0]> mypy
Success: no issues found in 48 source files
.pkg: _exit> python /Users/abramowi/Code/OpenSource/watchdog/.venv/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
  mypy: OK (1.67=setup[1.05]+cmd[0.62] seconds)
  congratulations :) (2.44 seconds)
```