### PR TITLE
feat: use double-buffer for winapi observer

### DIFF
--- a/src/watchdog/observers/read_directory_changes.py
+++ b/src/watchdog/observers/read_directory_changes.py
@@ -18,14 +18,11 @@ from watchdog.events import (
     generate_sub_moved_events,
 )
 from watchdog.observers.api import DEFAULT_EMITTER_TIMEOUT, DEFAULT_OBSERVER_TIMEOUT, BaseObserver, EventEmitter
-from watchdog.observers.winapi import close_directory_handle, get_directory_handle, read_events
+from watchdog.observers.winapi import DirectoryChangeReader
 
 if TYPE_CHECKING:
-    from ctypes.wintypes import HANDLE
-
     from watchdog.events import FileSystemEvent
     from watchdog.observers.api import EventQueue, ObservedWatch
-    from watchdog.observers.winapi import WinAPINativeEvent
 
 
 class WindowsApiEmitter(EventEmitter):
@@ -42,11 +39,14 @@ class WindowsApiEmitter(EventEmitter):
         event_filter: list[type[FileSystemEvent]] | None = None,
     ) -> None:
         super().__init__(event_queue, watch, timeout=timeout, event_filter=event_filter)
-        self._lock = threading.Lock()
-        self._whandle: HANDLE | None = None
+        self._lock = threading.RLock()
+        self._reader: DirectoryChangeReader | None = None
 
     def on_thread_start(self) -> None:
-        self._whandle = get_directory_handle(self.watch.path)
+        with self._lock:
+            assert self._reader is None
+            self._reader = DirectoryChangeReader(self.watch.path, recursive=self.watch.is_recursive)
+        self._reader.start()
 
     if platform.python_implementation() == "PyPy":
 
@@ -58,46 +58,49 @@ class WindowsApiEmitter(EventEmitter):
             sleep(0.01)
 
     def on_thread_stop(self) -> None:
-        if self._whandle:
-            close_directory_handle(self._whandle)
-
-    def _read_events(self) -> list[WinAPINativeEvent]:
-        if not self._whandle:
-            return []
-        return read_events(self._whandle, self.watch.path, recursive=self.watch.is_recursive)
+        with self._lock:
+            reader = self._reader
+            self._reader = None
+        if reader is not None:
+            reader.stop()
 
     def queue_events(self, timeout: float) -> None:
-        winapi_events = self._read_events()
-        with self._lock:
-            last_renamed_src_path = ""
-            for winapi_event in winapi_events:
-                src_path = os.path.join(self.watch.path, winapi_event.src_path)
+        reader = self._reader
+        if reader is None:
+            return  # reader has been stopped
+        last_renamed_src_path = ""
+        should_stop = False
+        for winapi_event in reader.get_events(timeout):
+            src_path = os.path.join(self.watch.path, winapi_event.src_path)
 
-                if winapi_event.is_renamed_old:
-                    last_renamed_src_path = src_path
-                elif winapi_event.is_renamed_new:
-                    dest_path = src_path
-                    src_path = last_renamed_src_path
-                    if os.path.isdir(dest_path):
-                        self.queue_event(DirMovedEvent(src_path, dest_path))
-                        if self.watch.is_recursive:
-                            for sub_moved_event in generate_sub_moved_events(src_path, dest_path):
-                                self.queue_event(sub_moved_event)
-                    else:
-                        self.queue_event(FileMovedEvent(src_path, dest_path))
-                elif winapi_event.is_modified:
-                    self.queue_event((DirModifiedEvent if os.path.isdir(src_path) else FileModifiedEvent)(src_path))
-                elif winapi_event.is_added:
-                    isdir = os.path.isdir(src_path)
-                    self.queue_event((DirCreatedEvent if isdir else FileCreatedEvent)(src_path))
-                    if isdir and self.watch.is_recursive:
-                        for sub_created_event in generate_sub_created_events(src_path):
-                            self.queue_event(sub_created_event)
-                elif winapi_event.is_removed:
-                    self.queue_event(FileDeletedEvent(src_path))
-                elif winapi_event.is_removed_self:
-                    self.queue_event(DirDeletedEvent(self.watch.path))
-                    self.stop()
+            if winapi_event.is_renamed_old:
+                last_renamed_src_path = src_path
+            elif winapi_event.is_renamed_new:
+                dest_path = src_path
+                src_path = last_renamed_src_path
+                if os.path.isdir(dest_path):
+                    self.queue_event(DirMovedEvent(src_path, dest_path))
+                    if self.watch.is_recursive:
+                        for sub_moved_event in generate_sub_moved_events(src_path, dest_path):
+                            self.queue_event(sub_moved_event)
+                else:
+                    self.queue_event(FileMovedEvent(src_path, dest_path))
+            elif winapi_event.is_modified:
+                self.queue_event((DirModifiedEvent if os.path.isdir(src_path) else FileModifiedEvent)(src_path))
+            elif winapi_event.is_added:
+                isdir = os.path.isdir(src_path)
+                self.queue_event((DirCreatedEvent if isdir else FileCreatedEvent)(src_path))
+                if isdir and self.watch.is_recursive:
+                    for sub_created_event in generate_sub_created_events(src_path):
+                        self.queue_event(sub_created_event)
+            elif winapi_event.is_removed:
+                self.queue_event(FileDeletedEvent(src_path))
+            elif winapi_event.is_removed_self:
+                self.queue_event(DirDeletedEvent(self.watch.path))
+                should_stop = True
+        if should_stop:
+            # watched directory was deleted, stop observer threads
+            self.stop()
 
 
 class WindowsApiObserver(BaseObserver):

--- a/tests/test_observers_winapi.py
+++ b/tests/test_observers_winapi.py
@@ -57,6 +57,7 @@ def test___init__(event_queue, emitter):
 
     sleep(SLEEP_TIME)
     emitter.stop()
+    sleep(SLEEP_TIME)  # time for background thread to exit
 
     # What we need here for the tests to pass is a collection type
     # that is:


### PR DESCRIPTION
This improves the performance of the winapi observer by using a second thread and by using double-buffering.

The `read_directory_changes()` function was replaced with a class `DirectoryChangeReader()` that takes care of reading the Windows handle.  The `ReadDirectoryChangesW()` calls are made in a separate background thread and data returned is copied into a separate queue, to be processed with `_parse_event_buffer()` in a separate thread.  

 The time window for events to be lost due to processing outside the `ReadDirectoryChangesW()` call should be smaller.  The events buffer is reused rather than creating a new one on every call.

The management of the Windows handle is encapulated in the `DirectoryChangeReader()` class and it takes care of waking the background thread, cleanly closing the handle and cleaning up the thread.

This partially addresses GH-1019.  However, a better fix would use either overlapped IO or completion ports.  However, that would be a more complex change.