### PR TITLE
Update README Badges

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,8 +12,10 @@ Adrian Tejn Kern <tejnkern@gmail.com>
 Andrew Schaaf <andrew@andrewschaaf.com>
 Danilo de Jesus da Silva Bellini <danilo.bellini@gmail.com>
 David LaPalomento <dlapalomento@gmail.com>
+dvogel <dvogel@wlscapi.uwsc.wisc.edu>
 Filip Noetzel <filip@j03.de>
 Gary van der Merwe <garyvdm@garyvdm.localdomain>
+gfxmonk <tim3d.junk@gmail.com>
 Gora Khargosh <gora.khargosh@gmail.com>
 Hannu Valtonen <hannu.valtonen@ohmu.fi>
 Jesse Printz <jesse@jonypawks.net>
@@ -25,6 +27,7 @@ Malthe Borch <mborch@gmail.com>
 Martin Kreichgauer <kreichgauer@gmail.com>
 Martin Kreichgauer <martin@kreichgauer.com>
 Mike Lundy <mike@fluffypenguin.org>
+Nicholas Hairs <info+watchdog@nicholashairs.com>
 Raymond Hettinger <python@rcn.com>
 Roman Ovchinnikov <coolthecold@gmail.com>
 Rotem Yaari <vmalloc@gmail.com>
@@ -43,9 +46,6 @@ Todd Whiteman <toddw@activestate.com>
 Will McGugan <will@willmcgugan.com>
 Yesudeep Mangalapilly <gora.khargosh@gmail.com>
 Yesudeep Mangalapilly <yesudeep@google.com>
-dvogel <dvogel@wlscapi.uwsc.wisc.edu>
-gfxmonk <tim3d.junk@gmail.com>
-
 
 We would like to thank these individuals for ideas:
 ---------------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,11 @@
 Watchdog
 ========
 
-|Build Status|
-|CirrusCI Status|
+|PyPI Version|
+|PyPI Status|
+|PyPI Python Versions|
+|GitHub Build Status|
+|GitHub License|
 
 Python API and shell utilities to monitor file system events.
 
@@ -270,7 +273,13 @@ to do:
 .. _file.monitor: https://github.com/pke/file.monitor
 .. _pyfilesystem: https://github.com/PyFilesystem/pyfilesystem
 
-.. |Build Status| image:: https://github.com/gorakhargosh/watchdog/workflows/Tests/badge.svg
+.. |PyPI Version| image:: https://img.shields.io/pypi/v/watchdog.svg
+   :target: https://pypi.python.org/pypi/watchdog/
+.. |PyPI Status| image:: https://img.shields.io/pypi/status/watchdog.svg
+   :target: https://pypi.python.org/pypi/watchdog/
+.. |PyPI Python Versions| image:: https://img.shields.io/pypi/pyversions/watchdog.svg
+   :target: https://pypi.python.org/pypi/watchdog/
+.. |Github Build Status| image:: https://github.com/gorakhargosh/watchdog/workflows/Tests/badge.svg
    :target: https://github.com/gorakhargosh/watchdog/actions?query=workflow%3ATests
-.. |CirrusCI Status| image:: https://api.cirrus-ci.com/github/gorakhargosh/watchdog.svg
-   :target: https://cirrus-ci.com/github/gorakhargosh/watchdog/
+.. |GitHub License| image:: https://img.shields.io/github/license/gorakhargosh/watchdog.svg
+   :target: https://github.com/gorakhargosh/watchdog/blob/master/LICENSE

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(
         ]
     ),
     classifiers=[
-        "Development Status :: 3 - Alpha",
+        "Development Status :: 5 - Production/Stable",
         "Environment :: Console",
         "Intended Audience :: Developers",
         "Intended Audience :: System Administrators",


### PR DESCRIPTION
This add more badges to the README to make it easier for users to identify key information including:

 - Latest PyPI version.
 - Development Status (PyPI classifier based)
 - Supported python versions (PyPI classifier based).
 - Licence (GitHub based)

It also updates the PyPI `Development Status` classifier to `5 - Production/Stable` to better reflect the status of the project. Note: this classifier change won't take effect until a new version is uploaded to PyPI.