### PR TITLE
feat: add __main__.py to support 'python -m watchdog'

### DIFF
--- a/src/watchdog/__main__.py
+++ b/src/watchdog/__main__.py
@@ -1,0 +1,5 @@
+"""Allow running watchmedo as ``python -m watchdog``."""
+
+from watchdog.watchmedo import main
+
+raise SystemExit(main())

--- a/src/watchdog/__main__.py
+++ b/src/watchdog/__main__.py
@@ -1,5 +1,7 @@
 """Allow running watchmedo as ``python -m watchdog``."""
 
-from watchdog.watchmedo import main
+if __name__ == "__main__":
+    import sys
+    from watchdog.watchmedo import main
 
-raise SystemExit(main())
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Add `__main__.py` to allow running watchmedo via `python -m watchdog`.

Closes #785

## Usage

```bash
python -m watchdog log-and-echo --recursive .
python -m watchdog shell-command --command='echo ${watch_src_path}' .
```

This is useful in environments where:
- The Scripts/bin directory is not on PATH
- The user cannot modify PYTHONPATH
- pip-installed console scripts are not accessible