### PR TITLE
Allow `Path` in `Observer.schedule`

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -8,8 +8,8 @@ Changelog
 
 202x-xx-xx • `full history <https://github.com/gorakhargosh/watchdog/compare/v6.0.0...HEAD>`__
 
-- 
-- Thanks to our beloved contributors: @BoboTiG, @
+- Adjust ``Observer.schedule()`` ``path`` type annotation to reflect the ``pathlib.Path`` support. (`#1096 <https://github.com/gorakhargosh/watchdog/pull/1096>`__)
+- Thanks to our beloved contributors: @BoboTiG, @tybug
 
 6.0.0
 ~~~~~

--- a/src/watchdog/observers/api.py
+++ b/src/watchdog/observers/api.py
@@ -283,7 +283,7 @@ class BaseObserver(EventDispatcher):
     def schedule(
         self,
         event_handler: FileSystemEventHandler,
-        path: str,
+        path: str | Path,
         *,
         recursive: bool = False,
         event_filter: list[type[FileSystemEvent]] | None = None,
@@ -301,7 +301,7 @@ class BaseObserver(EventDispatcher):
         :param path:
             Directory path that will be monitored.
         :type path:
-            ``str``
+            ``str`` or :class:`pathlib.Path`
         :param recursive:
             ``True`` if events will be emitted for sub-directories
             traversed recursively; ``False`` otherwise.

--- a/src/watchdog/observers/fsevents.py
+++ b/src/watchdog/observers/fsevents.py
@@ -12,6 +12,7 @@ import os
 import threading
 import time
 import unicodedata
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import _watchdog_fsevents as _fsevents
@@ -326,7 +327,7 @@ class FSEventsObserver(BaseObserver):
     def schedule(
         self,
         event_handler: FileSystemEventHandler,
-        path: str,
+        path: str | Path,
         *,
         recursive: bool = False,
         follow_symlink: bool = False,


### PR DESCRIPTION
A more permissive type hint here would be great so we can more correctly type https://github.com/HypothesisWorks/hypothesis/pull/4265 🙂 