### PR TITLE
Update PatternMatchingEventHandler documentation

### DIFF
--- a/src/watchdog/events.py
+++ b/src/watchdog/events.py
@@ -297,6 +297,8 @@ class FileSystemEventHandler:
 class PatternMatchingEventHandler(FileSystemEventHandler):
     """
     Matches given patterns with file paths associated with occurring events.
+    Uses pathlib's PurePath.match() method. `patterns` and `ignore_patterns`
+    are expected to be a list of strings.
     """
 
     def __init__(
@@ -375,6 +377,7 @@ class PatternMatchingEventHandler(FileSystemEventHandler):
 class RegexMatchingEventHandler(FileSystemEventHandler):
     """
     Matches given regexes with file paths associated with occurring events.
+    Uses the re module.
     """
 
     def __init__(

--- a/src/watchdog/events.py
+++ b/src/watchdog/events.py
@@ -297,7 +297,7 @@ class FileSystemEventHandler:
 class PatternMatchingEventHandler(FileSystemEventHandler):
     """
     Matches given patterns with file paths associated with occurring events.
-    Uses pathlib's PurePath.match() method. `patterns` and `ignore_patterns`
+    Uses pathlib's `PurePath.match()` method. `patterns` and `ignore_patterns`
     are expected to be a list of strings.
     """
 
@@ -377,7 +377,7 @@ class PatternMatchingEventHandler(FileSystemEventHandler):
 class RegexMatchingEventHandler(FileSystemEventHandler):
     """
     Matches given regexes with file paths associated with occurring events.
-    Uses the re module.
+    Uses the `re` module.
     """
 
     def __init__(


### PR DESCRIPTION
From the existing docs it's not clear what the difference is between PatternMatching and RegexMatching. Hopefully this makes it clearer.

Also made a note that RegexMatching uses the re module, since there are various flavors of regex syntax and it's important to know which one is used.