### PR TITLE
fix: escape square brackets in patterns to match literal bracket file…

### DIFF
--- a/src/watchdog/utils/patterns.py
+++ b/src/watchdog/utils/patterns.py
@@ -37,6 +37,14 @@ def _get_sep(path: PurePath) -> str:
 
 
 def _full_match(path: PurePath, pattern: str) -> bool:
+    # Escape square brackets in the pattern so they match file/directory names
+    # containing literal brackets rather than being interpreted as character
+    # classes.  For example, the pattern "[test].txt" should match a file
+    # literally named "[test].txt", not a file like "t.txt" (where [test] is a
+    # character class matching t, e, s).  Replacing "[" with "[[[]" makes the
+    # opening bracket literal in fnmatch/glob syntax.
+    # See: https://github.com/gorakhargosh/watchdog/issues/991
+    pattern = pattern.replace("[", "[[[]")
     try:
         return path.full_match(pattern)
     except AttributeError:

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -79,3 +79,19 @@ def test_match_any_paths(included_patterns, excluded_patterns, case_sensitive, e
         )
         == expected
     )
+
+
+@pytest.mark.parametrize(
+    ("raw_path", "included_patterns", "expected"),
+    [
+        # Regression tests for https://github.com/gorakhargosh/watchdog/issues/991:
+        # square brackets in patterns must match literal bracket characters
+        # instead of being interpreted as fnmatch character classes.
+        ("/users/gorakhargosh/[test].txt", {"**/[test].txt"}, True),
+        ("/users/gorakhargosh/t.txt", {"**/[test].txt"}, False),
+        ("/users/gorakhargosh/file[1].py", {"**/file[1].py"}, True),
+        ("/users/gorakhargosh/file1.py", {"**/file[1].py"}, False),
+    ],
+)
+def test_match_path_literal_brackets(raw_path, included_patterns, expected):
+    assert _match_path(raw_path, included_patterns, set(), case_sensitive=True) is expected


### PR DESCRIPTION
## Summary

Square brackets in watchdog patterns (e.g. `[test].txt`) were being interpreted as fnmatch character classes, causing:
- Pattern `[test].txt` matches `t.txt` ✗ (wrong — `[test]` treated as a char class)  
- Pattern `[test].txt` does NOT match `[test].txt` ✗ (wrong — literal file not detected)

## Root Cause

`_full_match()` delegates to `pathlib.PurePath.full_match()` (Python ≥ 3.13) or the `translate()` fallback, both of which use fnmatch-style glob patterns where `[…]` denotes a character class.

## Fix

Before pattern matching, replace `[` with `[[[]` so the bracket is literal in fnmatch/glob syntax. This makes `[test].txt` correctly match a file literally named `[test].txt`.

Fixes #991