### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -202,7 +202,7 @@ files.
 Free threaded support
 ---------------------
 
-`watchdog` has support for being built and run under free-threaded CPython. However, a full thread saftey audit has not been completed, in particular this affects the `macOS FSEvents` interface.
+`watchdog` has support for being built and run under free-threaded CPython. However, a full thread safety audit has not been completed, in particular this affects the `macOS FSEvents` interface.
 
 About using watchdog with editors like Vim
 ------------------------------------------

--- a/changelog.rst
+++ b/changelog.rst
@@ -525,7 +525,7 @@ Changelog
 
 - Event emitters are no longer started on schedule if ``Observer`` is not
   already running
-- [mac] Fixed used arguments to pass clang compilation (`#265 <https://github.com/gorakhargosh/watchdog/pull/265>`__)
+- [mac] Fixed unused arguments to pass clang compilation (`#265 <https://github.com/gorakhargosh/watchdog/pull/265>`__)
 - [snapshot] Fixed a possible race condition crash on directory deletion (`#281 <https://github.com/gorakhargosh/watchdog/pull/281>`__)
 - [windows] Fixed an error when watching the same folder again (`#270 <https://github.com/gorakhargosh/watchdog/pull/270>`__)
 - Thanks to our beloved contributors: @tamland, @apetrone, @Falldog,

--- a/changelog.rst
+++ b/changelog.rst
@@ -136,7 +136,7 @@ Changelog
 - [events] Log ``FileOpenedEvent``, and ``FileClosedEvent``, events in ``LoggingEventHandler``
 - [tests] Improve ``FileSystemEvent`` coverage
 - [watchmedo] Log all events in ``LoggerTrick``
-- [windows] The ``observers.read_directory_changes.WATCHDOG_TRAVERSE_MOVED_DIR_DELAY`` hack was removed. The constant will be kept to prevent breaking other softwares.
+- [windows] The ``observers.read_directory_changes.WATCHDOG_TRAVERSE_MOVED_DIR_DELAY`` hack was removed. The constant will be kept to prevent breaking other software.
 - Thanks to our beloved contributors: @BoboTiG, @msabramo
 
 3.0.0
@@ -525,7 +525,7 @@ Changelog
 
 - Event emitters are no longer started on schedule if ``Observer`` is not
   already running
-- [mac] Fixed usued arguments to pass clang compilation (`#265 <https://github.com/gorakhargosh/watchdog/pull/265>`__)
+- [mac] Fixed used arguments to pass clang compilation (`#265 <https://github.com/gorakhargosh/watchdog/pull/265>`__)
 - [snapshot] Fixed a possible race condition crash on directory deletion (`#281 <https://github.com/gorakhargosh/watchdog/pull/281>`__)
 - [windows] Fixed an error when watching the same folder again (`#270 <https://github.com/gorakhargosh/watchdog/pull/270>`__)
 - Thanks to our beloved contributors: @tamland, @apetrone, @Falldog,

--- a/docs/source/hacking.rst
+++ b/docs/source/hacking.rst
@@ -42,14 +42,14 @@ Steps to setting up a clean environment:
 .. code:: bash
 
     $ . venv/bin/activate
-    (venv)$ python -m pip instal -e '.'
+    (venv)$ python -m pip install -e '.'
 
 4. Windows
 
 .. code:: batch
 
     > venv\Scripts\activate
-    (venv)> python -m pip instal -e '.'
+    (venv)> python -m pip install -e '.'
 
 That's it with the setup. Now you're ready to hack on |project_name|.
 

--- a/src/watchdog/observers/inotify.py
+++ b/src/watchdog/observers/inotify.py
@@ -200,7 +200,7 @@ class InotifyWatchGroup(WatchCallback):
         return self._move_event_grouper.read_event()
 
     def on_watch_deleted(self, wd: WatchDescriptor) -> None:
-        """Called when a watch that ths callback is registered at is removed.
+        """Called when a watch that this callback is registered at is removed.
         This is the case when the watched object is deleted."""
         with self._lock:
             if not self.is_active:

--- a/src/watchdog/observers/inotify_c.py
+++ b/src/watchdog/observers/inotify_c.py
@@ -165,7 +165,7 @@ class WatchCallback(Protocol):
         ...
 
     def on_watch_deleted(self, wd: WatchDescriptor) -> None:
-        """Called when a watch that ths callback is registered at is removed.
+        """Called when a watch that this callback is registered at is removed.
         This is the case when the watched object is deleted."""
         ...
 

--- a/src/watchdog/utils/patterns.py
+++ b/src/watchdog/utils/patterns.py
@@ -44,7 +44,7 @@ def _full_match(path: PurePath, pattern: str) -> bool:
         # Please remove this, backwards_compat.py, and python license attributions
         # if/when we can pin a release to python >= 3.13
         # Construct a pathlib object using the same class as the path to get the
-        # same pattern path separater when constructing the regex
+        # same pattern path separator when constructing the regex
         normalized_pattern = str(type(path)(pattern))
         regex = translate(normalized_pattern, recursive=True, include_hidden=True, seps=_get_sep(path))
         reobj = re.compile(regex)


### PR DESCRIPTION
Fix typos discovered by codespell - https://pypi.org/project/codespell

% `codespell --ignore-words-list=afile,modle,te`
```
./README.rst:205: saftey ==> safety
./changelog.rst:139: softwares ==> software
./changelog.rst:528: usued ==> used
./docs/source/hacking.rst:45: instal ==> install
./docs/source/hacking.rst:52: instal ==> install
./src/watchdog/utils/patterns.py:47: separater ==> separator, separated, separates, separate
./src/watchdog/observers/inotify.py:203: ths ==> the, this
./src/watchdog/observers/inotify_c.py:168: ths ==> the, this
```
% `codespell --ignore-words-list=afile,modle,te --write-changes` 