### PR TITLE
Fix inotify full emitter to accept event_filter

### DIFF
--- a/src/watchdog/observers/inotify.py
+++ b/src/watchdog/observers/inotify.py
@@ -254,10 +254,15 @@ class InotifyFullEmitter(InotifyEmitter):
         Read events blocking timeout (in seconds).
     :type timeout:
         ``float``
+    :param event_filter:
+        Collection of event types to emit, or None for no filtering (default).
+    :type event_filter:
+        Optional[Iterable[:class:`watchdog.events.FileSystemEvent`]]
+
     """
 
-    def __init__(self, event_queue, watch, timeout=DEFAULT_EMITTER_TIMEOUT):
-        super().__init__(event_queue, watch, timeout)
+    def __init__(self, event_queue, watch, timeout=DEFAULT_EMITTER_TIMEOUT, event_filter=None):
+        super().__init__(event_queue, watch, timeout, event_filter)
 
     def queue_events(self, timeout, events=True):
         InotifyEmitter.queue_events(self, timeout, full_events=events)


### PR DESCRIPTION
It looks like adding event filters in https://github.com/gorakhargosh/watchdog/pull/989 somehow missed adding it to `InotifyFullEmitter`. This PR fixes this.

This is my first PR in this repo, feedback is welcome on how to do things up to your standards :)