### PR TITLE
docs: add file organizer example (fixes #1190)

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -29,3 +29,11 @@ Text editors and build tools can emit several events for a single logical change
 .. literalinclude:: examples/debounced.py
    :language: python
    :linenos:
+
+Organizing Files by Type
+------------------------
+A common task is to keep a busy directory (such as a ``Downloads`` folder) tidy by automatically moving newly created files into category subfolders based on their file extension:
+
+.. literalinclude:: examples/file_organizer.py
+   :language: python
+   :linenos:

--- a/docs/source/examples/file_organizer.py
+++ b/docs/source/examples/file_organizer.py
@@ -1,0 +1,74 @@
+"""Organize files in a watched directory into category subfolders.
+
+When a new file appears in the watched directory it is immediately moved
+into a subfolder based on its file extension (for example ``.png`` files
+are moved into ``images/`` and ``.mp4`` files into ``videos/``).
+
+Usage::
+
+    python file_organizer.py [path]
+
+The directory to watch defaults to the current directory.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import sys
+import time
+from pathlib import Path
+
+from watchdog.events import FileSystemEvent, FileSystemEventHandler
+from watchdog.observers import Observer
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s", datefmt="%H:%M:%S")
+
+#: Map a file extension to the subfolder it should be moved into.
+CATEGORIES = {
+    ".gif": "images",
+    ".jpeg": "images",
+    ".jpg": "images",
+    ".png": "images",
+    ".mkv": "videos",
+    ".mov": "videos",
+    ".mp4": "videos",
+    ".docx": "documents",
+    ".pdf": "documents",
+    ".txt": "documents",
+}
+
+
+class FileOrganizerHandler(FileSystemEventHandler):
+    def __init__(self, base_dir: Path) -> None:
+        self.base_dir = base_dir
+
+    def on_created(self, event: FileSystemEvent) -> None:
+        if event.is_directory:
+            return
+        source = Path(event.src_path)
+        category = CATEGORIES.get(source.suffix.lower(), "misc")
+        target_dir = self.base_dir / category
+        target_dir.mkdir(exist_ok=True)
+        target = target_dir / source.name
+        counter = 1
+        while target.exists():
+            target = target_dir / f"{source.stem}_{counter}{source.suffix}"
+            counter += 1
+        shutil.move(str(source), str(target))
+        logging.info("Moved %s -> %s", source.name, target)
+
+
+path = sys.argv[1] if len(sys.argv) > 1 else "."
+base_dir = Path(path).resolve()
+
+event_handler = FileOrganizerHandler(base_dir)
+observer = Observer()
+observer.schedule(event_handler, str(base_dir), recursive=False)
+observer.start()
+try:
+    while True:
+        time.sleep(1)
+finally:
+    observer.stop()
+    observer.join()


### PR DESCRIPTION
Adds a real-world example to the [Examples page](https://github.com/gorakhargosh/watchdog/issues/1190): a small script that automatically organizes newly created files into category subfolders by extension (e.g. `Downloads/` cleanup), demonstrating `FileSystemEventHandler.on_created`, case-insensitive extension matching, and collision-safe moves.

- `docs/source/examples/file_organizer.py` — the self-contained script (auto-picked-up by `tests/test_examples.py` via the existing `glob`).
- `docs/source/examples.rst` — new "Organizing Files by Type" section with `literalinclude`.

## Verification

- `pytest tests/test_examples.py` → 5 passed (includes `file_organizer.py`).
- `ruff check` and `ruff format --check` clean (ruff 0.7.1, as pinned).
- `mypy` clean.
- End-to-end smoke test: launching the script on a temp dir, creating `photo.PNG` moved it to `images/photo.PNG` with content intact.
