### PR TITLE
Fix deadlocks and crashes seen on free-threaded Python

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,6 +61,8 @@ jobs:
           - "3.12"
           - "3.13"
           - "3.13t"
+          - "3.14"
+          - "3.14t"
           - "pypy-3.9"
         exclude:
           - os:
@@ -79,6 +81,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           cache: pip
+          allow-prereleases: true
 
       - name: Install dependencies
         run: python -m pip install tox

--- a/src/watchdog/observers/api.py
+++ b/src/watchdog/observers/api.py
@@ -189,6 +189,7 @@ class EventDispatcher(BaseThread):
         super().__init__()
         self._event_queue = EventQueue()
         self._timeout = timeout
+        self._lock = threading.RLock()
 
     @property
     def timeout(self) -> float:
@@ -222,6 +223,9 @@ class EventDispatcher(BaseThread):
 
     def run(self) -> None:
         while self.should_keep_running():
+            with self._lock:
+                if not self.should_keep_running():
+                    return
             try:
                 self.dispatch_events(self.event_queue)
             except queue.Empty:
@@ -234,7 +238,6 @@ class BaseObserver(EventDispatcher):
     def __init__(self, emitter_class: type[EventEmitter], *, timeout: float = DEFAULT_OBSERVER_TIMEOUT) -> None:
         super().__init__(timeout=timeout)
         self._emitter_class = emitter_class
-        self._lock = threading.RLock()
         self._watches: set[ObservedWatch] = set()
         self._handlers: defaultdict[ObservedWatch, set[FileSystemEventHandler]] = defaultdict(set)
         self._emitters: set[EventEmitter] = set()
@@ -272,12 +275,15 @@ class BaseObserver(EventDispatcher):
         return self._emitters
 
     def start(self) -> None:
-        for emitter in self._emitters.copy():
-            try:
-                emitter.start()
-            except Exception:
-                self._remove_emitter(emitter)
-                raise
+        with self._lock:
+            for emitter in self._emitters.copy():
+                if not self.should_keep_running():
+                    break
+                try:
+                    emitter.start()
+                except Exception:
+                    self._remove_emitter(emitter)
+                    raise
         super().start()
 
     def schedule(
@@ -390,17 +396,21 @@ class BaseObserver(EventDispatcher):
         self.unschedule_all()
 
     def dispatch_events(self, event_queue: EventQueue) -> None:
+        with self._lock:
+            if not self.should_keep_running():
+                return
         entry = event_queue.get(block=True)
         if entry is EventDispatcher.stop_event:
             return
 
         event, watch = entry
 
-        with self._lock:
-            # To allow unschedule/stop and safe removal of event handlers
-            # within event handlers itself, check if the handler is still
-            # registered after every dispatch.
-            for handler in self._handlers[watch].copy():
-                if handler in self._handlers[watch]:
-                    handler.dispatch(event)
+        # To allow unschedule/stop and safe removal of event handlers
+        # within event handlers itself, check if the handler is still
+        # registered after every dispatch.
+        for handler in self._handlers[watch].copy():
+            with self._lock:
+                if handler not in self._handlers[watch]:
+                    continue
+            handler.dispatch(event)
         event_queue.task_done()

--- a/src/watchdog/observers/read_directory_changes.py
+++ b/src/watchdog/observers/read_directory_changes.py
@@ -58,8 +58,10 @@ class WindowsApiEmitter(EventEmitter):
             sleep(0.01)
 
     def on_thread_stop(self) -> None:
-        if self._whandle:
-            close_directory_handle(self._whandle)
+        whandle = self._whandle
+        if whandle:
+            self._whandle = None
+            close_directory_handle(whandle)
 
     def _read_events(self) -> list[WinAPINativeEvent]:
         if not self._whandle:


### PR DESCRIPTION
Closes #1132.

I got to this state after a lot of trial and error and I'd really appreciate it if @taleinat could perhaps look this over, since he also thought about this problem recently.

As I suspected in https://github.com/gorakhargosh/watchdog/issues/1132#issuecomment-3309790203, the issue is that `BaseObserver.start` didn't do any locking at all, so if someone engineers a situation where `stop` gets called while `start` is still running, you get a deadlock.

Adding locking in `start` wasn't quite enough, you also need to check in `dispatch_events` before dipatching an event if another thread called `stop` or removes a watch while `dispatch_events` is running.

Finally I also applied @colesbury's fix for the file handle re-use issue that leads to a Python crash, see https://github.com/gorakhargosh/watchdog/issues/1132#issuecomment-3307704051 for more on that.

Finally, I added 3.14 and 3.14t CI, since that doesn't lead to crashes or hangs anymore with this PR.