### PR TITLE
docs: fix sidebar layout overlap for long method names

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -74,6 +74,14 @@ pygments_style = "sphinx"
 # a list of builtin themes.
 html_theme = "pyramid"
 
+html_theme_options = {
+    "sidebarwidth": "280",
+}
+
+# Hide the class name prefix in the Table of Contents/sidebar for methods and attributes.
+# This prevents long names (like FileSystemEventHandler.on_closed_no_write()) from overflowing the sidebar.
+toc_object_entries_show_parents = "hide"
+
 # Output file base name for HTML help builder.
 htmlhelp_basename = "%sdoc" % PROJECT_NAME
 


### PR DESCRIPTION
Improve the Sphinx documentation sidebar so long API names are easier to read.

## Changes

- Increase the Pyramid theme sidebar width to **280px**.
- Hide parent class names in the sidebar/Table of Contents by setting:

  ```python
  toc_object_entries_show_parents = "hide"
  ```

Some API names, such as `FileSystemEventHandler.on_closed_no_write()`, are too long and can overflow the sidebar. This makes the navigation harder to read. These changes make the sidebar cleaner while keeping all API entries available.

## References

- Rendered documentation from my fork:  
  https://watchdog-docs.readthedocs.io/en/latest/api.html#watchdog.events.FileSystemEvent.is_directory

## Testing

- Built the documentation locally.
- Confirmed that long API names no longer overflow the sidebar.
- Verified that the sidebar navigation displays correctly.

> **Note:** This change only affects the documentation UI. It does not change the library's runtime behavior.