### PR TITLE
docs: Improve watchmedo CLI and tricks documentation

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,6 +1,6 @@
 .. include:: global.rst.inc
 
-.. api_reference:
+.. _api_reference:
 
 =============
 API Reference

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,9 +40,18 @@ User's Guide
    installation
    quickstart
    examples
+   watchmedo_cli
    api
    hacking
+
+.. toctree::
+   :maxdepth: 1
+
    changelog
+
+.. toctree::
+   :maxdepth: 2
+
    third_party_licenses
    authors
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,9 +40,17 @@ User's Guide
    installation
    quickstart
    examples
-   watchmedo_cli
    api
    hacking
+
+
+Command-Line Tool
+=================
+.. toctree::
+   :maxdepth: 2
+   
+   watchmedo_cli
+   tricks
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/tricks.rst
+++ b/docs/source/tricks.rst
@@ -1,0 +1,121 @@
+.. include:: global.rst.inc
+
+.. _tricks:
+
+Tricks & Advanced Configuration
+===============================
+
+A **trick** is a configurable filesystem event handler. Built-in tricks can log events, execute shell commands, or restart processes, and you can create your own by subclassing :class:`watchdog.tricks.Trick`.
+
+The ``watchmedo tricks`` command loads one or more event handlers ("tricks") from a configuration file and runs them under a **single filesystem observer**. Every configured trick receives matching filesystem events from the same observer.
+
+It is designed for complex or multi-step pipelines where you want to perform multiple actions for filesystem events (such as logging, executing commands, and restarting processes simultaneously) without running multiple separate ``watchmedo`` commands in different terminal windows, or writing a custom Python application.
+
+The Concept
+-----------
+
+Without tricks, running multiple tasks requires starting several terminal processes, each running its own observer:
+
+.. code-block:: bash
+
+    # Terminal 1
+    watchmedo log --patterns="*.py" .
+
+    # Terminal 2
+    watchmedo shell-command --patterns="*.py" --command="ruff check ." .
+
+    # Terminal 3
+    watchmedo auto-restart --patterns="*.py" --command="python app.py" .
+
+Using tricks simplifies configuration by allowing multiple event handlers to run under a single observer:
+
+.. code-block:: text
+
+               Filesystem
+                    │
+              One Observer
+                    │
+         ┌──────────┼──────────┐
+         │          │          │
+    LoggerTrick ShellCommand  CustomTrick
+
+Tricks Command
+--------------
+
+To run tricks, you specify a configuration file. The examples below use YAML, but the same configuration can also be provided as JSON:
+
+.. code-block:: bash
+
+    $ watchmedo tricks tricks.yaml
+
+Generating a Trick Template
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+To quickly get a template YAML file detailing the syntax for all available built-in tricks, run:
+
+.. code-block:: bash
+
+    $ watchmedo generate-tricks-yaml > tricks.yaml
+
+Configuration Format
+--------------------
+
+.. tip::
+   The configuration keys for each trick in the YAML file map directly to the constructor arguments (``__init__`` parameters) of the corresponding Python class (e.g. ``ShellCommandTrick``). They are conceptually identical to the command-line flags used in the direct CLI commands (for example, ``wait_for_process`` in YAML corresponds to the ``--wait`` CLI option).
+
+Here is a typical ``tricks.yaml`` configuration file demonstrating how to combine the built-in logger and shell-command tricks:
+
+.. code-block:: yaml
+
+    tricks:
+    - watchdog.tricks.LoggerTrick:
+        patterns: ["*.py", "*.txt"]
+        ignore_directories: true
+    - watchdog.tricks.ShellCommandTrick:
+        patterns: ["*.py"]
+        shell_command: "echo 'file changed: ${watch_src_path}'"
+        wait_for_process: true
+
+Writing Custom Tricks
+---------------------
+
+In addition to the built-in tricks, you can create your own by subclassing :class:`watchdog.tricks.Trick` and referencing it directly in your YAML configuration.
+
+1. **Write the custom trick class in Python:**
+
+   .. code-block:: python
+
+       # mypackage/tricks.py
+       from watchdog.tricks import Trick
+
+       class NotifyTeamTrick(Trick):
+           def on_modified(self, event):
+               # Perform custom validation, Slack alert, or cache update
+               print(f"Notifying team about: {event.src_path}")
+
+2. **Reference the custom trick in your configuration file:**
+
+   .. code-block:: yaml
+
+       tricks:
+       - mypackage.tricks.NotifyTeamTrick:
+           patterns: ["*.yaml"]
+
+Tricks Module Reference
+-----------------------
+
+Tricks are pre-implemented, configurable event handlers that subclass :class:`watchdog.tricks.Trick` (which itself subclasses :class:`watchdog.events.PatternMatchingEventHandler`). 
+
+You can reference and configure these tricks in your YAML files or instantiate them directly in your Python code:
+
+.. autoclass:: watchdog.tricks.Trick
+   :noindex:
+
+.. autoclass:: watchdog.tricks.LoggerTrick
+   :noindex:
+
+.. autoclass:: watchdog.tricks.ShellCommandTrick
+   :noindex:
+
+.. autoclass:: watchdog.tricks.AutoRestartTrick
+   :noindex:
+

--- a/docs/source/watchmedo_cli.rst
+++ b/docs/source/watchmedo_cli.rst
@@ -5,7 +5,7 @@
 Watchmedo CLI
 =============
 
-|project_name| comes with an optional utility command-line script called ``watchmedo`` that lets you quickly monitor file system changes, execute shell commands, restart processes, and run utility "tricks" without writing Python code.
+|project_name| comes with an optional utility command-line script called ``watchmedo`` that lets you quickly monitor file system changes, execute shell commands, and restart processes without writing Python code.
 
 Installation
 ------------
@@ -14,6 +14,24 @@ To use the ``watchmedo`` CLI utility, you must install |project_name| with the `
 .. code-block:: bash
 
     $ python -m pip install -U "watchdog[watchmedo]"
+
+When to use which command?
+--------------------------
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Command
+     - Best used for
+   * - ``log``
+     - Log file system events to the console.
+   * - ``shell-command``
+     - Execute commands (e.g. linting, compiling, formatting) in response to file system events.
+   * - ``auto-restart``
+     - Starting a long-running subprocess (like a development server or worker) and automatically restarting it when monitored files change.
+   * - ``tricks``
+     - Combining multiple handlers and pipelines from a single configuration file. See :ref:`tricks` for details.
 
 Commands
 --------
@@ -30,11 +48,14 @@ Logs file system events directly to the console.
 
 **Options:**
 
-*   ``--patterns="<patterns>"``: Glob patterns to observe, separated by semicolons (e.g., ``--patterns="*.py;*.txt"``).
-*   ``--ignore-patterns="<patterns>"``: Glob patterns to ignore, separated by semicolons.
-*   ``--ignore-directories``: Ignore directory events.
-*   ``--recursive``: Monitor the directory tree recursively.
-*   ``--verbose``: Verbose logging.
+*   ``directories``: Directories to watch (default: '.').
+*   ``--patterns="<patterns>"``:  Matches event paths with these patterns (separated by ;) (e.g., ``--patterns="*.py;*.txt"``).
+*   ``--ignore-patterns="<patterns>"``: Ignores event paths with these patterns (separated by ;).
+*   ``--ignore-directories``: Ignores events for directories.
+*   ``--recursive``: Monitors the directories recursively.
+*   ``--interval=TIMEOUT``, ``--timeout=TIMEOUT``: Use this as the polling interval/blocking timeout in seconds (default: 1.0).
+*   ``-q``, ``--quiet``: Minimize output (suppress standard event log messages).
+*   ``-v``, ``--verbose``: Verbose logging.
 
 **Example:**
 
@@ -56,20 +77,34 @@ Executes shell commands in response to file system events.
 
 **Options:**
 
-*   ``-c``, ``--command="<command>"``: The shell command to run.
-*   ``--patterns="<patterns>"``: Glob patterns to observe, separated by semicolons.
-*   ``--ignore-patterns="<patterns>"``: Glob patterns to ignore, separated by semicolons.
-*   ``--ignore-directories``: Ignore directory events.
-*   ``--recursive``: Monitor the directory tree recursively.
-*   ``--wait``: Wait for the command to finish before handling the next event.
-*   ``--drop``: Drop events that occur while the command is already running.
+*   ``directories``: Directories to watch (default: '.').
+*   ``-c``, ``--command="<command>"``: Shell command executed in response to matching events.
+*   ``--patterns="<patterns>"``: Matches event paths with these patterns (separated by ;).
+*   ``--ignore-patterns="<patterns>"``: Ignores event paths with these patterns (separated by ;).
+*   ``--ignore-directories``: Ignores events for directories (default: False).
+*   ``--recursive``: Monitors the directories recursively.
+*   ``--interval=TIMEOUT``, ``--timeout=TIMEOUT``: Use this as the polling interval/blocking timeout in seconds (default: 1.0).
+*   ``-q``, ``--quiet``: Minimize output (suppress standard event log messages).
+*   ``-v``, ``--verbose``: Verbose logging.
+*   ``--wait``: Wait for process to finish to avoid multiple simultaneous instances.
+*   ``--drop``: Ignore events that occur while command is still being executed to avoid multiple simultaneous instances.
+
+**Concurrency: Wait vs Drop**
+
+When multiple events occur in rapid succession while a command is running:
+
+*   ``--wait``: Queues up subsequent events. The command will run again for each queued event sequentially.
+*   ``--drop``: Discards any events that occur while the current command execution is still running.
 
 **Available Command Variables:**
 
 Within the command string, you can use the following environment variables which will be dynamically populated:
 
 *   ``${watch_src_path}``: The path where the event occurred.
-*   ``${watch_dest_path}``: The destination path (for moved/renamed events).
+    
+    *Example:* If a file ``src/main.py`` is modified, ``echo "${watch_src_path}"`` prints ``src/main.py``.
+    
+*   ``${watch_dest_path}``: The destination path (only populated for moved or renamed events; otherwise empty).
 *   ``${watch_event_type}``: The type of event (created, deleted, modified, moved).
 *   ``${watch_object}``: Whether the object is a "file" or a "directory".
 
@@ -87,7 +122,8 @@ Within the command string, you can use the following environment variables which
 
 ``watchmedo auto-restart``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
-Automatically restarts a process/command when monitored files change. This is extremely useful for automatically reloading development web servers, build pipelines, or test suites.
+Starts a long-running subprocess (like a development server, worker, or test suite) and automatically restarts it when monitored files change.
+
 
 **Usage:**
 
@@ -97,78 +133,67 @@ Automatically restarts a process/command when monitored files change. This is ex
 
 **Options:**
 
+*   ``directories``: Directories to watch (default: '.').
 *   ``-c``, ``--command="<command>"``: The process command to run.
-*   ``--patterns="<patterns>"``: Glob patterns to observe, separated by semicolons.
-*   ``--ignore-patterns="<patterns>"``: Glob patterns to ignore, separated by semicolons.
-*   ``--ignore-directories``: Ignore directory events.
-*   ``--recursive``: Monitor the directory tree recursively.
-*   ``--kill-after=SECONDS``: Wait for the specified seconds before sending a SIGKILL signal if SIGTERM fails (default: 15).
-*   ``--signal=SIGNAL``: Signal to send to the process (default: SIGINT).
+*   ``-d``, ``--directory=DIRECTORY``: Directory to watch. Use another ``-d`` or ``--directory`` option for each directory.
+*   ``--patterns="<patterns>"``: Matches event paths with these patterns (separated by ;).
+*   ``--ignore-patterns="<patterns>"``: Ignores event paths with these patterns (separated by ;).
+*   ``--ignore-directories``: Ignores events for directories.
+*   ``--recursive``: Monitors the directories recursively.
+*   ``--interval=TIMEOUT``, ``--timeout=TIMEOUT``: Use this as the polling interval/blocking timeout in seconds (default: 1.0).
+*   ``--debounce-interval=SECONDS``: After a file change, wait until the specified interval (in seconds) passes with no file changes, and only then restart (default: 0.0).
+*   ``--no-restart-on-command-exit``: Don't auto-restart the command after it exits.
+*   ``-q``, ``--quiet``: Minimize output (suppress standard event log messages).
+*   ``-v``, ``--verbose``: Verbose logging.
+*   ``--kill-after=SECONDS``: When stopping, kill the subprocess after the specified timeout in seconds (default 10.0).
+*   ``--signal=SIGNAL``: Stop the subprocess with this signal (default SIGINT).
 
 **Example:**
 
 .. code-block:: bash
 
-    $ watchmedo auto-restart \
-        --patterns="*.py" \
-        --recursive \
-        --command="python my_web_app.py" \
-        .
+    $ watchmedo auto-restart --patterns="*.py" \
+        --recursive --command="python my_web_app.py" .
 
----
+Common Use Cases
+----------------
 
-``watchmedo tricks`` (or ``tricks-from``)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Reads a YAML or JSON configuration file specifying multiple event handlers ("tricks") and runs them under a single observer. 
-
-This is useful when you have a complex monitoring pipeline (e.g., logging changes, linting Python files, and compiling style sheets simultaneously) and want to run it with a single command instead of opening multiple terminal windows.
-
-**Usage:**
+Automatically Run Tests
+~~~~~~~~~~~~~~~~~~~~~~~
+Run your pytest test suite immediately when any Python file changes:
 
 .. code-block:: bash
 
-    $ watchmedo tricks tricks.yaml
+    $ watchmedo shell-command --patterns="*.py" \
+        --recursive --command="pytest tests/" .
 
-**Example Config (``tricks.yaml``):**
 
-.. code-block:: yaml
-
-    tricks:
-    - watchdog.tricks.LoggerTrick:
-        patterns: ["*.py", "*.txt"]
-        ignore_directories: true
-    - watchdog.tricks.ShellCommandTrick:
-        patterns: ["*.py"]
-        shell_command: "echo 'file changed: ${watch_src_path}'"
-        wait_for_process: true
-
----
-
-``watchmedo generate-tricks-yaml`` (or ``tricks-generate-yaml``)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Generates a template YAML file detailing the syntax for all available built-in tricks.
-
-**Usage:**
+Compile Sass Stylesheets
+~~~~~~~~~~~~~~~~~~~~~~~~
+Compile Sass files to CSS automatically on edit:
 
 .. code-block:: bash
 
-    $ watchmedo generate-tricks-yaml > tricks.yaml
+    $ watchmedo shell-command --patterns="*.scss" \
+        --command="sass src/styles:dist/styles" .
 
-Tricks Module Reference
------------------------
+Platform Behavior & Limitations
+-------------------------------
 
-Tricks are pre-implemented, configurable event handlers that subclass :class:`watchdog.tricks.Trick` (which itself subclasses :class:`watchdog.events.PatternMatchingEventHandler`). 
+.. note::
+   Event ordering and duplicate events may vary depending on the operating system and observer backend (e.g., inotify, FSEvents, ReadDirectoryChangesW, or Polling).
 
-You can reference and configure these tricks in your YAML files or instantiate them directly in your Python code:
+Debugging & Forcing Observers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autoclass:: watchdog.tricks.Trick
-   :noindex:
+By default, ``watchmedo`` automatically selects the most efficient native observer backend for your operating system. However, in certain environments—such as inside Docker containers, virtual machines, or network-mounted directories (NFS/Samba)—native file events may not propagate correctly from the host.
 
-.. autoclass:: watchdog.tricks.LoggerTrick
-   :noindex:
+In these cases, you can force ``watchmedo`` to use a specific observer backend using one of the following debug options (available on all event-monitoring subcommands: ``log``, ``shell-command``, ``auto-restart``, and ``tricks``):
 
-.. autoclass:: watchdog.tricks.ShellCommandTrick
-   :noindex:
+*   ``--debug-force-polling``: Forces the use of polling to detect changes. This may be required for Docker containers or network mounts where standard OS file notifications do not work.
+*   ``--debug-force-inotify``: Forces the Linux ``inotify`` backend.
+*   ``--debug-force-fsevents``: Forces the macOS FSEvents backend.
+*   ``--debug-force-kqueue``: Forces the BSD ``kqueue`` backend.
+*   ``--debug-force-winapi``: Forces the Windows API backend.
 
-.. autoclass:: watchdog.tricks.AutoRestartTrick
-   :noindex:
+If the built-in commands do not meet your needs, you can implement a custom event handler in Python using the :ref:`api_reference` and :class:`watchdog.tricks.Trick` APIs.

--- a/docs/source/watchmedo_cli.rst
+++ b/docs/source/watchmedo_cli.rst
@@ -1,0 +1,174 @@
+.. include:: global.rst.inc
+
+.. _watchmedo_cli:
+
+Watchmedo CLI
+=============
+
+|project_name| comes with an optional utility command-line script called ``watchmedo`` that lets you quickly monitor file system changes, execute shell commands, restart processes, and run utility "tricks" without writing Python code.
+
+Installation
+------------
+To use the ``watchmedo`` CLI utility, you must install |project_name| with the ``watchmedo`` extra dependencies:
+
+.. code-block:: bash
+
+    $ python -m pip install -U "watchdog[watchmedo]"
+
+Commands
+--------
+
+``watchmedo log``
+~~~~~~~~~~~~~~~~~
+Logs file system events directly to the console.
+
+**Usage:**
+
+.. code-block:: bash
+
+    $ watchmedo log [options] [directory]
+
+**Options:**
+
+*   ``--patterns="<patterns>"``: Glob patterns to observe, separated by semicolons (e.g., ``--patterns="*.py;*.txt"``).
+*   ``--ignore-patterns="<patterns>"``: Glob patterns to ignore, separated by semicolons.
+*   ``--ignore-directories``: Ignore directory events.
+*   ``--recursive``: Monitor the directory tree recursively.
+*   ``--verbose``: Verbose logging.
+
+**Example:**
+
+.. code-block:: bash
+
+    $ watchmedo log --patterns="*.py;*.txt" --recursive .
+
+---
+
+``watchmedo shell-command``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Executes shell commands in response to file system events.
+
+**Usage:**
+
+.. code-block:: bash
+
+    $ watchmedo shell-command --command="<command>" [options] [directory]
+
+**Options:**
+
+*   ``-c``, ``--command="<command>"``: The shell command to run.
+*   ``--patterns="<patterns>"``: Glob patterns to observe, separated by semicolons.
+*   ``--ignore-patterns="<patterns>"``: Glob patterns to ignore, separated by semicolons.
+*   ``--ignore-directories``: Ignore directory events.
+*   ``--recursive``: Monitor the directory tree recursively.
+*   ``--wait``: Wait for the command to finish before handling the next event.
+*   ``--drop``: Drop events that occur while the command is already running.
+
+**Available Command Variables:**
+
+Within the command string, you can use the following environment variables which will be dynamically populated:
+
+*   ``${watch_src_path}``: The path where the event occurred.
+*   ``${watch_dest_path}``: The destination path (for moved/renamed events).
+*   ``${watch_event_type}``: The type of event (created, deleted, modified, moved).
+*   ``${watch_object}``: Whether the object is a "file" or a "directory".
+
+**Example:**
+
+.. code-block:: bash
+
+    $ watchmedo shell-command \
+        --patterns="*.py" \
+        --recursive \
+        --command="echo 'File ${watch_src_path} was ${watch_event_type}'" \
+        .
+
+---
+
+``watchmedo auto-restart``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+Automatically restarts a process/command when monitored files change. This is extremely useful for automatically reloading development web servers, build pipelines, or test suites.
+
+**Usage:**
+
+.. code-block:: bash
+
+    $ watchmedo auto-restart --command="<command>" [options] [directory]
+
+**Options:**
+
+*   ``-c``, ``--command="<command>"``: The process command to run.
+*   ``--patterns="<patterns>"``: Glob patterns to observe, separated by semicolons.
+*   ``--ignore-patterns="<patterns>"``: Glob patterns to ignore, separated by semicolons.
+*   ``--ignore-directories``: Ignore directory events.
+*   ``--recursive``: Monitor the directory tree recursively.
+*   ``--kill-after=SECONDS``: Wait for the specified seconds before sending a SIGKILL signal if SIGTERM fails (default: 15).
+*   ``--signal=SIGNAL``: Signal to send to the process (default: SIGINT).
+
+**Example:**
+
+.. code-block:: bash
+
+    $ watchmedo auto-restart \
+        --patterns="*.py" \
+        --recursive \
+        --command="python my_web_app.py" \
+        .
+
+---
+
+``watchmedo tricks`` (or ``tricks-from``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Reads a YAML or JSON configuration file specifying multiple event handlers ("tricks") and runs them under a single observer. 
+
+This is useful when you have a complex monitoring pipeline (e.g., logging changes, linting Python files, and compiling style sheets simultaneously) and want to run it with a single command instead of opening multiple terminal windows.
+
+**Usage:**
+
+.. code-block:: bash
+
+    $ watchmedo tricks tricks.yaml
+
+**Example Config (``tricks.yaml``):**
+
+.. code-block:: yaml
+
+    tricks:
+    - watchdog.tricks.LoggerTrick:
+        patterns: ["*.py", "*.txt"]
+        ignore_directories: true
+    - watchdog.tricks.ShellCommandTrick:
+        patterns: ["*.py"]
+        shell_command: "echo 'file changed: ${watch_src_path}'"
+        wait_for_process: true
+
+---
+
+``watchmedo generate-tricks-yaml`` (or ``tricks-generate-yaml``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Generates a template YAML file detailing the syntax for all available built-in tricks.
+
+**Usage:**
+
+.. code-block:: bash
+
+    $ watchmedo generate-tricks-yaml > tricks.yaml
+
+Tricks Module Reference
+-----------------------
+
+Tricks are pre-implemented, configurable event handlers that subclass :class:`watchdog.tricks.Trick` (which itself subclasses :class:`watchdog.events.PatternMatchingEventHandler`). 
+
+You can reference and configure these tricks in your YAML files or instantiate them directly in your Python code:
+
+.. autoclass:: watchdog.tricks.Trick
+   :noindex:
+
+.. autoclass:: watchdog.tricks.LoggerTrick
+   :noindex:
+
+.. autoclass:: watchdog.tricks.ShellCommandTrick
+   :noindex:
+
+.. autoclass:: watchdog.tricks.AutoRestartTrick
+   :noindex:

--- a/src/watchdog/events.py
+++ b/src/watchdog/events.py
@@ -114,13 +114,13 @@ class FileSystemEvent:
     dest_path: bytes | str = ""
     event_type: str = field(default="", init=False)
     is_directory: bool = field(default=False, init=False)
+    """True if event was triggered for a directory; False otherwise."""
 
-    """
-    True if event was synthesized; False otherwise.
+    is_synthetic: bool = field(default=False)
+    """True if event was synthesized; False otherwise.
     These are events that weren't actually broadcast by the OS, but
     are presumed to have happened based on other, actual events.
     """
-    is_synthetic: bool = field(default=False)
 
 
 class FileSystemMovedEvent(FileSystemEvent):

--- a/src/watchdog/tricks/__init__.py
+++ b/src/watchdog/tricks/__init__.py
@@ -74,7 +74,22 @@ class LoggerTrick(Trick):
 
 
 class ShellCommandTrick(Trick):
-    """Executes shell commands in response to matched events."""
+    """Executes shell commands in response to matched events.
+
+    :param shell_command:
+        The shell command to execute.
+    :param patterns:
+        Matches event paths with these patterns.
+    :param ignore_patterns:
+        Ignores event paths with these patterns.
+    :param ignore_directories:
+        Ignores events for directories (default: False).
+    :param wait_for_process:
+        Wait for process to finish to avoid multiple simultaneous instances.
+    :param drop_during_process:
+        Ignore events that occur while command is still being executed
+        to avoid multiple simultaneous instances.
+    """
 
     def __init__(
         self,
@@ -152,6 +167,25 @@ class AutoRestartTrick(Trick):
 
     Call `start()` after creating the Trick. Call `stop()` when stopping
     the process.
+
+    :param command:
+        The long-running command to run and restart.
+    :param patterns:
+        Matches event paths with these patterns.
+    :param ignore_patterns:
+        Ignores event paths with these patterns.
+    :param ignore_directories:
+        Ignores events for directories (default: False).
+    :param stop_signal:
+        Stop the subprocess with this signal (default SIGINT).
+    :param kill_after:
+        When stopping, kill the subprocess after the specified timeout in
+        seconds (default 10.0).
+    :param debounce_interval_seconds:
+        After a file change, wait until the specified interval (in seconds)
+        passes with no file changes, and only then restart (default: 0.0).
+    :param restart_on_command_exit:
+        Auto-restart the command after it exits (default: True).
     """
 
     def __init__(

--- a/src/watchdog/watchmedo.py
+++ b/src/watchdog/watchmedo.py
@@ -68,8 +68,8 @@ Licensed under the terms of the Apache license, version 2.0. Please see
 LICENSE in the source code for more information."""
 
 cli = ArgumentParser(epilog=epilog, formatter_class=HelpFormatter)
-cli.add_argument("--version", action="version", version=VERSION_STRING)
-subparsers = cli.add_subparsers(dest="top_command")
+cli.add_argument("-V", "--version", action="version", version=VERSION_STRING)
+subparsers = cli.add_subparsers(dest="top_command", title="subcommands")
 command_parsers = {}
 
 Argument = tuple[list[str], Any]
@@ -100,7 +100,13 @@ def command(
     def decorator(func: Callable) -> Callable:
         name = func.__name__.replace("_", "-")
         desc = dedent(func.__doc__ or "")
-        parser = parent.add_parser(name, aliases=cmd_aliases or [], description=desc, formatter_class=HelpFormatter)
+        parser = parent.add_parser(
+            name,
+            aliases=cmd_aliases or [],
+            description=desc,
+            help=desc.splitlines()[0].strip() if desc else None,
+            formatter_class=HelpFormatter,
+        )
         command_parsers[name] = parser
         verbosity_group = parser.add_mutually_exclusive_group()
         verbosity_group.add_argument("-q", "--quiet", dest="verbosity", action="append_const", const=-1)


### PR DESCRIPTION
This Pull Request addresses the documentation gap for the watchmedo CLI and the watchdog.tricks module as proposed in #1194.

**Verification Run**
- Ran uvx tox -e lint (All checks passed successfully).
- Ran uvx tox -e docs (Sphinx compiled successfully with 0 warnings or errors).