### PR TITLE
Simplify the quickstart example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,28 +16,26 @@ as command-line arguments and logs events generated:
 
 .. code-block:: python
 
-    import sys
     import time
-    import logging
     from watchdog.observers import Observer
-    from watchdog.events import LoggingEventHandler
+    from watchdog.events import FileSystemEventHandler
 
-    if __name__ == "__main__":
-        logging.basicConfig(level=logging.INFO,
-                            format='%(asctime)s - %(message)s',
-                            datefmt='%Y-%m-%d %H:%M:%S')
-        path = sys.argv[1] if len(sys.argv) > 1 else '.'
-        logging.info(f'start watching directory {path!r}')
-        event_handler = LoggingEventHandler()
-        observer = Observer()
-        observer.schedule(event_handler, path, recursive=True)
-        observer.start()
-        try:
-            while True:
-                time.sleep(1)
-        finally:
-            observer.stop()
-            observer.join()
+
+    class MyEventHandler(FileSystemEventHandler):
+        def on_any_event(self, event):
+            print(event)
+
+
+    event_handler = MyEventHandler()
+    observer = Observer()
+    observer.schedule(event_handler, '.', recursive=True)
+    observer.start()
+    try:
+        while True:
+            time.sleep(1)
+    finally:
+        observer.stop()
+        observer.join()
 
 
 Shell Utilities

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -10,9 +10,7 @@ to detect changes. Here is what we will do with the API:
 
 1. Create an instance of the :class:`watchdog.observers.Observer` thread class.
 
-2. Implement a subclass of :class:`watchdog.events.FileSystemEventHandler`
-   (or as in our case, we will use the built-in
-   :class:`watchdog.events.LoggingEventHandler`, which already does).
+2. Implement a subclass of :class:`watchdog.events.FileSystemEventHandler`.
 
 3. Schedule monitoring a few paths with the observer instance
    attaching the event handler.
@@ -29,27 +27,27 @@ entire directory trees is ensured.
 A Simple Example
 ----------------
 The following example program will monitor the current directory recursively for
-file system changes and simply log them to the console::
+file system changes and simply print them to the console::
 
-    import sys
-    import logging
+    import time
     from watchdog.observers import Observer
-    from watchdog.events import LoggingEventHandler
+    from watchdog.events import FileSystemEventHandler
 
-    if __name__ == "__main__":
-        logging.basicConfig(level=logging.INFO,
-                            format='%(asctime)s - %(message)s',
-                            datefmt='%Y-%m-%d %H:%M:%S')
-        path = sys.argv[1] if len(sys.argv) > 1 else '.'
-        event_handler = LoggingEventHandler()
-        observer = Observer()
-        observer.schedule(event_handler, path, recursive=True)
-        observer.start()
-        try:
-            while observer.is_alive():
-                observer.join(1)
-        finally:
-            observer.stop()
-            observer.join()
+
+    class MyEventHandler(FileSystemEventHandler):
+        def on_any_event(self, event):
+            print(event)
+
+
+    event_handler = MyEventHandler()
+    observer = Observer()
+    observer.schedule(event_handler, '.', recursive=True)
+    observer.start()
+    try:
+        while True:
+            time.sleep(1)
+    finally:
+        observer.stop()
+        observer.join()
 
 To stop the program, press Control-C.


### PR DESCRIPTION
Personally, I found the quickstart example to be jumbled and a little confusing. It was hard for me to tell where I would put my own code to react to file system events (indeed the quickstart never showed how to do this).

I also think the selection of the path using sys.argv and place everything under "if name == main" is unnecessary for the simple example.

I hope you find this helpful.