### PR TITLE
Delayed clearing of event records from moved_events dictionary in a separate daemon thread 

### DIFF
--- a/tests/threaded/conftest.py
+++ b/tests/threaded/conftest.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import contextlib
+import gc
+import os
+import threading
+from functools import partial
+
+import pytest
+
+from tests.utils import ExpectEvent, Helper, P, StartWatching, TestEventQueue
+
+
+@pytest.fixture(autouse=True)
+def _no_thread_leaks():
+    """
+    A fixture override, disables thread counter from parent folder
+    """
+
+

--- a/tests/threaded/test_inotify_c.py
+++ b/tests/threaded/test_inotify_c.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import pytest
+
+from watchdog.utils import platform
+
+if not platform.is_linux():
+    pytest.skip("GNU/Linux only.", allow_module_level=True)
+
+import ctypes
+import errno
+import logging
+import os
+import select
+import struct
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from watchdog.events import DirCreatedEvent, DirDeletedEvent, DirModifiedEvent
+from watchdog.observers.inotify_c import Inotify, InotifyConstants, InotifyEvent
+
+if TYPE_CHECKING:
+    from ..utils import Helper, P, StartWatching, TestEventQueue
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+
+
+
+def test_watch_file_move(p: P, event_queue: TestEventQueue, start_watching: StartWatching) -> None:
+    folder = p()
+    path = p("this_is_a_file")
+    path_moved = p("this_is_a_file2")
+    with open(path, "a"):
+        pass
+    start_watching(path=folder)
+    os.rename(path, path_moved)
+    event, _ = event_queue.get(timeout=5)
+    assert event.src_path == path
+    assert event.dest_path == path_moved
+    assert repr(event)
+


### PR DESCRIPTION
Added separate daemon thread to clean records from moved_events that are used for source_path acquisition with some delay for events not to get cleaned before they have a chance to be used as for source_path acquisition 

Dict optimized to hold smaller object with only src_path and timestamp. 
Unfortunately a thread breaks some pytest fixtures in place, so I added a "threaded" folder where such test could be moved as an example if this approach is to be accepted

This PR supposed to deal with https://github.com/gorakhargosh/watchdog/issues/1041
And possibly partly with https://github.com/gorakhargosh/watchdog/issues/587