### PR TITLE
Fix flaky test_renaming_top_level_directory on Windows

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -26,6 +26,7 @@ Changelog
 - [core] Fixed ``generate_sub_moved_events()`` corrupting paths when the directory name appears multiple times in the path. (`#1158 <https://github.com/gorakhargosh/watchdog/pull/1158>`__)
 - Thanks to our beloved contributors: @BoboTiG, @tybug, @Corentin-pro, @kirkhansen, @JoachimCoenen, @blitztide
 - [core] Call ``task_done()`` for the stop sentinel in ``dispatch_events()`` to prevent ``join()`` from hanging. (`#1159 <https://github.com/gorakhargosh/watchdog/pull/1159>`__)
+- [tests] Fix ``test_renaming_top_level_directory`` failing on Windows when NTFS delays the last-write-time change notification of a watched directory. (`#1128 <https://github.com/gorakhargosh/watchdog/issues/1128>`__)
 
 6.0.0
 ~~~~~

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -450,12 +450,22 @@ def test_renaming_top_level_directory(
     mkdir(p("a", "b"))
     with events_checker() as ec:
         ec.add(DirCreatedEvent, "a/b")
-        if not platform.is_windows():
+        if platform.is_windows():
+            # NTFS updates the last write time of "a" lazily, so the
+            # notification may be delivered now, only when a later operation
+            # flushes it (see below), or not at all (#1128).
+            ec.add(DirModifiedEvent, "a", optional=True)
+        else:
             ec.add(DirModifiedEvent, "a")
 
     mv(p("a"), p("a2"))
     with events_checker() as ec:
         if platform.is_windows():
+            # The rename may flush the pending last-write-time change of "a"
+            # caused by mkdir(p("a", "b")) above.  By the time the emitter
+            # handles the notification, "a" no longer exists on disk, so the
+            # event may be classified as a file event (#1128).
+            ec.add((DirModifiedEvent, FileModifiedEvent), "a", optional=True)
             ec.add(DirMovedEvent, "a", dest_path="a2")
             ec.add(DirMovedEvent, "a/b", dest_path="a2/b")
             ec.add(DirModifiedEvent, "a2")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -147,9 +147,17 @@ class _ExpectedEvent:
     everything else is optional (not checked if it is None).
     """
 
-    expected_class: type
+    expected_class: type | tuple[type, ...]
     src_path: str | None = None
     dest_path: str | None = None
+    # If true, the event may be absent from the received events.
+    optional: bool = False
+
+    @property
+    def class_name(self) -> str:
+        if isinstance(self.expected_class, tuple):
+            return "(" + ", ".join(cls.__name__ for cls in self.expected_class) + ")"
+        return self.expected_class.__name__
 
 
 class _EventsChecker:
@@ -191,17 +199,29 @@ class _EventsChecker:
         path = os.path.join(self.tmp, *parts)
         return os.path.normpath(path)
 
-    def add(self, expected_class: type, src_path: str | None = None, dest_path: str | None = None) -> None:
+    def add(
+        self,
+        expected_class: type | tuple[type, ...],
+        src_path: str | None = None,
+        dest_path: str | None = None,
+        *,
+        optional: bool = False,
+    ) -> None:
         """Add details for an expected event.  The `expected_class` argument
-        is required, everything else is optional.  The order that events are
-        received does not matter but adding the same kind of event more than
-        once will require that it appears more than once.
+        is required, everything else is optional.  It can be a single class or
+        a tuple of classes, in which case an event of any of those classes is
+        accepted.  Adding the same kind of event more than once will require
+        that it appears more than once.
+
+        If `optional` is true, the event is allowed to be absent from the
+        received events.  Use it for events whose delivery timing is not
+        deterministic on the platform.
 
         Note that paths are provided as relative to `tmp` and using the forward
         slash separator. They will be converted to absolute paths using `tmp`
         and normalized.  An empty path, i.e. "", is kept as-is.
         """
-        self.expected_events.append(_ExpectedEvent(expected_class, src_path, dest_path))
+        self.expected_events.append(_ExpectedEvent(expected_class, src_path, dest_path, optional))
 
     def _match_event(self, event: FileSystemEvent, expected_event: _ExpectedEvent) -> bool:
         if not isinstance(event, expected_event.expected_class):
@@ -229,13 +249,14 @@ class _EventsChecker:
                     del expected_events[i]
                     matched_events.append(event)
                     break
-        if expected_events:
+        missing_events = [e for e in expected_events if not e.optional]
+        if missing_events:
             # Fail, we did not find some of the expected events.
             if self._verbose:
                 self._debug("missing:")
-                for e in expected_events:
-                    self._debug("  ", e.expected_class.__name__, e.src_path)
-            assert not expected_events, "some expected events not found"
+                for e in missing_events:
+                    self._debug("  ", e.class_name, e.src_path)
+            assert not missing_events, "some expected events not found"
         if not self._allow_extra:  # noqa: SIM102
             # Check that we did not receive extra events
             if len(matched_events) < len(found_events):
@@ -245,12 +266,36 @@ class _EventsChecker:
                 msg = "received unexpected events"
                 raise AssertionError(msg)
 
-    def _check_events_with_order( self, found_events: list[FileSystemEvent]) -> None:
-        if not self._allow_extra:
-            # we need exactly the number of expected events
-            assert len(found_events) == len(self.expected_events), "wrong number of events"
-        for event, expected_event in zip(found_events, self.expected_events):
-            assert self._match_event(event, expected_event), "did not find expected event"
+    def _check_events_with_order(self, found_events: list[FileSystemEvent]) -> None:
+        # Check that the received events match the expected events, in order.
+        # Optional expected events are skipped when they did not occur.
+        expected_events = self.expected_events
+        index = 0
+        for event in found_events:
+            matched = False
+            while index < len(expected_events):
+                expected_event = expected_events[index]
+                if self._match_event(event, expected_event):
+                    index += 1
+                    matched = True
+                    break
+                if expected_event.optional:
+                    # The optional event did not occur, skip it.
+                    self._debug("skipping optional:", expected_event)
+                    index += 1
+                    continue
+                break
+            if not matched and not self._allow_extra:
+                self._debug("unexpected:", event)
+                msg = "received unexpected events"
+                raise AssertionError(msg)
+        missing_events = [e for e in expected_events[index:] if not e.optional]
+        if missing_events:
+            if self._verbose:
+                self._debug("missing:")
+                for e in missing_events:
+                    self._debug("  ", e.class_name, e.src_path)
+            assert not missing_events, "some expected events not found"
 
     def check_events(self, timeout: float = 2) -> None:
         """Read events from the events queue (waiting for up to `timeout` for
@@ -260,7 +305,7 @@ class _EventsChecker:
         if self._verbose:
             self._debug("expecting:")
             for e in self.expected_events:
-                self._debug("  ", e.expected_class.__name__, repr(e.src_path))
+                self._debug("  ", e.class_name, repr(e.src_path))
 
         found_events = []
         while True:


### PR DESCRIPTION
Addresses the Windows failure mode of #1128.

## Root cause

On Windows, `mkdir(p("a", "b"))` updates the last-write time of directory `a`, but NTFS flushes that change - and thus delivers the corresponding `FILE_ACTION_MODIFIED` notification for `a` - lazily. Instrumenting `DirectoryChangeReader` directly shows the notification is not delivered when the subdirectory is created; on my machine it only shows up when the subsequent `mv(p("a"), p("a2"))` touches the directory, ~4 seconds later:

```
[  3.031s] mkdir a/b
  [  3.266s] action=1 (ADDED)        src='a\b'
[  7.031s] rename a -> a2
  [  7.313s] action=3 (MODIFIED)     src='a'    <- delayed notification from the mkdir
  [  7.313s] action=4 (RENAMED_OLD)  src='a'
  [  7.313s] action=5 (RENAMED_NEW)  src='a2'
  [  7.313s] action=3 (MODIFIED)     src='a2'
```

Two consequences for the test:

1. The modified event for `a` arrives in the events-checker block for the rename, not the block for the mkdir - or, on other machines (apparently the GitHub runners), not at all.
2. When it arrives after the rename, `a` no longer exists on disk anymore, so `WindowsApiEmitter.queue_events()` classifies it as a `FileModifiedEvent` instead of a `DirModifiedEvent` (`src/watchdog/observers/read_directory_changes.py` line 89 - the `os.path.isdir(src_path)` check runs at processing time, not at event time).

The events checker requires exactly the expected events, in order, so the stray event makes the test fail with `AssertionError: wrong number of events`.

## Fix

Test-side only. The emitter cannot reliably classify a modified event for a path that no longer exists without the extended info from `ReadDirectoryChangesExW`, which is what #1156 is introducing for deletions - I did not want to conflict with that work.

- `_EventsChecker.add()` accepts `optional=True` for events whose delivery is not deterministic on the platform; both the ordered and unordered checks now tolerate absent optional events. The ordered check is rewritten as a two-pointer walk over found/expected events (the previous `zip()`-based check also silently ignored missing trailing events whenever `allow_extra_events()` was used).
- `expected_class` may now be a tuple of classes (passed straight through to `isinstance()`). This is needed because the class of the delayed event depends on whether the directory still exists when the emitter processes the notification (see point 2 above).
- `test_renaming_top_level_directory` declares the delayed notification for `a` as optional in the two affected blocks.

## Before/after

On this machine (Windows 11, NTFS, Python 3.12.10), `tests/test_emitter.py::test_renaming_top_level_directory`:

- unmodified master: failed 9/9 runs;
- with this change: passed 7/7 runs.

Full test suite apart from `test_0_watchmedo`: 102 passed, 12 skipped. `test_0_watchmedo` had one unrelated flaky failure (`test_auto_restart_on_file_change_debounce`, thread-count assertion) which also fails on master CI on Linux 3.13t; it passes on rerun and does not use the events checker. `ruff check` is clean on the touched files.

## Limitations

#1128 also shows a Linux/Python 3.14 failure (`DirMovedEvent` not delivered within the 2 s timeout, pre-dating the events-checker refactor). I could not reproduce that on this machine and this PR does not address it - only the Windows failure mode, which is deterministic here.
