### PR TITLE
Fix memory leak in watchdog_fsevents.c

### DIFF
--- a/src/watchdog_fsevents.c
+++ b/src/watchdog_fsevents.c
@@ -446,6 +446,9 @@ watchdog_FSEventStreamCallback(ConstFSEventStreamRef          stream_ref,
         CFRunLoopStop(stream_callback_info_ref->run_loop_ref);
     }
 
+    /* Clean up callback result reference */
+    Py_XDECREF(callback_result);
+
     /* Release the lock and restore thread state. */
     PyThreadState_Swap(saved_thread_state);
     PyGILState_Release(gil_state);


### PR DESCRIPTION
In case the callback_result is not empty, the memory is never released which caused a memory leak.