### PR TITLE
Add .readthedocs.yaml to fix ReadTheDocs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,17 @@
+version: 2
+
+sphinx:
+  configuration: docs/source/conf.py
+
+build:
+  os: ubuntu-lts-latest
+  tools:
+    python: "3.12"
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - watchmedo
+    - requirements: requirements-tests.txt


### PR DESCRIPTION
### Description
Closes #1121 and Closes #1074.

This PR adds a `.readthedocs.yaml` configuration file to the root of the project to fix the documentation builds on Read the Docs, which are currently failing and stuck on version 2.1.6 (from 2021).

### Changes
- **`.readthedocs.yaml`**: Created configuration pinning build environment to `ubuntu-lts-latest` and Python `3.12`. It installs the package and its requirements using `pip`.

### Verification
- Verified by building the documentation locally via `tox -e docs` (Sphinx 8.1.3 build succeeded without errors).

### Official References
- [Read the Docs Blog: Mandating Configuration v2](https://blog.readthedocs.com/migrate-configuration-v2/) (Requires `.readthedocs.yaml` for all builds as of Jan 20, 2025).
- [Read the Docs Configuration Manual](https://docs.readthedocs.io/en/stable/config-file/v2.html)
