### PR TITLE
docs: add debounced events example

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -21,3 +21,11 @@ Watchdog also includes built-in "tricks" (pre-implemented event handlers). For i
 .. literalinclude:: examples/logger.py
    :language: python
    :linenos:
+
+Debouncing Events
+-----------------
+Text editors and build tools can emit several events for a single logical change. Use :class:`watchdog.utils.event_debouncer.EventDebouncer` to collect a burst of events and run an expensive action once the watched directory has been quiet for a short interval:
+
+.. literalinclude:: examples/debounced.py
+   :language: python
+   :linenos:

--- a/docs/source/examples/debounced.py
+++ b/docs/source/examples/debounced.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import logging
+import sys
+import time
+
+from watchdog.events import FileSystemEvent, FileSystemEventHandler
+from watchdog.observers import Observer
+from watchdog.utils.event_debouncer import EventDebouncer
+
+logging.basicConfig(level=logging.INFO)
+
+
+def rebuild(events: list[FileSystemEvent]) -> None:
+    """Run an expensive action once after a burst of file changes."""
+    logging.info("Rebuilding after %d filesystem events", len(events))
+
+
+class DebouncedEventHandler(FileSystemEventHandler):
+    def __init__(self, debouncer: EventDebouncer) -> None:
+        self.debouncer = debouncer
+
+    def on_any_event(self, event: FileSystemEvent) -> None:
+        if not event.is_directory:
+            self.debouncer.handle_event(event)
+
+
+path = sys.argv[1] if len(sys.argv) > 1 else "."
+
+debouncer = EventDebouncer(debounce_interval_seconds=1, events_callback=rebuild)
+event_handler = DebouncedEventHandler(debouncer)
+observer = Observer()
+observer.schedule(event_handler, path, recursive=True)
+
+debouncer.start()
+observer.start()
+try:
+    while True:
+        time.sleep(1)
+finally:
+    observer.stop()
+    debouncer.stop()
+    observer.join()
+    debouncer.join()


### PR DESCRIPTION
## Summary

- add a self-contained example that coalesces a burst of filesystem events before running an expensive action
- stop and join both the observer and debouncer cleanly on shutdown
- include the example on the documentation Examples page

This contributes one of the practical examples requested in #1190 without closing the umbrella issue.

## Tests

- python -m pytest tests/test_examples.py -vv — 4 passed
- python -m ruff format --check docs/source/examples — passed
- python -m ruff check docs/source/examples — passed
- python -m mypy docs/source/examples — passed
- sphinx-build -aEWb html docs/source /tmp/watchdog-docs-build — passed with warnings treated as errors