### PR TITLE
Add testing on Python 3.14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,6 +61,8 @@ jobs:
           - "3.12"
           - "3.13"
           - "3.13t"
+          - "3.14"
+          - "3.14t"
           - "pypy-3.9"
         exclude:
           - os:
@@ -78,6 +80,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
+          allow-prereleases: true
           cache: pip
 
       - name: Install dependencies


### PR DESCRIPTION
I suspect there will be new CI failures on Linux, but the same test has been failing for the past two weeks on Windows (see #1128). It's marked as flaky and I've seen it pass on CI sometimes. Not sure if you're comfortable adding new jobs that fail.