### PR TITLE
test: cover platform-specific observer selection in _get_observer_cls

### DIFF
--- a/tests/test_observers_init.py
+++ b/tests/test_observers_init.py
@@ -54,17 +54,6 @@ def _set_platform(
     monkeypatch.setattr("watchdog.observers.platform.is_bsd", lambda: bsd)
 
 
-def test_linux_returns_inotify_observer(monkeypatch: pytest.MonkeyPatch) -> None:
-    _set_platform(monkeypatch, linux=True)
-    sentinel = object()
-    _patch_imports(
-        monkeypatch,
-        {"watchdog.observers.inotify": _stub_module("watchdog.observers.inotify", InotifyObserver=sentinel)},
-    )
-
-    assert _get_observer_cls() is sentinel
-
-
 def test_linux_reraises_errors_other_than_unsupported_libc(monkeypatch: pytest.MonkeyPatch) -> None:
     # Only UnsupportedLibcError is meant to trigger a fallback on Linux; any
     # other failure while importing the inotify backend should propagate.
@@ -84,17 +73,6 @@ def test_linux_falls_back_to_polling_on_unsupported_libc(monkeypatch: pytest.Mon
             "watchdog.observers.inotify": UnsupportedLibcError("no libc"),
             "watchdog.observers.polling": _stub_module("watchdog.observers.polling", PollingObserver=sentinel),
         },
-    )
-
-    assert _get_observer_cls() is sentinel
-
-
-def test_darwin_returns_fsevents_observer(monkeypatch: pytest.MonkeyPatch) -> None:
-    _set_platform(monkeypatch, darwin=True)
-    sentinel = object()
-    _patch_imports(
-        monkeypatch,
-        {"watchdog.observers.fsevents": _stub_module("watchdog.observers.fsevents", FSEventsObserver=sentinel)},
     )
 
     assert _get_observer_cls() is sentinel
@@ -139,21 +117,6 @@ def test_darwin_falls_back_to_polling_when_fsevents_and_kqueue_fail(monkeypatch:
     assert any("Fall back to polling" in str(w.message) for w in caught)
 
 
-def test_windows_returns_winapi_observer(monkeypatch: pytest.MonkeyPatch) -> None:
-    _set_platform(monkeypatch, windows=True)
-    sentinel = object()
-    _patch_imports(
-        monkeypatch,
-        {
-            "watchdog.observers.read_directory_changes": _stub_module(
-                "watchdog.observers.read_directory_changes", WindowsApiObserver=sentinel
-            ),
-        },
-    )
-
-    assert _get_observer_cls() is sentinel
-
-
 def test_windows_falls_back_to_polling_on_import_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     _set_platform(monkeypatch, windows=True)
     sentinel = object()
@@ -171,17 +134,6 @@ def test_windows_falls_back_to_polling_on_import_failure(monkeypatch: pytest.Mon
 
     assert result is sentinel
     assert any("Failed to import `read_directory_changes`" in str(w.message) for w in caught)
-
-
-def test_bsd_returns_kqueue_observer(monkeypatch: pytest.MonkeyPatch) -> None:
-    _set_platform(monkeypatch, bsd=True)
-    sentinel = object()
-    _patch_imports(
-        monkeypatch,
-        {"watchdog.observers.kqueue": _stub_module("watchdog.observers.kqueue", KqueueObserver=sentinel)},
-    )
-
-    assert _get_observer_cls() is sentinel
 
 
 def test_unrecognized_platform_returns_polling_observer(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_observers_init.py
+++ b/tests/test_observers_init.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import builtins
+import types
+import warnings
+from typing import Any, Callable
+
+import pytest
+
+from watchdog.observers import _get_observer_cls
+from watchdog.utils import UnsupportedLibcError
+
+
+def _stub_module(name: str, **attrs: Any) -> types.ModuleType:
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    return module
+
+
+def _patch_imports(
+    monkeypatch: pytest.MonkeyPatch,
+    overrides: dict[str, types.ModuleType | Exception],
+) -> None:
+    """Make `from <name> import ...` return a stub or raise, for the given dotted names.
+
+    Everything else falls through to the real ``__import__``, so unrelated
+    imports (including the platform-detection helpers themselves) still work.
+    """
+    real_import: Callable[..., Any] = builtins.__import__
+
+    def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name in overrides:
+            override = overrides[name]
+            if isinstance(override, Exception):
+                raise override
+            return override
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+
+def _set_platform(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    linux: bool = False,
+    darwin: bool = False,
+    windows: bool = False,
+    bsd: bool = False,
+) -> None:
+    monkeypatch.setattr("watchdog.observers.platform.is_linux", lambda: linux)
+    monkeypatch.setattr("watchdog.observers.platform.is_darwin", lambda: darwin)
+    monkeypatch.setattr("watchdog.observers.platform.is_windows", lambda: windows)
+    monkeypatch.setattr("watchdog.observers.platform.is_bsd", lambda: bsd)
+
+
+def test_linux_returns_inotify_observer(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_platform(monkeypatch, linux=True)
+    sentinel = object()
+    _patch_imports(
+        monkeypatch,
+        {"watchdog.observers.inotify": _stub_module("watchdog.observers.inotify", InotifyObserver=sentinel)},
+    )
+
+    assert _get_observer_cls() is sentinel
+
+
+def test_linux_reraises_errors_other_than_unsupported_libc(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Only UnsupportedLibcError is meant to trigger a fallback on Linux; any
+    # other failure while importing the inotify backend should propagate.
+    _set_platform(monkeypatch, linux=True)
+    _patch_imports(monkeypatch, {"watchdog.observers.inotify": ImportError("boom")})
+
+    with pytest.raises(ImportError, match="boom"):
+        _get_observer_cls()
+
+
+def test_linux_falls_back_to_polling_on_unsupported_libc(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_platform(monkeypatch, linux=True)
+    sentinel = object()
+    _patch_imports(
+        monkeypatch,
+        {
+            "watchdog.observers.inotify": UnsupportedLibcError("no libc"),
+            "watchdog.observers.polling": _stub_module("watchdog.observers.polling", PollingObserver=sentinel),
+        },
+    )
+
+    assert _get_observer_cls() is sentinel
+
+
+def test_darwin_returns_fsevents_observer(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_platform(monkeypatch, darwin=True)
+    sentinel = object()
+    _patch_imports(
+        monkeypatch,
+        {"watchdog.observers.fsevents": _stub_module("watchdog.observers.fsevents", FSEventsObserver=sentinel)},
+    )
+
+    assert _get_observer_cls() is sentinel
+
+
+def test_darwin_falls_back_to_kqueue_when_fsevents_import_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_platform(monkeypatch, darwin=True)
+    sentinel = object()
+    _patch_imports(
+        monkeypatch,
+        {
+            "watchdog.observers.fsevents": ImportError("no fsevents extension"),
+            "watchdog.observers.kqueue": _stub_module("watchdog.observers.kqueue", KqueueObserver=sentinel),
+        },
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = _get_observer_cls()
+
+    assert result is sentinel
+    assert any("Fall back to kqueue" in str(w.message) for w in caught)
+
+
+def test_darwin_falls_back_to_polling_when_fsevents_and_kqueue_fail(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_platform(monkeypatch, darwin=True)
+    sentinel = object()
+    _patch_imports(
+        monkeypatch,
+        {
+            "watchdog.observers.fsevents": ImportError("no fsevents extension"),
+            "watchdog.observers.kqueue": ImportError("no kqueue support"),
+            "watchdog.observers.polling": _stub_module("watchdog.observers.polling", PollingObserver=sentinel),
+        },
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = _get_observer_cls()
+
+    assert result is sentinel
+    assert any("Fall back to polling" in str(w.message) for w in caught)
+
+
+def test_windows_returns_winapi_observer(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_platform(monkeypatch, windows=True)
+    sentinel = object()
+    _patch_imports(
+        monkeypatch,
+        {
+            "watchdog.observers.read_directory_changes": _stub_module(
+                "watchdog.observers.read_directory_changes", WindowsApiObserver=sentinel
+            ),
+        },
+    )
+
+    assert _get_observer_cls() is sentinel
+
+
+def test_windows_falls_back_to_polling_on_import_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_platform(monkeypatch, windows=True)
+    sentinel = object()
+    _patch_imports(
+        monkeypatch,
+        {
+            "watchdog.observers.read_directory_changes": ImportError("no winapi extension"),
+            "watchdog.observers.polling": _stub_module("watchdog.observers.polling", PollingObserver=sentinel),
+        },
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = _get_observer_cls()
+
+    assert result is sentinel
+    assert any("Failed to import `read_directory_changes`" in str(w.message) for w in caught)
+
+
+def test_bsd_returns_kqueue_observer(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_platform(monkeypatch, bsd=True)
+    sentinel = object()
+    _patch_imports(
+        monkeypatch,
+        {"watchdog.observers.kqueue": _stub_module("watchdog.observers.kqueue", KqueueObserver=sentinel)},
+    )
+
+    assert _get_observer_cls() is sentinel
+
+
+def test_unrecognized_platform_returns_polling_observer(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_platform(monkeypatch)
+    sentinel = object()
+    _patch_imports(
+        monkeypatch,
+        {"watchdog.observers.polling": _stub_module("watchdog.observers.polling", PollingObserver=sentinel)},
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = _get_observer_cls()
+
+    assert result is sentinel
+    assert not caught


### PR DESCRIPTION
`observers/__init__.py` picks which native backend (inotify, fsevents, kqueue, the Windows API, or the polling fallback) to hand back as `Observer`, but none of that branching had a test. Since it only runs once at import time, whichever branch matched the CI runner's own OS was the only one that ever executed.

I mocked `platform.is_linux/is_darwin/is_windows/is_bsd` and the backend imports themselves (via a stubbed `__import__`) so the branches can run regardless of what OS actually executes them.

Scope is narrower than it was originally: @BoboTiG pointed out that combining the Linux, FreeBSD, macOS and Windows runners already exercises each platform's success path, which is right, so the four tests asserting those are gone. What's left is the six arms no runner reaches, because the backend imports always succeed on CI:

- the `UnsupportedLibcError` suppression on Linux, and the plain `ImportError` that must propagate rather than fall back alongside it
- the two macOS fallbacks, fsevents -> kqueue and fsevents+kqueue -> polling, including the warnings that are a user's only signal they aren't on the observer they think they are
- the Windows fallback when `read_directory_changes` won't import
- the `PollingObserver` return at the bottom, which every platform branch returns before reaching

That Linux asymmetry is worth spelling out since it's the one that looks like a bug and isn't: only `UnsupportedLibcError` triggers the polling fallback there, so an unrelated `ImportError` while loading the inotify backend propagates instead of being swallowed the way it would on macOS/Windows. I pinned the current behavior rather than changing it. If that ever became a plain `except ImportError`, inotify would quietly become polling on any machine where the import fails and the whole matrix would stay green.

On coverage: this file no longer takes `observers/__init__.py` to 100% on its own, and shouldn't. Lines 58, 71, 78 and 80-82 are the per-platform returns, each covered by its own runner. The six remaining tests pass, and ruff format/check are clean.

Related to #19.
