### PR TITLE
Properly clean up threads when stopping Inotify. Improve Eventlet tests.

### DIFF
--- a/src/watchdog/utils/bricks.py
+++ b/src/watchdog/utils/bricks.py
@@ -72,14 +72,13 @@ class SkipRepeatsQueue(queue.Queue):
         super()._init(maxsize)
         self._last_item = None
 
-    def _put(self, item: Any) -> None:
+    def put(self, item: Any, block: bool = True, timeout: float | None = None) -> None:
         if self._last_item is None or item != self._last_item:
-            super()._put(item)
-            self._last_item = item
-        else:
-            # `put` increments `unfinished_tasks` even if we did not put
-            # anything into the queue here
-            self.unfinished_tasks -= 1
+            super().put(item, block, timeout)
+
+    def _put(self, item: Any) -> None:
+        super()._put(item)
+        self._last_item = item
 
     def _get(self) -> Any:
         item = super()._get()

--- a/tests/isolated/eventlet_observer_stops.py
+++ b/tests/isolated/eventlet_observer_stops.py
@@ -1,0 +1,30 @@
+if __name__ == '__main__':
+    import eventlet
+
+    eventlet.monkey_patch()
+
+    import signal
+    import sys
+    import tempfile
+
+    from watchdog.observers import Observer
+    from watchdog.events import LoggingEventHandler
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        def run_observer():
+            event_handler = LoggingEventHandler()
+            observer = Observer()
+            observer.schedule(event_handler, temp_dir)
+            observer.start()
+            eventlet.sleep(1)
+            observer.stop()
+
+        def on_alarm(signum, frame):
+            print("Observer.stop() never finished!", file=sys.stderr)
+            sys.exit(1)
+
+        signal.signal(signal.SIGALRM, on_alarm)
+        signal.alarm(4)
+
+        thread = eventlet.spawn(run_observer)
+        thread.wait()

--- a/tests/isolated/eventlet_skip_repeat_queue.py
+++ b/tests/isolated/eventlet_skip_repeat_queue.py
@@ -1,0 +1,23 @@
+if __name__ == '__main__':
+    import eventlet
+
+    eventlet.monkey_patch()
+
+    from watchdog.utils.bricks import SkipRepeatsQueue
+
+    # same as test_basic_queue() inside test_skip_repeats_queue.py
+
+    q = SkipRepeatsQueue()
+
+    e1 = (2, "fred")
+    e2 = (2, "george")
+    e3 = (4, "sally")
+
+    q.put(e1)
+    q.put(e2)
+    q.put(e3)
+
+    assert e1 == q.get()
+    assert e2 == q.get()
+    assert e3 == q.get()
+    assert q.empty()

--- a/tests/isolated/eventlet_skip_repeat_queue.py
+++ b/tests/isolated/eventlet_skip_repeat_queue.py
@@ -5,19 +5,29 @@ if __name__ == '__main__':
 
     from watchdog.utils.bricks import SkipRepeatsQueue
 
-    # same as test_basic_queue() inside test_skip_repeats_queue.py
+    q = SkipRepeatsQueue(10)
+    q.put('A')
+    q.put('A')
+    q.put('A')
+    q.put('A')
+    q.put('B')
+    q.put('A')
 
-    q = SkipRepeatsQueue()
+    value = q.get()
+    assert value == 'A'
+    q.task_done()
 
-    e1 = (2, "fred")
-    e2 = (2, "george")
-    e3 = (4, "sally")
+    assert q.unfinished_tasks == 2
 
-    q.put(e1)
-    q.put(e2)
-    q.put(e3)
+    value = q.get()
+    assert value == 'B'
+    q.task_done()
 
-    assert e1 == q.get()
-    assert e2 == q.get()
-    assert e3 == q.get()
+    assert q.unfinished_tasks == 1
+
+    value = q.get()
+    assert value == 'A'
+    q.task_done()
+
     assert q.empty()
+    assert q.unfinished_tasks == 0

--- a/tests/markers.py
+++ b/tests/markers.py
@@ -1,7 +1,0 @@
-from __future__ import annotations
-
-from platform import python_implementation
-
-import pytest
-
-cpython_only = pytest.mark.skipif(python_implementation() != "CPython", reason="CPython only.")

--- a/tests/test_isolated.py
+++ b/tests/test_isolated.py
@@ -1,11 +1,14 @@
 import pytest
 import importlib
 
-from .markers import cpython_only
+from watchdog.utils import platform
+
 from .utils import run_isolated_test
 
 
-@cpython_only
+# Kqueue isn't supported by Eventlet, so BSD is out
+# Current usage ReadDirectoryChangesW on Windows is blocking, though async may be possible
+@pytest.mark.skipif(not platform.is_linux(), reason="Eventlet only supported in Linux")
 def test_observer_stops_in_eventlet():
     if not importlib.util.find_spec('eventlet'):
         pytest.skip("eventlet not installed")
@@ -13,7 +16,7 @@ def test_observer_stops_in_eventlet():
     run_isolated_test('eventlet_observer_stops.py')
 
 
-@cpython_only
+@pytest.mark.skipif(not platform.is_linux(), reason="Eventlet only supported in Linux")
 def test_eventlet_skip_repeat_queue():
     if not importlib.util.find_spec('eventlet'):
         pytest.skip("eventlet not installed")

--- a/tests/test_isolated.py
+++ b/tests/test_isolated.py
@@ -1,0 +1,21 @@
+import pytest
+import importlib
+
+from .markers import cpython_only
+from .utils import run_isolated_test
+
+
+@cpython_only
+def test_observer_stops_in_eventlet():
+    if not importlib.util.find_spec('eventlet'):
+        pytest.skip("eventlet not installed")
+
+    run_isolated_test('eventlet_observer_stops.py')
+
+
+@cpython_only
+def test_eventlet_skip_repeat_queue():
+    if not importlib.util.find_spec('eventlet'):
+        pytest.skip("eventlet not installed")
+
+    run_isolated_test('eventlet_skip_repeat_queue.py')

--- a/tests/test_skip_repeats_queue.py
+++ b/tests/test_skip_repeats_queue.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
-import pytest
-
 from watchdog import events
 from watchdog.utils.bricks import SkipRepeatsQueue
 
-from .markers import cpython_only
 
-
-def basic_actions():
+def test_basic_queue():
     q = SkipRepeatsQueue()
 
     e1 = (2, "fred")
@@ -23,10 +19,6 @@ def basic_actions():
     assert e2 == q.get()
     assert e3 == q.get()
     assert q.empty()
-
-
-def test_basic_queue():
-    basic_actions()
 
 
 def test_allow_nonconsecutive():
@@ -86,10 +78,3 @@ def test_consecutives_allowed_across_empties():
     q.put(e1)  # this repeat is allowed because 'last' added is now gone from queue
     assert e1 == q.get()
     assert q.empty()
-
-
-@cpython_only
-def test_eventlet_monkey_patching():
-    eventlet = pytest.importorskip("eventlet")
-    eventlet.monkey_patch()
-    basic_actions()


### PR DESCRIPTION
Fixes #1045 
Fixes #679

New Eventlet release means it's time to fix these bugs! Actually, it turns out we don't need the latest Eventlet version to get this working, so I could have put this PR out months ago...

I made a couple minor improvements:

1. Inotify cleans up its threads more reliably
   - Now, it reads the inotify file descriptor and an extra file descriptor simultaneously. When we want to shutdown Inotify, we can write to that second file descriptor and guarantee that any thread waiting for data is woken up.
2. `SkipRepeatsQueue` is now compatible with both the standard Python Queue and Eventlet's monkey patched version
3. Improved tests related to Eventlet and moved them into their own file
   - All tests in `pytest` are run inside the same Python interpreter, so if you do something that modifies global state, like calling `eventlet.monkey_patch()`, you run the risk of interfering with other tests. To be safe, I moved tests with Eventlet monkey patching into `tests/isolated/` and ran them in a separate Python interpreter with `Popen`.

Let me know if there's anything else that I need to do