### PR TITLE
Add manylinux_2_17 wheel targets

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -78,7 +78,7 @@ jobs:
         run: python -m pip install -U setuptools wheel
       - name: Build wheels
         run: |
-          for platform in 'manylinux_2_17_x86_64' 'manylinux_2_17_aarch64' 'manylinux_2_17_i686' 'manylinux_2_17_s390x' 'manylinux_2_17_armv7l' 'manylinux_2_17_ppc64le' 'manylinux2014_x86_64' 'manylinux2014_i686' 'manylinux2014_aarch64' 'manylinux2014_armv7l' 'manylinux2014_ppc64' 'manylinux2014_ppc64le' 'manylinux2014_s390x' 'win32' 'win_amd64' 'win_ia64'
+          for platform in 'manylinux_2_17_x86_64' 'manylinux_2_17_aarch64' 'manylinux_2_17_i686' 'manylinux_2_17_ppc64le' 'manylinux_2_17_s390x' 'manylinux_2_17_armv7l' 'manylinux_2_17_ppc64' 'manylinux2014_x86_64' 'manylinux2014_i686' 'manylinux2014_aarch64' 'manylinux2014_armv7l' 'manylinux2014_ppc64' 'manylinux2014_ppc64le' 'manylinux2014_s390x' 'win32' 'win_amd64' 'win_ia64'
           do
             python setup.py bdist_wheel --plat-name $platform
           done


### PR DESCRIPTION
Add the `manylinux_2_17` targets as requested by #1125 

## Targets being Added

The original issue suggested only adding `manylinux_2_17_x86_64` and `manylinux_2_17_aarch64`; however, given that most of the popular packages targeted ppc64/armv7l/s390x/ppc64le/i686 and **this package** targeted those arch's for manylinux2014, I included them in this PR. If we wish to reduce it just to x64/aarch64, we can do that instead.