### PR TITLE
Fix DirDeletedEvent not being raised for deleted directories on Windows

### DIFF
--- a/src/watchdog/observers/read_directory_changes.py
+++ b/src/watchdog/observers/read_directory_changes.py
@@ -94,7 +94,9 @@ class WindowsApiEmitter(EventEmitter):
                     for sub_created_event in generate_sub_created_events(src_path):
                         self.queue_event(sub_created_event)
             elif winapi_event.is_removed:
-                self.queue_event(FileDeletedEvent(src_path))
+                # Use is_directory from extended file info to correctly identify
+                # deleted directories (fixes issue #1153)
+                self.queue_event((DirDeletedEvent if winapi_event.is_directory else FileDeletedEvent)(src_path))
             elif winapi_event.is_removed_self:
                 self.queue_event(DirDeletedEvent(self.watch.path))
                 should_stop = True


### PR DESCRIPTION
## Summary

On Windows, when a directory was deleted, watchdog incorrectly raised `FileDeletedEvent` instead of `DirDeletedEvent`. This happened because deleted items cannot be queried with `os.path.isdir()` - they no longer exist.

## Solution

Use `ReadDirectoryChangesExW` (available on Windows 10+) instead of `ReadDirectoryChangesW`. The extended API returns `FILE_NOTIFY_EXTENDED_INFORMATION` which includes `FileAttributes`, allowing us to correctly identify whether a deleted item was a directory.

## Changes

**`src/watchdog/observers/winapi.py`:**
- Add `ReadDirectoryChangesExW` function definition
- Add `FileNotifyExtendedInformation` structure matching the Windows API
- Add `is_directory` field to `WinAPINativeEvent` dataclass
- Update `_parse_event_buffer` to extract `FileAttributes` and determine if the item was a directory
- Update `DirectoryChangeReader._run_inner` to use `ReadDirectoryChangesExW`

**`src/watchdog/observers/read_directory_changes.py`:**
- Update `WindowsApiEmitter.queue_events` to use `is_directory` for deleted events instead of always using `FileDeletedEvent`

**`tests/test_observers_winapi.py`:**
- Add `test_directory_deleted_event` to verify directories produce `DirDeletedEvent`
- Add `test_file_deleted_event` to verify files still produce `FileDeletedEvent`

## Notes

- `ReadDirectoryChangesExW` is only available on Windows 10 and later
- The `_parse_event_buffer` function now accepts an `extended` parameter to support both old and new formats for backward compatibility

## Related Issues

Fixes #1153
Related to #1154

## Test Plan

- [ ] Run tests on Windows 10+ to verify `DirDeletedEvent` is raised for deleted directories
- [ ] Run tests to verify `FileDeletedEvent` is still raised for deleted files
- [ ] Verify no regressions in other event types