### PR TITLE
fix(bsd): do not let PermissionError kill the kqueue emitter thread

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -14,6 +14,7 @@ Changelog
 
 **Other Changes**
 
+- [bsd] Do not let a ``PermissionError`` raised while registering a kevent kill the emitter thread. (`#1115 <https://github.com/gorakhargosh/watchdog/issues/1115>`__)
 - [core] Add context manager support to ``Observer`` class. The observer can now be used with a ``with`` statement for automatic start/stop management. (`#1090 <https://github.com/gorakhargosh/watchdog/pull/1149>`__)
 - [freebsd] Supports ``inotify`` on FreeBSD 15+. (`#1147 <https://github.com/gorakhargosh/watchdog/pull/1147>`__)
 - [core] Adjust ``Observer.schedule()`` ``path`` type annotation to reflect the ``pathlib.Path`` support. (`#1096 <https://github.com/gorakhargosh/watchdog/pull/1096>`__)

--- a/src/watchdog/observers/kqueue.py
+++ b/src/watchdog/observers/kqueue.py
@@ -452,6 +452,12 @@ class KqueueEmitter(EventEmitter):
                 # access to it (e.g. NFS). On BSD systems look at
                 # EOPNOTSUPP in man 2 open.
                 pass
+            elif e.errno in {errno.EACCES, errno.EPERM}:
+                # The path is not readable by the current user, e.g. a file
+                # created by another user in a world-writable directory such
+                # as /tmp. We cannot watch it, but that must not kill the
+                # emitter thread: the event itself was already queued.
+                pass
             else:
                 # All other errors are propagated.
                 raise

--- a/tests/test_kqueue.py
+++ b/tests/test_kqueue.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pytest
+
+from watchdog.utils import platform
+
+if not platform.is_bsd() and not platform.is_darwin():
+    pytest.skip("BSD/macOS only.", allow_module_level=True)
+
+import errno
+import os
+from unittest.mock import patch
+
+from watchdog.observers.api import EventQueue, ObservedWatch
+from watchdog.observers.kqueue import KqueueEmitter
+
+
+@pytest.mark.parametrize("err", [errno.EACCES, errno.EPERM])
+def test_register_kevent_ignores_permission_errors(tmpdir, err):
+    """A file we are not allowed to open must not kill the emitter thread.
+
+    See https://github.com/gorakhargosh/watchdog/issues/1115
+    """
+    emitter = KqueueEmitter(EventQueue(), ObservedWatch(str(tmpdir), recursive=False), timeout=1)
+
+    # The file appears after the watch was set up, as in the reported scenario.
+    path = os.path.join(str(tmpdir), "denied")
+    with open(path, "w"):
+        pass
+
+    real_open = os.open
+
+    def fake_open(p, flags, *args, **kwargs):
+        if p == path:
+            raise PermissionError(err, os.strerror(err), p)
+        return real_open(p, flags, *args, **kwargs)
+
+    try:
+        with patch("os.open", side_effect=fake_open):
+            emitter._register_kevent(path, is_directory=False)  # noqa: SLF001
+    finally:
+        emitter._descriptors.clear()  # noqa: SLF001


### PR DESCRIPTION
Closes #1115

`KqueueEmitter.queue_event()` registers a kevent descriptor for every newly created path, which opens the file. `_register_kevent()` ignores `ENOENT` and `EOPNOTSUPP` but re-raises everything else, so watching a world-writable directory such as `/tmp` kills the emitter thread with `PermissionError` as soon as another user creates a file there. `EACCES`/`EPERM` now join the ignored errnos — the path cannot be watched, but the event was already queued and the observer keeps running.

`tests/test_kqueue.py` patches `os.open` to raise `EACCES`/`EPERM` for a path appearing after the watch was set up; it fails with the reported `PermissionError` before the fix and passes after it.
