### PR TITLE
test: fix flaky test_move_nested_subdirectories_on_windows on native Windows

### DIFF
--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -563,13 +563,12 @@ def test_move_nested_subdirectories_on_windows(
         ec.add(DirCreatedEvent, "dir2")
         ec.add(DirCreatedEvent, "dir2/dir3")
         ec.add(FileCreatedEvent, "dir2/dir3/a")
-        ec.add(DirModifiedEvent, "dir2")
-        if False:
-            # The following event is not consistently generated.
-            ec.add(DirModifiedEvent, "dir2/dir3")
-        else:
-            # Allow test to pass if above event is present or not
-            ec.allow_extra_events()
+        # The path of the trailing DirModifiedEvent is not consistent across
+        # environments: CI emits `dir2`, while some native Windows installs
+        # emit `dir2/dir3`. Match any DirModifiedEvent under the moved tree
+        # and tolerate it being absent (see #1206).
+        ec.add(DirModifiedEvent)
+        ec.allow_extra_events()
 
     touch(p("dir2/dir3", "a"))
 


### PR DESCRIPTION
Closes #1206.

## Problem

`test_move_nested_subdirectories_on_windows` fails deterministically on some native Windows installs (reproduced on Windows 11 here), while passing on CI. After a nested directory move, the trailing `DirModifiedEvent` is emitted for `dir2/dir3` instead of `dir2`. The test pinned position 5 to `dir2`; `allow_extra_events()` only relaxes the length check in `_check_events_with_order`, so when the inconsistent event arrives *instead of* the expected one, the positional `zip` misaligns and the test fails.

## Change

- Assert the four deterministic events (`FileDeleted dir1/dir2`, `DirCreated dir2`, `DirCreated dir2/dir3`, `FileCreated dir2/dir3/a`) in order.
- Match the trailing `DirModifiedEvent` without a pinned path, since its path is environment-dependent (`dir2` on CI, `dir2/dir3` on some native Windows installs — both under the moved tree).
- Keep tolerating its absence (consistent with the test's prior intent).
- Drop the dead `if False:` / `else:` block.

## Verification

- `pytest tests/test_emitter.py::test_move_nested_subdirectories_on_windows` — failed before the change, passes after (3 consecutive runs on native Windows 11).
- `ruff check tests/test_emitter.py` — clean.

Note: `test_renaming_top_level_directory` also fails on this machine but is a separate, known Windows flake already addressed by #1179.