### PR TITLE
[inotify] Add support for `IN_CLOSE_NOWRITE` events

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,4 +87,4 @@ jobs:
         run: python -m pip install tox
 
       - name: Run ${{ matrix.tox.name }} in tox
-        run: python -m tox -e ${{ matrix.tox.environment }}
+        run: python -m tox -q -e ${{ matrix.tox.environment }}

--- a/changelog.rst
+++ b/changelog.rst
@@ -16,6 +16,7 @@ Changelog
 - [inotify] Renamed the ``inotify_event_struct`` class to ``InotifyEventStruct`` (`#1055 <https://github.com/gorakhargosh/watchdog/pull/1055>`__)
 - [inotify] Renamed the ``UnsupportedLibc`` exception to ``UnsupportedLibcError`` (`#1057 <https://github.com/gorakhargosh/watchdog/pull/1057>`__)
 - [inotify] Add support for ``IN_CLOSE_NOWRITE`` events. A ``FileClosedNoWriteEvent`` event will be fired, and its ``on_closed_no_write()`` dispatcher has been introduced (`#1046 <https://github.com/gorakhargosh/watchdog/pull/1046>`__)
+- [inotify] Removed the ``InotifyConstants.IN_CLOSE`` constant (`#1046 <https://github.com/gorakhargosh/watchdog/pull/1046>`__)
 - [watchmedo] Renamed the ``LogLevelException`` exception to ``LogLevelError`` (`#1057 <https://github.com/gorakhargosh/watchdog/pull/1057>`__)
 - [watchmedo] Renamed the ``WatchdogShutdown`` exception to ``WatchdogShutdownError`` (`#1057 <https://github.com/gorakhargosh/watchdog/pull/1057>`__)
 - [windows] Renamed the ``FILE_NOTIFY_INFORMATION`` class to ``FileNotifyInformation`` (`#1055 <https://github.com/gorakhargosh/watchdog/pull/1055>`__)

--- a/changelog.rst
+++ b/changelog.rst
@@ -15,6 +15,7 @@ Changelog
 - [core] Improve typing references for events (`#1040 <https://github.com/gorakhargosh/watchdog/issues/1040>`__)
 - [inotify] Renamed the ``inotify_event_struct`` class to ``InotifyEventStruct`` (`#1055 <https://github.com/gorakhargosh/watchdog/pull/1055>`__)
 - [inotify] Renamed the ``UnsupportedLibc`` exception to ``UnsupportedLibcError`` (`#1057 <https://github.com/gorakhargosh/watchdog/pull/1057>`__)
+- [inotify] Add support for ``IN_CLOSE_NOWRITE`` events. A ``FileClosedNoWriteEvent`` event will be fired, and its ``on_closed_no_write()`` dispatcher has been introduced (`#1046 <https://github.com/gorakhargosh/watchdog/pull/1046>`__)
 - [watchmedo] Renamed the ``LogLevelException`` exception to ``LogLevelError`` (`#1057 <https://github.com/gorakhargosh/watchdog/pull/1057>`__)
 - [watchmedo] Renamed the ``WatchdogShutdown`` exception to ``WatchdogShutdownError`` (`#1057 <https://github.com/gorakhargosh/watchdog/pull/1057>`__)
 - [windows] Renamed the ``FILE_NOTIFY_INFORMATION`` class to ``FileNotifyInformation`` (`#1055 <https://github.com/gorakhargosh/watchdog/pull/1055>`__)

--- a/src/watchdog/observers/inotify.py
+++ b/src/watchdog/observers/inotify.py
@@ -227,7 +227,7 @@ class InotifyEmitter(EventEmitter):
             elif cls in (DirDeletedEvent, FileDeletedEvent):
                 event_mask |= InotifyConstants.IN_DELETE
             elif cls is FileClosedEvent:
-                event_mask |= InotifyConstants.IN_CLOSE
+                event_mask |= InotifyConstants.IN_CLOSE_WRITE
             elif cls is FileClosedNoWriteEvent:
                 event_mask |= InotifyConstants.IN_CLOSE_NOWRITE
             elif cls is FileOpenedEvent:

--- a/src/watchdog/observers/inotify_c.py
+++ b/src/watchdog/observers/inotify_c.py
@@ -56,7 +56,6 @@ class InotifyConstants:
     IN_MOVE_SELF = 0x00000800  # Self was moved.
 
     # Helper user-space events.
-    IN_CLOSE = IN_CLOSE_WRITE | IN_CLOSE_NOWRITE  # Close.
     IN_MOVE = IN_MOVED_FROM | IN_MOVED_TO  # Moves.
 
     # Events sent by the kernel to a watch.
@@ -552,11 +551,7 @@ class InotifyEvent:
     def _get_mask_string(mask):
         masks = []
         for c in dir(InotifyConstants):
-            if c.startswith("IN_") and c not in [
-                "IN_ALL_EVENTS",
-                "IN_CLOSE",
-                "IN_MOVE",
-            ]:
+            if c.startswith("IN_") and c not in {"IN_ALL_EVENTS", "IN_MOVE"}:
                 c_val = getattr(InotifyConstants, c)
                 if mask & c_val:
                     masks.append(c)

--- a/src/watchdog/observers/inotify_c.py
+++ b/src/watchdog/observers/inotify_c.py
@@ -109,6 +109,7 @@ WATCHDOG_ALL_EVENTS = reduce(
         InotifyConstants.IN_DELETE_SELF,
         InotifyConstants.IN_DONT_FOLLOW,
         InotifyConstants.IN_CLOSE_WRITE,
+        InotifyConstants.IN_CLOSE_NOWRITE,
         InotifyConstants.IN_OPEN,
     ],
 )

--- a/src/watchdog/tricks/__init__.py
+++ b/src/watchdog/tricks/__init__.py
@@ -49,7 +49,7 @@ import subprocess
 import threading
 import time
 
-from watchdog.events import EVENT_TYPE_OPENED, FileSystemEvent, PatternMatchingEventHandler
+from watchdog.events import EVENT_TYPE_CLOSED_NO_WRITE, EVENT_TYPE_OPENED, FileSystemEvent, PatternMatchingEventHandler
 from watchdog.utils import echo, platform
 from watchdog.utils.event_debouncer import EventDebouncer
 from watchdog.utils.process_watcher import ProcessWatcher
@@ -111,7 +111,7 @@ class ShellCommandTrick(Trick):
         self._process_watchers = set()
 
     def on_any_event(self, event: FileSystemEvent) -> None:
-        if event.event_type == EVENT_TYPE_OPENED:
+        if event.event_type in {EVENT_TYPE_OPENED, EVENT_TYPE_CLOSED_NO_WRITE}:
             # FIXME: see issue #949, and find a way to better handle that scenario
             return
 
@@ -277,7 +277,7 @@ class AutoRestartTrick(Trick):
 
     @echo_events
     def on_any_event(self, event: FileSystemEvent) -> None:
-        if event.event_type == EVENT_TYPE_OPENED:
+        if event.event_type in {EVENT_TYPE_OPENED, EVENT_TYPE_CLOSED_NO_WRITE}:
             # FIXME: see issue #949, and find a way to better handle that scenario
             return
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from watchdog.events import (
     EVENT_TYPE_CLOSED,
+    EVENT_TYPE_CLOSED_NO_WRITE,
     EVENT_TYPE_CREATED,
     EVENT_TYPE_DELETED,
     EVENT_TYPE_MODIFIED,
@@ -27,6 +28,7 @@ from watchdog.events import (
     DirModifiedEvent,
     DirMovedEvent,
     FileClosedEvent,
+    FileClosedNoWriteEvent,
     FileCreatedEvent,
     FileDeletedEvent,
     FileModifiedEvent,
@@ -94,6 +96,14 @@ def test_file_closed_event():
     assert not event.is_synthetic
 
 
+def test_file_closed_no_write_event():
+    event = FileClosedNoWriteEvent(path_1)
+    assert path_1 == event.src_path
+    assert event.event_type == EVENT_TYPE_CLOSED_NO_WRITE
+    assert not event.is_directory
+    assert not event.is_synthetic
+
+
 def test_file_opened_event():
     event = FileOpenedEvent(path_1)
     assert path_1 == event.src_path
@@ -132,6 +142,7 @@ def test_file_system_event_handler_dispatch():
     dir_cre_event = DirCreatedEvent("/path/blah.py")
     file_cre_event = FileCreatedEvent("/path/blah.txt")
     file_cls_event = FileClosedEvent("/path/blah.txt")
+    file_cls_nw_event = FileClosedNoWriteEvent("/path/blah.txt")
     file_opened_event = FileOpenedEvent("/path/blah.txt")
     dir_mod_event = DirModifiedEvent("/path/blah.py")
     file_mod_event = FileModifiedEvent("/path/blah.txt")
@@ -148,29 +159,50 @@ def test_file_system_event_handler_dispatch():
         file_cre_event,
         file_mov_event,
         file_cls_event,
+        file_cls_nw_event,
         file_opened_event,
     ]
 
+    checkpoint = 0
+
     class TestableEventHandler(FileSystemEventHandler):
         def on_any_event(self, event):
-            pass
+            nonlocal checkpoint
+            checkpoint += 1
 
         def on_modified(self, event):
+            nonlocal checkpoint
+            checkpoint += 1
             assert event.event_type == EVENT_TYPE_MODIFIED
 
         def on_deleted(self, event):
+            nonlocal checkpoint
+            checkpoint += 1
             assert event.event_type == EVENT_TYPE_DELETED
 
         def on_moved(self, event):
+            nonlocal checkpoint
+            checkpoint += 1
             assert event.event_type == EVENT_TYPE_MOVED
 
         def on_created(self, event):
+            nonlocal checkpoint
+            checkpoint += 1
             assert event.event_type == EVENT_TYPE_CREATED
 
         def on_closed(self, event):
+            nonlocal checkpoint
+            checkpoint += 1
             assert event.event_type == EVENT_TYPE_CLOSED
 
+        def on_closed_no_write(self, event):
+            nonlocal checkpoint
+            checkpoint += 1
+            assert event.event_type == EVENT_TYPE_CLOSED_NO_WRITE
+
         def on_opened(self, event):
+            nonlocal checkpoint
+            checkpoint += 1
             assert event.event_type == EVENT_TYPE_OPENED
 
     handler = TestableEventHandler()
@@ -178,6 +210,8 @@ def test_file_system_event_handler_dispatch():
     for event in all_events:
         assert not event.is_synthetic
         handler.dispatch(event)
+
+    assert checkpoint == len(all_events) * 2  # `on_any_event()` + specific `on_XXX()`
 
 
 def test_event_comparison():

--- a/tests/test_inotify_buffer.py
+++ b/tests/test_inotify_buffer.py
@@ -94,13 +94,11 @@ def test_move_internal_batch(p):
         mv(p("dir1", f), p("dir2", f))
 
     # Check that all n events are paired
-    i = 0
-    while i < n:
+    for _ in range(n):
         frm, to = wait_for_move_event(inotify.read_event)
         assert os.path.dirname(frm.src_path).endswith(b"/dir1")
         assert os.path.dirname(to.src_path).endswith(b"/dir2")
         assert frm.name == to.name
-        i += 1
     inotify.close()
 
 
@@ -146,11 +144,8 @@ def delay_call(function, seconds):
 class InotifyBufferDelayedRead(InotifyBuffer):
     def run(self, *args, **kwargs):
         # Introduce a delay to trigger the race condition where the file descriptor is
-        # closed prior to a read being triggered.  Ignoring type concerns since we are
-        # intentionally doing something odd.
-        self._inotify.read_events = delay_call(  # type: ignore[method-assign]
-            function=self._inotify.read_events, seconds=1
-        )
+        # closed prior to a read being triggered.
+        self._inotify.read_events = delay_call(self._inotify.read_events, 1)
 
         return super().run(*args, **kwargs)
 

--- a/tests/test_logging_event_handler.py
+++ b/tests/test_logging_event_handler.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from watchdog.events import (
     EVENT_TYPE_CLOSED,
+    EVENT_TYPE_CLOSED_NO_WRITE,
     EVENT_TYPE_CREATED,
     EVENT_TYPE_DELETED,
     EVENT_TYPE_MODIFIED,
@@ -27,6 +28,7 @@ from watchdog.events import (
     DirModifiedEvent,
     DirMovedEvent,
     FileClosedEvent,
+    FileClosedNoWriteEvent,
     FileCreatedEvent,
     FileDeletedEvent,
     FileModifiedEvent,
@@ -64,13 +66,16 @@ class _TestableEventHandler(LoggingEventHandler):
         super().on_closed(event)
         assert event.event_type == EVENT_TYPE_CLOSED
 
+    def on_closed_no_write(self, event):
+        super().on_closed_no_write(event)
+        assert event.event_type == EVENT_TYPE_CLOSED_NO_WRITE
+
     def on_opened(self, event):
         super().on_opened(event)
         assert event.event_type == EVENT_TYPE_OPENED
 
 
 def test_logging_event_handler_dispatch():
-    # Utilities.
     dir_del_event = DirDeletedEvent("/path/blah.py")
     file_del_event = FileDeletedEvent("/path/blah.txt")
     dir_cre_event = DirCreatedEvent("/path/blah.py")
@@ -81,6 +86,7 @@ def test_logging_event_handler_dispatch():
     file_mov_event = FileMovedEvent("/path/blah.txt", "/path/blah")
     file_ope_event = FileOpenedEvent("/path/blah.txt")
     file_clo_event = FileClosedEvent("/path/blah.txt")
+    file_clo_nw_event = FileClosedNoWriteEvent("/path/blah.txt")
 
     all_events = [
         dir_mod_event,
@@ -93,6 +99,7 @@ def test_logging_event_handler_dispatch():
         file_mov_event,
         file_ope_event,
         file_clo_event,
+        file_clo_nw_event,
     ]
 
     handler = _TestableEventHandler()


### PR DESCRIPTION
A `FileClosedNoWriteEvent` event will be fired, and its `on_closed_no_write()` dispatcher has been introduced.
Also removed the `InotifyConstants.IN_CLOSE` constant.

Closes #1046.