### PR TITLE
Use `select.poll()` if available.

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -8,7 +8,7 @@ Changelog
 
 2024-xx-xx • `full history <https://github.com/gorakhargosh/watchdog/compare/v5.0.3...HEAD>`__
 
--
+- [inotify] Use of ``select.poll()`` instead of deprecated ``select.select()``, if available. (`#1078 <https://github.com/gorakhargosh/watchdog/pull/1078>`__)
 - Thanks to our beloved contributors: @BoboTiG, @
 
 5.0.3


### PR DESCRIPTION
Details:

As stated in the `select()` man page:
```
WARNING: select() can monitor only file descriptors numbers that are less than FD_SETSIZE
         (1024)—an unreasonably low limit for many modern applications—and this limitation will not
         change.
```

This can lead to `ValueError: filedescriptor out of range in select()` when using watchdog. Following the advice of the `select()` man page, we use `select.poll()` instead, if available. The call to `select()` used as a fallback.

---

Fixes #1079.