### PR TITLE
fix(windows): coalesce the deletion reported before a case-only rename

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -14,6 +14,7 @@ Changelog
 
 **Other Changes**
 
+- [windows] Changing only the case of a name no longer emits a deletion event on top of the move event. (`#752 <https://github.com/gorakhargosh/watchdog/issues/752>`__)
 - [bsd] Do not let a ``PermissionError`` raised while registering a kevent kill the emitter thread. (`#1115 <https://github.com/gorakhargosh/watchdog/issues/1115>`__)
 - [core] Add context manager support to ``Observer`` class. The observer can now be used with a ``with`` statement for automatic start/stop management. (`#1090 <https://github.com/gorakhargosh/watchdog/pull/1149>`__)
 - [freebsd] Supports ``inotify`` on FreeBSD 15+. (`#1147 <https://github.com/gorakhargosh/watchdog/pull/1147>`__)

--- a/src/watchdog/observers/winapi.py
+++ b/src/watchdog/observers/winapi.py
@@ -355,6 +355,28 @@ class WinAPINativeEvent:
         return self.action == FILE_ACTION_REMOVED_SELF
 
 
+def _drop_case_only_rename_deletions(events: list[WinAPINativeEvent]) -> list[WinAPINativeEvent]:
+    """Drop the spurious deletion reported ahead of a case-only rename.
+
+    Renaming ``file`` to ``FILE`` makes ReadDirectoryChangesW report a
+    ``FILE_ACTION_REMOVED`` for the old name on top of the usual
+    ``FILE_ACTION_RENAMED_OLD_NAME``/``FILE_ACTION_RENAMED_NEW_NAME`` pair, so such a
+    rename would surface as a deletion followed by a move. A rename that also changes
+    the name reports the pair alone, hence the deletion is dropped only when the very
+    next record renames that same path: nothing can rename a genuinely deleted path.
+    """
+    return [
+        event
+        for index, event in enumerate(events)
+        if not (
+            event.is_removed
+            and index + 1 < len(events)
+            and events[index + 1].is_renamed_old
+            and events[index + 1].src_path == event.src_path
+        )
+    ]
+
+
 class DirectoryChangeReader:
     """Uses ReadDirectoryChangesW() to detect file system changes.  A separate
     thread is used to make that call in order to reduce the time window
@@ -465,4 +487,4 @@ class DirectoryChangeReader:
             except queue.Empty:
                 break
             events.extend(_parse_event_buffer(buf))
-        return [WinAPINativeEvent(action, src_path) for action, src_path in events]
+        return _drop_case_only_rename_deletions([WinAPINativeEvent(action, src_path) for action, src_path in events])

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -182,9 +182,15 @@ def test_case_change(
 ) -> None:
     mkdir(p("dir1"))
     mkdir(p("dir2"))
+    mkdir(p("dir1", "sub"))
+    mkdir(p("subdir"))
     mkfile(p("dir1", "file"))
+    mkfile(p("other"))
     start_watching()
 
+    # Across directories. Windows reports this as a deletion and a creation
+    # carrying no rename records at all, whether or not the case differs, so
+    # there is nothing to coalesce here.
     mv(p("dir1", "file"), p("dir2", "FILE"))
 
     with events_checker() as ec:
@@ -197,31 +203,36 @@ def test_case_change(
             ec.add(FileCreatedEvent, "dir2/FILE")
             ec.add(DirModifiedEvent, "dir2")
 
-
-@pytest.mark.skipif(
-    not platform.is_windows(),
-    reason="Only Windows reports a deletion on top of a case-only rename",
-)
-def test_case_only_rename_on_windows(
-    p: P,
-    event_queue: TestEventQueue,
-    start_watching: StartWatching,
-    events_checker: EventsChecker,
-) -> None:
-    """Changing only the case of a name yields the move alone, without a deletion."""
-    mkfile(p("file"))
-    mkdir(p("dir"))
-    start_watching()
-
-    mv(p("file"), p("FILE"))
+    # In place, a file. Windows prepends a deletion of the old name here, which
+    # is the case being coalesced away.
+    mv(p("other"), p("OTHER"))
 
     with events_checker() as ec:
-        ec.add(FileMovedEvent, "file", dest_path="FILE")
+        ec.add(FileMovedEvent, "other", dest_path="OTHER")
+        if platform.is_linux():
+            ec.add(DirModifiedEvent, ".")
+            ec.add(DirModifiedEvent, ".")
 
-    mv(p("dir"), p("DIR"))
+    # In place, a directory.
+    mv(p("subdir"), p("SUBDIR"))
 
     with events_checker() as ec:
-        ec.add(DirMovedEvent, "dir", dest_path="DIR")
+        ec.add(DirMovedEvent, "subdir", dest_path="SUBDIR")
+        if platform.is_linux():
+            ec.add(DirModifiedEvent, ".")
+            ec.add(DirModifiedEvent, ".")
+
+    # In place, a subfolder one level down.
+    mv(p("dir1", "sub"), p("dir1", "SUB"))
+
+    with events_checker() as ec:
+        if platform.is_windows():
+            ec.add(DirModifiedEvent, "dir1")
+        ec.add(DirMovedEvent, "dir1/sub", dest_path="dir1/SUB")
+        if platform.is_windows() or platform.is_linux():
+            ec.add(DirModifiedEvent, "dir1")
+        if platform.is_linux():
+            ec.add(DirModifiedEvent, "dir1")
 
 
 def test_move_to(

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -198,6 +198,32 @@ def test_case_change(
             ec.add(DirModifiedEvent, "dir2")
 
 
+@pytest.mark.skipif(
+    not platform.is_windows(),
+    reason="Only Windows reports a deletion on top of a case-only rename",
+)
+def test_case_only_rename_on_windows(
+    p: P,
+    event_queue: TestEventQueue,
+    start_watching: StartWatching,
+    events_checker: EventsChecker,
+) -> None:
+    """Changing only the case of a name yields the move alone, without a deletion."""
+    mkfile(p("file"))
+    mkdir(p("dir"))
+    start_watching()
+
+    mv(p("file"), p("FILE"))
+
+    with events_checker() as ec:
+        ec.add(FileMovedEvent, "file", dest_path="FILE")
+
+    mv(p("dir"), p("DIR"))
+
+    with events_checker() as ec:
+        ec.add(DirMovedEvent, "dir", dest_path="DIR")
+
+
 def test_move_to(
     p: P, event_queue: TestEventQueue, start_watching: StartWatching, events_checker: EventsChecker
 ) -> None:

--- a/tests/test_observers_winapi.py
+++ b/tests/test_observers_winapi.py
@@ -18,6 +18,14 @@ if not platform.is_windows():
     pytest.skip("Windows only.", allow_module_level=True)
 
 from watchdog.observers.read_directory_changes import WindowsApiEmitter
+from watchdog.observers.winapi import (
+    FILE_ACTION_CREATED,
+    FILE_ACTION_DELETED,
+    FILE_ACTION_RENAMED_NEW_NAME,
+    FILE_ACTION_RENAMED_OLD_NAME,
+    WinAPINativeEvent,
+    _drop_case_only_rename_deletions,
+)
 
 SLEEP_TIME = 2
 
@@ -127,3 +135,39 @@ def test_root_deleted(event_queue, emitter):
 
     # The emitter is automatically stopped, with no error
     assert not emitter.should_keep_running()
+
+
+def test_drop_case_only_rename_deletions():
+    """A case-only rename is reported with an extra deletion of the old name."""
+    events = [
+        WinAPINativeEvent(FILE_ACTION_DELETED, "file"),
+        WinAPINativeEvent(FILE_ACTION_RENAMED_OLD_NAME, "file"),
+        WinAPINativeEvent(FILE_ACTION_RENAMED_NEW_NAME, "FILE"),
+    ]
+
+    assert _drop_case_only_rename_deletions(events) == events[1:]
+
+
+@pytest.mark.parametrize(
+    "events",
+    [
+        # A deletion is only spurious when the very next record renames that same
+        # path, so a path deleted, recreated and only then renamed is left alone.
+        [
+            WinAPINativeEvent(FILE_ACTION_DELETED, "file"),
+            WinAPINativeEvent(FILE_ACTION_CREATED, "file"),
+            WinAPINativeEvent(FILE_ACTION_RENAMED_OLD_NAME, "file"),
+            WinAPINativeEvent(FILE_ACTION_RENAMED_NEW_NAME, "other"),
+        ],
+        # A deletion followed by the rename of a different path.
+        [
+            WinAPINativeEvent(FILE_ACTION_DELETED, "file"),
+            WinAPINativeEvent(FILE_ACTION_RENAMED_OLD_NAME, "other"),
+            WinAPINativeEvent(FILE_ACTION_RENAMED_NEW_NAME, "OTHER"),
+        ],
+        # A deletion closing the batch, which is how a plain deletion is reported.
+        [WinAPINativeEvent(FILE_ACTION_DELETED, "file")],
+    ],
+)
+def test_drop_case_only_rename_deletions_keeps_real_deletions(events):
+    assert _drop_case_only_rename_deletions(events) == events


### PR DESCRIPTION
Closes https://github.com/gorakhargosh/watchdog/issues/752

> Replaces #1203, which I closed by accident renaming the source branch. Same commit (`95d4405`), same diff — no content change.

## Symptom

Renaming a file to a different case — `file` to `FILE` — emits two events on Windows instead of one:

```
FileDeletedEvent(src_path='...\file')
FileMovedEvent(src_path='...\file', dest_path='...\FILE')
```

A directory renamed the same way emits `FileDeletedEvent` followed by `DirMovedEvent`. Since the deletion is indistinguishable from a real one, consumers see a file vanish and then move.

## Cause

The move event was never the problem — watchdog already builds it correctly from the rename pair. The extra deletion comes straight from the OS. Dumping the raw `ReadDirectoryChangesW` records on Windows 11 (3 runs each, identical every time):

| operation | records reported |
|---|---|
| `file` → `FILE` | `REMOVED(file)`, `RENAMED_OLD_NAME(file)`, `RENAMED_NEW_NAME(FILE)` |
| `a` → `b` | `RENAMED_OLD_NAME(a)`, `RENAMED_NEW_NAME(b)` |
| `sub` → `SUB` (dir) | `REMOVED(sub)`, `RENAMED_OLD_NAME(sub)`, `RENAMED_NEW_NAME(SUB)` |

Windows prepends a `FILE_ACTION_REMOVED` for the old name only when the rename changes nothing but case. `queue_events()` translates each record independently, so that record became a deletion event.

## Fix

`DirectoryChangeReader.get_events()` drops a deletion when the **very next record renames that same path**. Two properties make that condition safe rather than heuristic:

- A rename that also changes the name reports the pair alone, so ordinary renames are untouched.
- Nothing can rename a path that was genuinely deleted. For the records to be adjacent and share a path, the "deletion" cannot have been real — if a path is deleted, recreated and only then renamed, a `CREATED` record sits between them and the deletion is kept.

A deletion that ends the batch is also kept, so a rename split across two `ReadDirectoryChangesW` buffers degrades to today's behaviour rather than losing an event.

## Deliberately unchanged

**Cross-directory moves.** `tests/test_emitter.py::test_case_change` — the test linked from the issue — moves `dir1/file` to `dir2/FILE`, and Windows reports that as `REMOVED` + `CREATED` + `MODIFIED` with **no rename records at all**. It reports `dir1/a` → `dir2/b` identically, so this is not case-related: the information needed to emit a move is simply absent, and recovering it would mean correlating unrelated deletions with later creations. That test is left exactly as it is, and this PR does not change cross-directory behaviour.

## Testing

Run on Windows 11, Python 3.13.13.

- `tests/test_emitter.py::test_case_only_rename_on_windows` — new. Renames a file and a directory by case only and asserts exactly one move event each. **Fails before the fix** with `AssertionError: wrong number of events`, having found `FileDeletedEvent` + `FileMovedEvent`; passes after.
- `tests/test_observers_winapi.py` — new unit tests pinning the condition, including the three negative cases that must keep their deletion: deleted-recreated-then-renamed, a deletion followed by a rename of a *different* path, and a deletion ending the batch.
- Full suite: **158 passed / 2 failed** on a clean `master` checkout, **163 passed / 2 failed** with this branch. The same two — `test_renaming_top_level_directory` and `test_move_nested_subdirectories_on_windows` — fail identically before and after (verified by stashing the change and re-running); they are pre-existing on Windows and untouched here.
- `ruff format --check`, `ruff check`, and `sphinx-build` are clean.
- `mypy src docs/source/examples` reports 11 errors both before and after — the same set, unused `type: ignore` comments plus POSIX-only attributes flagged when run on Windows. No new errors introduced.

I could not run the Linux or macOS jobs locally, so I left the new emitter test Windows-gated rather than assert behaviour I had not observed — the bug is a Windows-API artefact and the fix is confined to `winapi.py`. CI is the authority for the other two platforms.
