### PR TITLE
Inotify's symlink follow with recursive option

### DIFF
--- a/src/watchdog/observers/inotify_c.py
+++ b/src/watchdog/observers/inotify_c.py
@@ -408,7 +408,7 @@ class Inotify:
             raise OSError(errno.ENOTDIR, os.strerror(errno.ENOTDIR), path)
         self._add_watch(path, mask)
         if recursive:
-            for root, dirnames, _ in os.walk(path):
+            for root, dirnames, _ in os.walk(path, followlinks=self._follow_symlink):
                 for dirname in dirnames:
                     full_path = os.path.join(root, dirname)
                     if not self._follow_symlink and os.path.islink(full_path):


### PR DESCRIPTION
* Using symlink follow now working as intended with recursive (used to be shallow only)
* Add test for recursive + follow symlink for Inotify observer
* Improve test for recursive cases : in case of recursive Inotify, directory open event always triggers first