### PR TITLE
Add follow symlink tests

### DIFF
--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -337,5 +337,6 @@ class FSEventsObserver(BaseObserver):
         if isinstance(path, str):
             path = unicodedata.normalize("NFC", path)
 
-        return super().schedule(event_handler, path, recursive=recursive, follow_symlink=follow_symlink,
-                                event_filter=event_filter)
+        return super().schedule(
+            event_handler, path, recursive=recursive, follow_symlink=follow_symlink, event_filter=event_filter
+        )

--- a/tests/shell.py
+++ b/tests/shell.py
@@ -42,6 +42,10 @@ def mkdir(path, *, parents=False):
         os.mkdir(path)
 
 
+def symlink(source, destination, *, target_is_directory: bool = False):
+    os.symlink(source, destination, target_is_directory=target_is_directory)
+
+
 def rm(path, *, recursive=False):
     """Deletes files or directories."""
     if os.path.isdir(path):


### PR DESCRIPTION
Added 2 tests for the new `follow_symlink` options.

The tests correctly fail if `follow_symlink` is set to `False`.

The code coverage slightly increases, this only adds the line `185` of `src/watchdog/observers/inotify_c.py` corresponding to
```python
if follow_symlink:
    event_mask &= ~InotifyConstants.IN_DONT_FOLLOW
```

PS : a minor code style was automatically fixed in `src/watchdog/observers/fsevents.py`.