### PR TITLE
Fix #1112: Set `_last_item` attribute on SkipRepeatsQueue, when gevent has patched `queue.Queue`

### DIFF
--- a/src/watchdog/utils/bricks.py
+++ b/src/watchdog/utils/bricks.py
@@ -68,8 +68,8 @@ class SkipRepeatsQueue(queue.Queue):
     based on the OrderedSetQueue below
     """
 
-    def _init(self, maxsize: int) -> None:
-        super()._init(maxsize)
+    def __init__(self, maxsize: int = 0) -> None:
+        super().__init__(maxsize)
         self._last_item = None
 
     def put(self, item: Any, block: bool = True, timeout: float | None = None) -> None:  # noqa: FBT001,FBT002


### PR DESCRIPTION
Use `__init__` method to set _last_item attribute, rather than `_init`, for compatibility with gevent>25

This is because gevent>25 patches the queue.Queue class with its own implementation, which doesn't call the `_init()` method, but it does call `__init__()`, so this change means _last_item should be always set.

I believe this should still be compatible when not using gevent, and `queue.Queue` is the standard library class.

Closes #1112