### PR TITLE
Fix reading inotify file descriptor after closing it.

### DIFF
--- a/tests/test_inotify_c.py
+++ b/tests/test_inotify_c.py
@@ -81,7 +81,7 @@ def test_late_double_deletion(helper: Helper, p: P, event_queue: TestEventQueue,
 
         def poll(self, *args, **kwargs):
             if self._fake:
-                return None
+                return [(inotify_fd, select.POLLIN)]
             return self._orig.poll(*args, **kwargs)
 
     os_read_bkp = os.read


### PR DESCRIPTION
There is a small chance that it will try to read the inotify file descriptor after closing it if the following events occur:
1. Set `self._waiting_to_read = True`
2. Make select/poll call
3. Set `self._waiting_to_read = False`
4. `self.close()` gets call from another thread
   - it will close the inotify file descriptor
5. Tries to read inotify file descriptor (which has already been closed)

The solution is simple: read the inotify fd before setting `_waiting_to_read = false`