### PR TITLE
ci: restrict GITHUB_TOKEN to read-only

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -34,6 +34,11 @@ concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name != 'pull_request' && github.sha || '' }}
   cancel-in-progress: true
 
+# Publishing authenticates to PyPI with its own token, not the GITHUB_TOKEN, so
+# read-only is sufficient for every job here. Elevate per-job if that ever changes.
+permissions:
+  contents: read
+
 jobs:
   macos-built-distributions:
     name: Build macOS wheels

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,10 @@ concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name != 'pull_request' && github.sha || '' }}
   cancel-in-progress: true
 
+# No job requires write access to the GITHUB_TOKEN; checkout only needs contents: read.
+permissions:
+  contents: read
+
 jobs:
   quality:
     name: 🧑‍🏭 Quality & Docs


### PR DESCRIPTION
Neither workflow declared a permissions block, so both ran with the
repository default token, which may grant write access to contents,
packages, and more.

No job requires write access to the GITHUB_TOKEN. Checkout uses it with
contents: read, while publishing authenticates to PyPI with
secrets.PYPI_API_TOKEN. Read-only is therefore sufficient throughout.

Any job that later needs more (for example, id-token: write for PyPI
Trusted Publishing) should elevate at the job level rather than relaxing
the top-level default.
