### PR TITLE
Add follow_symlink argument to Inotify observer

### DIFF
--- a/src/watchdog/observers/api.py
+++ b/src/watchdog/observers/api.py
@@ -37,9 +37,11 @@ class ObservedWatch:
         Optional collection of :class:`watchdog.events.FileSystemEvent` to watch
     """
 
-    def __init__(self, path: str | Path, *, recursive: bool, event_filter: list[type[FileSystemEvent]] | None = None):
+    def __init__(self, path: str | Path, *, recursive: bool, event_filter: list[type[FileSystemEvent]] | None = None,
+                 follow_symlink: bool = False):
         self._path = str(path) if isinstance(path, Path) else path
         self._is_recursive = recursive
+        self._follow_symlink = follow_symlink
         self._event_filter = frozenset(event_filter) if event_filter is not None else None
 
     @property
@@ -51,6 +53,11 @@ class ObservedWatch:
     def is_recursive(self) -> bool:
         """Determines whether subdirectories are watched for the path."""
         return self._is_recursive
+
+    @property
+    def follow_symlink(self) -> bool:
+        """Determines whether symlink are followed."""
+        return self._follow_symlink
 
     @property
     def event_filter(self) -> frozenset[type[FileSystemEvent]] | None:
@@ -274,6 +281,7 @@ class BaseObserver(EventDispatcher):
         *,
         recursive: bool = False,
         event_filter: list[type[FileSystemEvent]] | None = None,
+        follow_symlink: bool = False
     ) -> ObservedWatch:
         """Schedules watching a path and calls appropriate methods specified
         in the given event handler in response to file system events.
@@ -302,7 +310,7 @@ class BaseObserver(EventDispatcher):
             a watch.
         """
         with self._lock:
-            watch = ObservedWatch(path, recursive=recursive, event_filter=event_filter)
+            watch = ObservedWatch(path, recursive=recursive, event_filter=event_filter, follow_symlink=follow_symlink)
             self._add_handler_for_watch(event_handler, watch)
 
             # If we don't have an emitter for this watch already, create it.

--- a/src/watchdog/observers/api.py
+++ b/src/watchdog/observers/api.py
@@ -37,8 +37,14 @@ class ObservedWatch:
         Optional collection of :class:`watchdog.events.FileSystemEvent` to watch
     """
 
-    def __init__(self, path: str | Path, *, recursive: bool, event_filter: list[type[FileSystemEvent]] | None = None,
-                 follow_symlink: bool = False):
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        recursive: bool,
+        event_filter: list[type[FileSystemEvent]] | None = None,
+        follow_symlink: bool = False,
+    ):
         self._path = str(path) if isinstance(path, Path) else path
         self._is_recursive = recursive
         self._follow_symlink = follow_symlink
@@ -281,7 +287,7 @@ class BaseObserver(EventDispatcher):
         *,
         recursive: bool = False,
         event_filter: list[type[FileSystemEvent]] | None = None,
-        follow_symlink: bool = False
+        follow_symlink: bool = False,
     ) -> ObservedWatch:
         """Schedules watching a path and calls appropriate methods specified
         in the given event handler in response to file system events.

--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -329,6 +329,7 @@ class FSEventsObserver(BaseObserver):
         path: str,
         *,
         recursive: bool = False,
+        follow_symlink: bool = False,
         event_filter: list[type[FileSystemEvent]] | None = None,
     ) -> ObservedWatch:
         # Fix for issue #26: Trace/BPT error when given a unicode path
@@ -336,4 +337,5 @@ class FSEventsObserver(BaseObserver):
         if isinstance(path, str):
             path = unicodedata.normalize("NFC", path)
 
-        return super().schedule(event_handler, path, recursive=recursive, event_filter=event_filter)
+        return super().schedule(event_handler, path, recursive=recursive, follow_symlink=follow_symlink,
+                                event_filter=event_filter)

--- a/src/watchdog/observers/inotify.py
+++ b/src/watchdog/observers/inotify.py
@@ -116,7 +116,8 @@ class InotifyEmitter(EventEmitter):
     def on_thread_start(self) -> None:
         path = os.fsencode(self.watch.path)
         event_mask = self.get_event_mask_from_filter()
-        self._inotify = InotifyBuffer(path, recursive=self.watch.is_recursive, event_mask=event_mask)
+        self._inotify = InotifyBuffer(path, recursive=self.watch.is_recursive, event_mask=event_mask,
+                                      follow_symlink=self.watch.follow_symlink)
 
     def on_thread_stop(self) -> None:
         if self._inotify:

--- a/src/watchdog/observers/inotify.py
+++ b/src/watchdog/observers/inotify.py
@@ -116,8 +116,9 @@ class InotifyEmitter(EventEmitter):
     def on_thread_start(self) -> None:
         path = os.fsencode(self.watch.path)
         event_mask = self.get_event_mask_from_filter()
-        self._inotify = InotifyBuffer(path, recursive=self.watch.is_recursive, event_mask=event_mask,
-                                      follow_symlink=self.watch.follow_symlink)
+        self._inotify = InotifyBuffer(
+            path, recursive=self.watch.is_recursive, event_mask=event_mask, follow_symlink=self.watch.follow_symlink
+        )
 
     def on_thread_stop(self) -> None:
         if self._inotify:

--- a/src/watchdog/observers/inotify_buffer.py
+++ b/src/watchdog/observers/inotify_buffer.py
@@ -23,8 +23,9 @@ class InotifyBuffer(BaseThread):
 
     delay = 0.5
 
-    def __init__(self, path: bytes, *, recursive: bool = False, event_mask: int | None = None,
-                 follow_symlink: bool = False) -> None:
+    def __init__(
+        self, path: bytes, *, recursive: bool = False, event_mask: int | None = None, follow_symlink: bool = False
+    ) -> None:
         super().__init__()
         # XXX: Remove quotes after Python 3.9 drop
         self._queue = DelayedQueue["InotifyEvent | tuple[InotifyEvent, InotifyEvent]"](self.delay)

--- a/src/watchdog/observers/inotify_buffer.py
+++ b/src/watchdog/observers/inotify_buffer.py
@@ -23,11 +23,12 @@ class InotifyBuffer(BaseThread):
 
     delay = 0.5
 
-    def __init__(self, path: bytes, *, recursive: bool = False, event_mask: int | None = None) -> None:
+    def __init__(self, path: bytes, *, recursive: bool = False, event_mask: int | None = None,
+                 follow_symlink: bool = False) -> None:
         super().__init__()
         # XXX: Remove quotes after Python 3.9 drop
         self._queue = DelayedQueue["InotifyEvent | tuple[InotifyEvent, InotifyEvent]"](self.delay)
-        self._inotify = Inotify(path, recursive=recursive, event_mask=event_mask)
+        self._inotify = Inotify(path, recursive=recursive, event_mask=event_mask, follow_symlink=follow_symlink)
         self.start()
 
     def read_event(self) -> InotifyEvent | tuple[InotifyEvent, InotifyEvent] | None:

--- a/src/watchdog/observers/inotify_c.py
+++ b/src/watchdog/observers/inotify_c.py
@@ -142,7 +142,8 @@ class Inotify:
         ``True`` if subdirectories should be monitored; ``False`` otherwise.
     """
 
-    def __init__(self, path: bytes, *, recursive: bool = False, event_mask: int | None = None) -> None:
+    def __init__(self, path: bytes, *, recursive: bool = False, event_mask: int | None = None,
+                 follow_symlink: bool = False) -> None:
         # The file descriptor associated with the inotify instance.
         inotify_fd = inotify_init()
         if inotify_fd == -1:
@@ -179,7 +180,10 @@ class Inotify:
         # Default to all events
         if event_mask is None:
             event_mask = WATCHDOG_ALL_EVENTS
+            if follow_symlink:
+                event_mask &= ~InotifyConstants.IN_DONT_FOLLOW
         self._event_mask = event_mask
+        self._follow_symlink = follow_symlink
         self._is_recursive = recursive
         if os.path.isdir(path):
             self._add_dir_watch(path, event_mask, recursive=recursive)
@@ -406,7 +410,7 @@ class Inotify:
             for root, dirnames, _ in os.walk(path):
                 for dirname in dirnames:
                     full_path = os.path.join(root, dirname)
-                    if os.path.islink(full_path):
+                    if os.path.islink(full_path) and not self._follow_symlink:
                         continue
                     self._add_watch(full_path, mask)
 

--- a/src/watchdog/observers/inotify_c.py
+++ b/src/watchdog/observers/inotify_c.py
@@ -142,8 +142,9 @@ class Inotify:
         ``True`` if subdirectories should be monitored; ``False`` otherwise.
     """
 
-    def __init__(self, path: bytes, *, recursive: bool = False, event_mask: int | None = None,
-                 follow_symlink: bool = False) -> None:
+    def __init__(
+        self, path: bytes, *, recursive: bool = False, event_mask: int | None = None, follow_symlink: bool = False
+    ) -> None:
         # The file descriptor associated with the inotify instance.
         inotify_fd = inotify_init()
         if inotify_fd == -1:
@@ -410,7 +411,7 @@ class Inotify:
             for root, dirnames, _ in os.walk(path):
                 for dirname in dirnames:
                     full_path = os.path.join(root, dirname)
-                    if os.path.islink(full_path) and not self._follow_symlink:
+                    if not self._follow_symlink and os.path.islink(full_path):
                         continue
                     self._add_watch(full_path, mask)
 


### PR DESCRIPTION
Adding `follow_symlink` as keyword argument allow to have recursive watch consistent with the polling method.

This makes the change from PR #109  the default behavior but not the only option. The default values being `False` this changes will not change nor break any previous use of the library.

This fixes issues like #365.

Ruff is OK and 2 tests are not passing (were not passing before changes either on my computer):
* **test_0_watchmedo.py::test_kill_auto_restart** : `threading.active_count() == old_thread_count` -> `assert 1 == 2`
* **test_inotify_c.py::test_select_fd**: `stack.enter_context(open(path))` -> `OSError: [Errno 24] Too many open files: '/tmp/[...]/pytest-1/test_select_fd0/new_file'`, my ulimit is `unlimited`