### PR TITLE
Call task_done() for stop sentinel in dispatch_events

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -24,6 +24,7 @@ Changelog
 - [utils] Fixed ``repr(EmptyDirectorySnapshot)``, before that it was throwing an ``AttributeError: 'EmptyDirectorySnapshot' object has no attribute '_stat_info'``.
 - [utils] Implemented ``len(DirectorySnapshotDiff)`` to return the total number of changes.
 - Thanks to our beloved contributors: @BoboTiG, @tybug, @Corentin-pro, @kirkhansen, @JoachimCoenen, @blitztide
+- [core] Call ``task_done()`` for the stop sentinel in ``dispatch_events()`` to prevent ``join()`` from hanging. (`#1159 <https://github.com/gorakhargosh/watchdog/pull/1159>`__)
 
 6.0.0
 ~~~~~

--- a/src/watchdog/observers/api.py
+++ b/src/watchdog/observers/api.py
@@ -413,6 +413,7 @@ class BaseObserver(EventDispatcher):
     def dispatch_events(self, event_queue: EventQueue) -> None:
         entry = event_queue.get(block=True)
         if entry is EventDispatcher.stop_event:
+            event_queue.task_done()
             return
 
         event, watch = entry


### PR DESCRIPTION
`BaseObserver.dispatch_events` calls `event_queue.get()` to pull items off the queue. For normal events, it dispatches them to handlers and then calls `event_queue.task_done()`. However, when it receives the stop sentinel, it returns immediately without calling `task_done()`.

`Queue.task_done()` must be called once for every `get()` to keep the queue's internal unfinished-task counter accurate. Skipping it means the counter is permanently off by one, causing any subsequent `event_queue.join()` to block indefinitely.

The fix adds the missing `task_done()` call on the stop-event path, before `return`.
