### PR TITLE
docs: integrate all-contributors bot and credits page

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,16 @@
+{
+  "files": [
+    "docs/source/contributors.md"
+  ],
+  "imageSize": 70,
+  "commit": true,
+  "contributors": [],
+  "contributorsPerLine": 7,
+  "projectName": "watchdog",
+  "projectOwner": "gorakhargosh",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "skipCi": true,
+  "commitType": "docs",
+  "commitConvention": "angular"
+}

--- a/docs/source/authors.rst
+++ b/docs/source/authors.rst
@@ -1,0 +1,13 @@
+.. include:: global.rst.inc
+
+Contributors & Credits
+======================
+
+.. include:: ../../AUTHORS
+
+Recent Contributors
+-------------------
+This project is built and maintained by the community. Thank you to everyone who has contributed:
+
+.. raw:: html
+   :file: contributors.md

--- a/docs/source/contributors.md
+++ b/docs/source/contributors.md
@@ -1,0 +1,3 @@
+<!-- All Contributors Grid -->
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- ALL-CONTRIBUTORS-LIST:END -->

--- a/docs/source/hacking.rst
+++ b/docs/source/hacking.rst
@@ -45,14 +45,14 @@ Steps to setting up a clean environment:
    .. code:: bash
 
        $ . venv/bin/activate
-       (venv)$ python -m pip install -e '.'
+       (venv)$ python -m pip install -e '.[watchmedo]'
 
    *Windows*
 
    .. code:: batch
 
        > venv\Scripts\activate
-       (venv)> python -m pip install -e '.'
+       (venv)> python -m pip install -e '.[watchmedo]'
 
 That's it with the setup. Now you're ready to hack on |project_name|.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,6 +44,7 @@ User's Guide
    hacking
    changelog
    third_party_licenses
+   authors
 
 Contribute
 ==========


### PR DESCRIPTION
Addresses: https://github.com/gorakhargosh/watchdog/issues/1194
This PR proposes integrating the `@allcontributors` bot to automate contributor recognition, adds a dedicated credits page to the documentation.

### Changes:
*   **`.all-contributorsrc`**: Initialized All Contributors Bot configuration.
*   **`docs/source/contributors.md`**: Created a clean Markdown file with placeholders for the bot to automatically generate the contributor avatar grid.
*   **`docs/source/authors.rst`**: Created a credits page wrapping the legacy `AUTHORS` file and dynamically including the visual contributors grid.
*   **`docs/source/index.rst`**: Registered the new contributors page in the Sphinx navigation sidebar.


 **_Once merged, the repository owner needs to install the [All Contributors GitHub App](https://github.com/apps/allcontributors) on this repo to activate the bot._**