### PR TITLE
`kqueue.control()` only accepts positional parameters

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -8,8 +8,8 @@ Changelog
 
 2024-xx-xx • `full history <https://github.com/gorakhargosh/watchdog/compare/v5.0.0...HEAD>`__
 
-- 
-- Thanks to our beloved contributors: @
+- [kqueue] Fix ``TypeError: kqueue.control() only accepts positional parameters``  (`#1062 <https://github.com/gorakhargosh/watchdog/pull/1062>`__)
+- Thanks to our beloved contributors: @apoirier
 
 5.0.0
 ~~~~~

--- a/src/watchdog/observers/kqueue.py
+++ b/src/watchdog/observers/kqueue.py
@@ -599,7 +599,7 @@ class KqueueEmitter(EventEmitter):
         :type timeout:
             ``float`` (seconds)
         """
-        return self._kq.control(self._descriptors.kevents, MAX_EVENTS, timeout=timeout)
+        return self._kq.control(self._descriptors.kevents, MAX_EVENTS, timeout)
 
     def queue_events(self, timeout: float) -> None:
         """Queues events by reading them from a call to the blocking


### PR DESCRIPTION
A `TypeError`, `kqueue.control() takes no keyword argumentsTypeError` is raised