### PR TITLE
docs: add single-file watcher example

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -14,6 +14,16 @@ To filter file system events using glob patterns (for example, only observing ch
    :language: python
    :linenos:
 
+Watch a Single File
+-------------------
+Observers watch directories, not individual files. To monitor one file, schedule its parent directory and filter events by the file name. The following example watches ``example.txt`` in the given directory; pass a different file name as the optional second argument::
+
+    python single_file.py /path/to/directory [filename]
+
+.. literalinclude:: examples/single_file.py
+   :language: python
+   :linenos:
+
 Logging Trick
 -------------
 Watchdog also includes built-in "tricks" (pre-implemented event handlers). For instance, the :class:`watchdog.tricks.LoggerTrick` automatically logs events. Here is how you can use it:

--- a/docs/source/examples/single_file.py
+++ b/docs/source/examples/single_file.py
@@ -1,0 +1,27 @@
+import logging
+import sys
+import time
+
+from watchdog.events import FileSystemEvent, PatternMatchingEventHandler
+from watchdog.observers import Observer
+
+logging.basicConfig(level=logging.INFO)
+
+
+class SingleFileEventHandler(PatternMatchingEventHandler):
+    def on_any_event(self, event: FileSystemEvent) -> None:
+        logging.info(event)
+
+
+watched_directory = sys.argv[1]
+filename = sys.argv[2] if len(sys.argv) > 2 else "example.txt"
+event_handler = SingleFileEventHandler(patterns=[filename], ignore_directories=True)
+observer = Observer()
+observer.schedule(event_handler, watched_directory, recursive=False)
+observer.start()
+try:
+    while True:
+        time.sleep(1)
+finally:
+    observer.stop()
+    observer.join()

--- a/docs/source/examples/single_file.py
+++ b/docs/source/examples/single_file.py
@@ -1,0 +1,27 @@
+import logging
+import sys
+import time
+
+from watchdog.events import FileSystemEvent, PatternMatchingEventHandler
+from watchdog.observers import Observer
+
+logging.basicConfig(level=logging.INFO)
+
+
+class SingleFileEventHandler(PatternMatchingEventHandler):
+    def on_any_event(self, event: FileSystemEvent) -> None:
+        logging.info(event)
+
+
+watched_directory = sys.argv[1]
+filename = sys.argv[2] if len(sys.argv) > 2 else "example.txt"
+event_handler = SingleFileEventHandler(patterns=[f"**/{filename}"], ignore_directories=True)
+observer = Observer()
+observer.schedule(event_handler, watched_directory, recursive=False)
+observer.start()
+try:
+    while True:
+        time.sleep(1)
+finally:
+    observer.stop()
+    observer.join()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -6,14 +6,17 @@ from unittest.mock import patch
 
 import pytest
 
+from watchdog.events import FileModifiedEvent
+
 EXAMPLES_DIR = Path("docs/source/examples")
 EXAMPLES = [str(p) for p in sorted(EXAMPLES_DIR.glob("*.py")) if p.name != "__init__.py"]
 
 
 @pytest.mark.parametrize("script_path", EXAMPLES)
-def test_example(script_path: str) -> None:
+def test_example(script_path: str, tmp_path: Path) -> None:
     # Mock sys.argv to supply the path parameter, and time.sleep to exit the loop
-    with patch("sys.argv", [script_path, "."]), patch("time.sleep", side_effect=KeyboardInterrupt):
+    watched_directory = tmp_path.resolve()
+    with patch("sys.argv", [script_path, str(watched_directory)]), patch("time.sleep", side_effect=KeyboardInterrupt):
         # Load and execute the module dynamically
         spec = importlib.util.spec_from_file_location("example_module", script_path)
         assert spec is not None
@@ -23,3 +26,9 @@ def test_example(script_path: str) -> None:
         # This will run the script, trigger KeyboardInterrupt, and run the finally block
         with pytest.raises(KeyboardInterrupt):
             spec.loader.exec_module(module)
+
+    if Path(script_path).name == "single_file.py":
+        event = FileModifiedEvent(str(watched_directory / "example.txt"))
+        with patch("logging.info") as log:
+            module.event_handler.dispatch(event)
+        log.assert_called_once_with(event)


### PR DESCRIPTION
## Summary
- add a runnable example for monitoring one file by watching its parent directory
- show how to filter events by the file name without scheduling a file path directly

Closes #1190.

## Validation
- `python -m pytest tests/test_examples.py`
- `python -m ruff check docs/source/examples/single_file.py`
- `python -m ruff format --check docs/source/examples/single_file.py`
- `python -m mypy docs/source/examples/single_file.py`
- `python -m sphinx.cmd.build -aEWb html docs/source docs/build/html`
