### PR TITLE
docs: improve hacking guide, integrate changelog and third-party licenses

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,0 +1,1 @@
+.. include:: ../../changelog.rst

--- a/docs/source/hacking.rst
+++ b/docs/source/hacking.rst
@@ -4,14 +4,15 @@
 
 Contributing
 ============
-Welcome hacker! So you have got something you would like to see in
-|project_name|? Whee. This document will help you get started.
+👋 **Welcome hacker!** So you have got something you would like to see in
+|project_name|? Whee! This document will help you get started.
 
 Important URLs
 --------------
-|project_name| uses git_ to track code history and hosts its `code repository`_
-at github_. The `issue tracker`_ is where you can file bug reports and request
-features or enhancements to |project_name|.
+
+* 🐙 **Code Repository**: `code repository`_ (GitHub)
+* 🐛 **Issue Tracker**: `issue tracker`_ (GitHub Issues)
+* 📖 **Documentation**: `Official Documentation <https://python-watchdog.readthedocs.io/>`_
 
 Before you start
 ----------------
@@ -31,26 +32,79 @@ Steps to setting up a clean environment:
 
 2. Clone fork and create virtual environment:
 
-.. code:: bash
+   .. code:: bash
 
-    $ git clone https://github.com/gorakhargosh/watchdog.git
-    $ cd watchdog
-    $ python -m venv venv
+     $ git clone https://github.com/gorakhargosh/watchdog.git
+     $ cd watchdog
+     $ python -m venv venv
 
-3. Linux
+3. Activate the virtual environment and install the package in editable mode:
 
-.. code:: bash
+   *macOS & Linux*
 
-    $ . venv/bin/activate
-    (venv)$ python -m pip install -e '.'
+   .. code:: bash
 
-4. Windows
+       $ . venv/bin/activate
+       (venv)$ python -m pip install -e '.'
 
-.. code:: batch
+   *Windows*
 
-    > venv\Scripts\activate
-    (venv)> python -m pip install -e '.'
+   .. code:: batch
+
+       > venv\Scripts\activate
+       (venv)> python -m pip install -e '.'
 
 That's it with the setup. Now you're ready to hack on |project_name|.
 
-Happy hacking!
+Running Tests and Checks
+------------------------
+
+Before submitting a Pull Request, please verify your changes pass the test suite and style checks. If you are adding a new feature or fixing a bug, please include new test cases covering the changes.
+
+Make sure your virtual environment is active, then install the testing and development dependencies:
+
+.. code:: bash
+
+    (venv)$ python -m pip install -r requirements-tests.txt
+
+To run style and formatting checks:
+
+.. code:: bash
+
+    # Run Ruff to check and format code
+    (venv)$ python -m ruff format src tests docs/source/examples
+    (venv)$ python -m ruff check --fix src tests docs/source/examples
+
+To run type checking:
+
+.. code:: bash
+
+    (venv)$ python -m mypy src docs/source/examples
+
+To run the test suite:
+
+.. code:: bash
+
+    # Run pytest
+    (venv)$ python -m pytest
+
+    # Or run the entire suite using tox (if installed in your venv)
+    (venv)$ tox
+
+    # Or run using uv without installing tox locally
+    (venv)$ uvx tox
+
+To build the documentation locally:
+
+.. code:: bash
+
+    # Build using sphinx-build directly
+    (venv)$ sphinx-build -b html docs/source docs/build/html
+
+    # Or build using tox via uv without installing tox locally
+    (venv)$ uvx tox -e docs
+
+.. note::
+   If you are using `uv` to manage your environment, you can use `uv pip install -r requirements-tests.txt` instead of standard `pip` to avoid externally-managed environment errors. Additionally, `tox` is not included in `requirements-tests.txt` to keep the testing dependency lightweight; running via `uvx tox` is the recommended way if `tox` is not installed globally.
+
+🚀 **Happy hacking!** We are excited to see what you build.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -42,6 +42,8 @@ User's Guide
    examples
    api
    hacking
+   changelog
+   third_party_licenses
 
 Contribute
 ==========

--- a/docs/source/third_party_licenses.rst
+++ b/docs/source/third_party_licenses.rst
@@ -1,0 +1,70 @@
+.. include:: global.rst.inc
+
+Third Party Licenses
+====================
+
+Python C-API compatibility header
+---------------------------------
+
+This project includes the ``pythoncapi_compat.h`` header provided by the
+``pythoncapi-compat`` project. It is located in the ``src`` directory.
+
+This header is included to allow writing code using C API constructs only
+available in newer Python versions.
+
+* **License**: Zero Clause BSD
+* **Copyright**: Contributors to the pythoncapi_compat project.
+* **Source**: https://github.com/python/pythoncapi_compat
+
+Python Standard Library Compatibility Code
+------------------------------------------
+
+This project includes the following unmodified functions from the Python 3.13 standard library:
+
+* ``glob.translate`` (from ``Lib/glob.py``)
+* ``fnmatch._translate`` (from ``Lib/fnmatch.py``)
+
+These are included in ``backwards_compat.py`` to provide backwards compatibility with older Python versions.
+
+* **License**: Python Software Foundation License Version 2
+* **Copyright**: © 2001–2024 Python Software Foundation; All Rights Reserved
+* **Source**: https://github.com/python/cpython
+
+--------------------------------------------------------------------------------
+
+Zero Clause BSD License
+-----------------------
+
+BSD Zero Clause License
+
+Copyright Contributors to the pythoncapi_compat project.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+
+Python Software Foundation License Version 2
+--------------------------------------------
+
+1. This LICENSE AGREEMENT is between the Python Software Foundation ("PSF"), and the Individual or Organization ("Licensee") accessing and otherwise using this software ("Python") in source or binary form and its associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, PSF hereby grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce, analyze, test, perform and/or display publicly, prepare derivative works, distribute, and otherwise use Python alone or in any derivative version, provided, however, that PSF's License Agreement and PSF's notice of copyright, i.e., "Copyright (c) 2001 Python Software Foundation; All Rights Reserved" are retained in Python alone or in any derivative version prepared by Licensee.
+
+3. In the event Licensee prepares a derivative work that is based on or incorporates Python or any part thereof, and wants to make the derivative work available to others as provided herein, then Licensee hereby agrees to include in any such work a brief summary of the changes made to Python.
+
+4. PSF is making Python available to Licensee on an "AS IS" basis.  PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON, OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material breach of its terms and conditions.
+
+7. Nothing in this License Agreement shall be deemed to create any relationship of agency, partnership, or joint venture between PSF and Licensee.  This License Agreement does not grant permission to use PSF trademarks or trade name in a trademark sense to endorse or promote products or services of Licensee, or any third party.
+
+8. By copying, installing or otherwise using Python, Licensee agrees to be bound by the terms and conditions of this License Agreement.

--- a/src/watchdog/__main__.py
+++ b/src/watchdog/__main__.py
@@ -2,6 +2,7 @@
 
 if __name__ == "__main__":
     import sys
+
     from watchdog.watchmedo import main
 
     sys.exit(main())

--- a/src/watchdog/events.py
+++ b/src/watchdog/events.py
@@ -514,11 +514,11 @@ def generate_sub_moved_events(
     for root, directories, filenames in os.walk(dest_dir_path):  # type: ignore[type-var]
         for directory in directories:
             full_path = os.path.join(root, directory)  # type: ignore[call-overload]
-            renamed_path = src_dir_path + full_path[len(dest_dir_path):] if src_dir_path else ""
+            renamed_path = src_dir_path + full_path[len(dest_dir_path) :] if src_dir_path else ""
             yield DirMovedEvent(renamed_path, full_path, is_synthetic=True)
         for filename in filenames:
             full_path = os.path.join(root, filename)  # type: ignore[call-overload]
-            renamed_path = src_dir_path + full_path[len(dest_dir_path):] if src_dir_path else ""
+            renamed_path = src_dir_path + full_path[len(dest_dir_path) :] if src_dir_path else ""
             yield FileMovedEvent(renamed_path, full_path, is_synthetic=True)
 
 

--- a/src/watchdog/observers/winapi.py
+++ b/src/watchdog/observers/winapi.py
@@ -412,7 +412,7 @@ class DirectoryChangeReader:
         # missed, we re-use these for each call to _run_inner().
         event_buffer = ctypes.create_string_buffer(BUFFER_SIZE)
         nbytes = DWORD()
-        self._buf_queue.put(b'')  # indicates that this thread has started
+        self._buf_queue.put(b"")  # indicates that this thread has started
         try:
             while not self._should_stop:
                 self._run_inner(handle, event_buffer, nbytes)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -254,4 +254,3 @@ def test_generate_sub_moved_events_repeated_dirname():
 
         assert len(file_events) == 1
         assert file_events[0].src_path == os.path.join(src_root, "data", "file.txt")
-

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -7,10 +7,7 @@ from unittest.mock import patch
 import pytest
 
 EXAMPLES_DIR = Path("docs/source/examples")
-EXAMPLES = [
-    str(p) for p in sorted(EXAMPLES_DIR.glob("*.py"))
-    if p.name != "__init__.py"
-]
+EXAMPLES = [str(p) for p in sorted(EXAMPLES_DIR.glob("*.py")) if p.name != "__init__.py"]
 
 
 @pytest.mark.parametrize("script_path", EXAMPLES)
@@ -22,7 +19,7 @@ def test_example(script_path: str) -> None:
         assert spec is not None
         assert spec.loader is not None
         module = importlib.util.module_from_spec(spec)
-        
+
         # This will run the script, trigger KeyboardInterrupt, and run the finally block
         with pytest.raises(KeyboardInterrupt):
             spec.loader.exec_module(module)

--- a/tests/test_observers_polling.py
+++ b/tests/test_observers_polling.py
@@ -47,6 +47,7 @@ def emitter(event_queue):
     em.stop()
     em.join(5)
 
+
 def test___init__(event_queue, emitter):
     sleep(SLEEP_TIME)
     mkdir(p("project"))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -153,7 +153,6 @@ class _ExpectedEvent:
 
 
 class _EventsChecker:
-
     expected_events: list[_ExpectedEvent]
 
     def __init__(self, helper: Helper, *, verbose: bool = False):
@@ -215,7 +214,7 @@ class _EventsChecker:
         self._debug("matched:", expected_event)
         return True
 
-    def _check_events_without_order( self, found_events: list[FileSystemEvent]) -> None:
+    def _check_events_without_order(self, found_events: list[FileSystemEvent]) -> None:
         # Check that events received contain the expected events.  This is
         # an inefficient way to do it, O(n*m) but since the list of expected
         # events should be fairly short, this is okay.  Using a list allows
@@ -245,7 +244,7 @@ class _EventsChecker:
                 msg = "received unexpected events"
                 raise AssertionError(msg)
 
-    def _check_events_with_order( self, found_events: list[FileSystemEvent]) -> None:
+    def _check_events_with_order(self, found_events: list[FileSystemEvent]) -> None:
         if not self._allow_extra:
             # we need exactly the number of expected events
             assert len(found_events) == len(self.expected_events), "wrong number of events"


### PR DESCRIPTION
Addresses #1194. This PR introduces the documentation updates discussed in the issue:

*  **Hacking Guide (`hacking.rst`)**: Added instructions for local testing (`pytest`/`tox`), linting/formatting (`ruff`/`mypy`), and writing unit tests, plus a note for `uv` environment users.
*  **Changelog & Licenses**: Registered first-class documentation pages for the `changelog` and `third_party_licenses` in the Sphinx navigation sidebar.
*  **Code Formatting**: Cleaned up minor styling, imports formatting, and trailing whitespaces across source and test files using `ruff`.
