### PR TITLE
docs: document that BaseThread always runs as a daemon thread

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -28,6 +28,7 @@ Changelog
 - [core] Fixed ``generate_sub_moved_events()`` corrupting paths when the directory name appears multiple times in the path. (`#1158 <https://github.com/gorakhargosh/watchdog/pull/1158>`__)
 - Thanks to our beloved contributors: @BoboTiG, @tybug, @Corentin-pro, @kirkhansen, @JoachimCoenen, @blitztide
 - [core] Call ``task_done()`` for the stop sentinel in ``dispatch_events()`` to prevent ``join()`` from hanging. (`#1159 <https://github.com/gorakhargosh/watchdog/pull/1159>`__)
+- [docs] Document that ``BaseThread`` always runs as a daemon thread, instead of inheriting ``daemon`` from the creating thread as the inherited ``threading.Thread`` documentation states. (`#1117 <https://github.com/gorakhargosh/watchdog/issues/1117>`__)
 
 6.0.0
 ~~~~~

--- a/src/watchdog/utils/__init__.py
+++ b/src/watchdog/utils/__init__.py
@@ -33,7 +33,14 @@ class WatchdogShutdownError(Exception):
 
 
 class BaseThread(threading.Thread):
-    """Convenience class for creating stoppable threads."""
+    """Convenience class for creating stoppable threads.
+
+    Instances always run as daemon threads: :meth:`__init__` sets
+    :attr:`~threading.Thread.daemon` to ``True`` unconditionally. The value is
+    therefore *not* inherited from the creating thread, unlike a plain
+    :class:`threading.Thread`, and setting it before :meth:`~threading.Thread.start`
+    is the caller's only opportunity to override it.
+    """
 
     def __init__(self) -> None:
         threading.Thread.__init__(self)


### PR DESCRIPTION
Closes #1117.

## Summary

The published API docs for `watchdog.utils.BaseThread` state that `daemon` "is inherited from the creating thread", but `BaseThread.__init__` sets `daemon = True` unconditionally. The reporter was reading real documentation — it just isn't `watchdog`'s.

`docs/source/api/utils.rst` renders the class with `:inherited-members:`, so Sphinx pulls in CPython's `threading.Thread.daemon` docstring verbatim. That text is correct for `threading.Thread` and wrong for every `BaseThread` subclass, which is `EventEmitter` and `EventDispatcher`. The inherited docstring belongs to CPython and cannot be edited here, so the class docstring now states the actual contract.

This is a documentation change only. `BaseThread`'s behaviour is unchanged — the daemon flag is load-bearing for interpreter shutdown, and altering it was not in scope.

## Changes

- `src/watchdog/utils/__init__.py` — expand the `BaseThread` docstring to record that instances always run as daemon threads, that the value is *not* inherited from the creating thread, and that setting it before `start()` is the caller's only override point.
- `changelog.rst` — one `[docs]` entry under **Other Changes**.

## Testing

Behaviour confirmed before writing the text, on Windows 11 / Python 3.13.13:

```
main thread daemon: False
BaseThread() created from MAIN -> daemon: True
creator thread daemon: False -> BaseThread daemon: True
plain Thread created from a DAEMON creator inherits daemon: True
```

The last line is the control: a plain `threading.Thread` *does* inherit `daemon` from its creator, which is why the inherited docstring is accurate for `Thread` and misleading only for `BaseThread`.

Docs build, the same command CI runs (`-W`, warnings as errors):

```
$ python -m sphinx -aEWb html docs/source docs/build/html
build succeeded.
```

Rendered output contains the new sentence at `docs/build/html/api/utils.html`.

Test suite, `python -m pytest tests/`:

```
2 failed, 108 passed, 14 skipped in 108.05s
FAILED tests/test_emitter.py::test_renaming_top_level_directory
FAILED tests/test_emitter.py::test_move_nested_subdirectories_on_windows
```

**Both failures are pre-existing and unrelated to this change** — they reproduce identically on unmodified `master` (`2a0d0ce`) and on `a0bb46c` before it. The first is #1128. The second appears unreported; I am filing it separately rather than bundling it here.

`ruff format --check` reports the file already formatted. `ruff check` reports one `CPY001 Missing copyright notice` on this file, which is also pre-existing on unmodified `master` and not introduced here.

I could not run `tox -e types,lint` or `tox -e docs` as CI invokes them; I ran `sphinx-build` and `ruff` directly with the pinned versions from `requirements-tests.txt`. CI remains the authority.
