### PR TITLE
Read _reader under the lock in WindowsApiEmitter.queue_events() (#1170)

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -26,6 +26,7 @@ Changelog
 - [core] Fixed ``generate_sub_moved_events()`` corrupting paths when the directory name appears multiple times in the path. (`#1158 <https://github.com/gorakhargosh/watchdog/pull/1158>`__)
 - Thanks to our beloved contributors: @BoboTiG, @tybug, @Corentin-pro, @kirkhansen, @JoachimCoenen, @blitztide
 - [core] Call ``task_done()`` for the stop sentinel in ``dispatch_events()`` to prevent ``join()`` from hanging. (`#1159 <https://github.com/gorakhargosh/watchdog/pull/1159>`__)
+- [windows] Read ``_reader`` under the lock in ``WindowsApiEmitter.queue_events()`` so the access is synchronized with ``on_thread_stop()``. (`#1170 <https://github.com/gorakhargosh/watchdog/issues/1170>`__)
 
 6.0.0
 ~~~~~

--- a/src/watchdog/observers/read_directory_changes.py
+++ b/src/watchdog/observers/read_directory_changes.py
@@ -65,7 +65,10 @@ class WindowsApiEmitter(EventEmitter):
             reader.stop()
 
     def queue_events(self, timeout: float) -> None:
-        reader = self._reader
+        # Read the reader under the lock, mirroring on_thread_stop(), so this
+        # access is synchronized with on_thread_stop() clearing it.
+        with self._lock:
+            reader = self._reader
         if reader is None:
             return  # reader has been stopped
         last_renamed_src_path = ""

--- a/tests/test_observers_winapi.py
+++ b/tests/test_observers_winapi.py
@@ -127,3 +127,32 @@ def test_root_deleted(event_queue, emitter):
 
     # The emitter is automatically stopped, with no error
     assert not emitter.should_keep_running()
+
+
+def test_queue_events_reads_reader_under_lock(emitter):
+    """queue_events() must read ``_reader`` while holding ``_lock``, mirroring
+    on_thread_stop(), so the two accesses are synchronized (issue #1170)."""
+    acquired = []
+    real_lock = emitter._lock  # noqa: SLF001
+
+    class LockSpy:
+        def __enter__(self):
+            acquired.append(True)
+            return real_lock.__enter__()
+
+        def __exit__(self, *args):
+            return real_lock.__exit__(*args)
+
+    emitter._lock = LockSpy()  # noqa: SLF001
+
+    class FakeReader:
+        def get_events(self, timeout):
+            return []
+
+        def stop(self):
+            pass
+
+    emitter._reader = FakeReader()  # noqa: SLF001
+    emitter.queue_events(0)
+
+    assert acquired, "queue_events() did not acquire the lock to read _reader"


### PR DESCRIPTION
## Summary

Closes #1170.

`WindowsApiEmitter.on_thread_stop()` reads and clears `self._reader` while holding `self._lock`:

```python
def on_thread_stop(self) -> None:
    with self._lock:
        reader = self._reader
        self._reader = None
    if reader is not None:
        reader.stop()
```

but `queue_events()` read `self._reader` **without** holding the same lock, so the two accesses to the shared attribute were unsynchronized.

## Fix

Copy `self._reader` into a local while holding `self._lock`, mirroring `on_thread_stop()`, then use the local reference outside the lock (the `reader.get_events()` loop stays outside the lock, as before). This is the approach suggested in the issue.

## Tests

Added `test_queue_events_reads_reader_under_lock`, which spies on the emitter's lock and asserts that `queue_events()` acquires it while reading `_reader`. It fails on `master` (the lock is never taken in `queue_events()`) and passes with this change. `ruff check`/`ruff format` are clean; added a changelog entry.

(The test is in the Windows-only `test_observers_winapi.py` module and was run on Windows.)