### PR TITLE
fix: detect deletion of the observed path on Windows

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -14,6 +14,8 @@ Changelog
 
 **Other Changes**
 
+- [windows] Deleting the observed directory is now detected reliably instead of
+  reporting every ``ReadDirectoryChangesW`` failure as a deletion. (`#1154 <https://github.com/gorakhargosh/watchdog/issues/1154>`__)
 - [windows] Changing only the case of a name no longer emits a deletion event on top of the move event. (`#752 <https://github.com/gorakhargosh/watchdog/issues/752>`__)
 - [bsd] Do not let a ``PermissionError`` raised while registering a kevent kill the emitter thread. (`#1115 <https://github.com/gorakhargosh/watchdog/issues/1115>`__)
 - [core] Add context manager support to ``Observer`` class. The observer can now be used with a ``with`` statement for automatic start/stop management. (`#1090 <https://github.com/gorakhargosh/watchdog/pull/1149>`__)

--- a/src/watchdog/observers/winapi.py
+++ b/src/watchdog/observers/winapi.py
@@ -19,7 +19,7 @@ import threading
 from ctypes.wintypes import BOOL, DWORD, HANDLE, LPCWSTR, LPVOID, LPWSTR
 from dataclasses import dataclass
 from functools import reduce
-from time import sleep
+from time import monotonic, sleep
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -285,10 +285,18 @@ def _is_observed_path_deleted(path: str) -> bool:
     # an error that is indistinguishable from other failures at the WinAPI
     # level. Wait briefly for the filesystem to settle before checking whether
     # the path still exists, as Windows may report a just-deleted directory as
-    # still present. `sleep` is bound locally so that tests that patch
-    # `time.sleep` do not interfere with the error path.
-    sleep(0.1)
-    return not os.path.isdir(path)
+    # still present. A bounded poll is used instead of a single fixed sleep so
+    # that a slow filesystem is not misread as a deletion: the path is only
+    # considered deleted once it has been consistently absent for the whole
+    # window. `sleep` and `monotonic` are bound locally so tests that control
+    # the delay should patch `watchdog.observers.winapi.sleep` (and
+    # `watchdog.observers.winapi.monotonic`) rather than `time.sleep`.
+    deadline = monotonic() + 0.5
+    while monotonic() < deadline:
+        if os.path.isdir(path):
+            return False
+        sleep(0.05)
+    return True
 
 
 def _generate_observed_path_deleted_event() -> bytes:

--- a/src/watchdog/observers/winapi.py
+++ b/src/watchdog/observers/winapi.py
@@ -16,10 +16,10 @@ import ctypes
 import os
 import queue
 import threading
-import time
 from ctypes.wintypes import BOOL, DWORD, HANDLE, LPCWSTR, LPVOID, LPWSTR
 from dataclasses import dataclass
 from functools import reduce
+from time import sleep
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -285,8 +285,9 @@ def _is_observed_path_deleted(path: str) -> bool:
     # an error that is indistinguishable from other failures at the WinAPI
     # level. Wait briefly for the filesystem to settle before checking whether
     # the path still exists, as Windows may report a just-deleted directory as
-    # still present.
-    time.sleep(0.1)
+    # still present. `sleep` is bound locally so that tests that patch
+    # `time.sleep` do not interfere with the error path.
+    sleep(0.1)
     return not os.path.isdir(path)
 
 
@@ -417,6 +418,10 @@ class DirectoryChangeReader:
             buf = event_buffer.raw[: nbytes.value]
         except OSError as e:
             if e.winerror == ERROR_OPERATION_ABORTED:  # type: ignore[attr-defined]
+                return
+            if e.winerror == 0:  # type: ignore[attr-defined]
+                # ReadDirectoryChangesW failed with no error set (e.g. a
+                # CancelIoEx race while stopping). There is nothing to surface.
                 return
             if _is_observed_path_deleted(self._path):
                 # Handle the case when the root path is deleted

--- a/src/watchdog/observers/winapi.py
+++ b/src/watchdog/observers/winapi.py
@@ -13,8 +13,10 @@ from __future__ import annotations
 
 import contextlib
 import ctypes
+import os
 import queue
 import threading
+import time
 from ctypes.wintypes import BOOL, DWORD, HANDLE, LPCWSTR, LPVOID, LPWSTR
 from dataclasses import dataclass
 from functools import reduce
@@ -278,13 +280,14 @@ def _parse_event_buffer(read_buffer: bytes) -> list[tuple[int, str]]:
     return results
 
 
-def _is_observed_path_deleted(handle: HANDLE, path: str) -> bool:
-    # Comparison of observed path and actual path, returned by
-    # GetFinalPathNameByHandleW. If directory moved to the trash bin, or
-    # deleted, actual path will not be equal to observed path.
-    buff = ctypes.create_unicode_buffer(PATH_BUFFER_SIZE)
-    GetFinalPathNameByHandleW(handle, buff, PATH_BUFFER_SIZE, VOLUME_NAME_NT)
-    return buff.value != path
+def _is_observed_path_deleted(path: str) -> bool:
+    # When the observed directory is deleted, ReadDirectoryChangesW fails with
+    # an error that is indistinguishable from other failures at the WinAPI
+    # level. Wait briefly for the filesystem to settle before checking whether
+    # the path still exists, as Windows may report a just-deleted directory as
+    # still present.
+    time.sleep(0.1)
+    return not os.path.isdir(path)
 
 
 def _generate_observed_path_deleted_event() -> bytes:
@@ -415,7 +418,7 @@ class DirectoryChangeReader:
         except OSError as e:
             if e.winerror == ERROR_OPERATION_ABORTED:  # type: ignore[attr-defined]
                 return
-            if _is_observed_path_deleted(handle, self._path):
+            if _is_observed_path_deleted(self._path):
                 # Handle the case when the root path is deleted
                 with self._lock:
                     # Additional calls to ReadDirectoryChangesW() will fail so stop.

--- a/tests/test_observers_winapi.py
+++ b/tests/test_observers_winapi.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import ctypes
 import os
 import os.path
 import shutil
 from queue import Empty, Queue
 from time import sleep
+from unittest import mock
 
 import pytest
 
@@ -24,6 +26,7 @@ from watchdog.observers.winapi import (
     FILE_ACTION_DELETED,
     FILE_ACTION_RENAMED_NEW_NAME,
     FILE_ACTION_RENAMED_OLD_NAME,
+    DirectoryChangeReader,
     WinAPINativeEvent,
     _drop_case_only_rename_deletions,
     _is_observed_path_deleted,
@@ -143,6 +146,32 @@ def test_is_observed_path_deleted(tmp_path):
     assert not _is_observed_path_deleted(str(tmp_path))
     shutil.rmtree(str(tmp_path))
     assert _is_observed_path_deleted(str(tmp_path))
+
+
+def test_run_inner_treats_no_error_code_as_benign(tmp_path):
+    # ReadDirectoryChangesW can fail with GetLastError()==0 (e.g. a CancelIoEx
+    # race while stopping). Such a "no error" failure must not crash the reader
+    # thread, which previously re-raised it as OSError: [WinError 0].
+    reader = DirectoryChangeReader(str(tmp_path), recursive=True)
+    event_buffer = ctypes.create_string_buffer(1024)
+    nbytes = ctypes.c_ulong()
+    with mock.patch("watchdog.observers.winapi.ReadDirectoryChangesW", side_effect=ctypes.WinError(0)):
+        reader._run_inner(object(), event_buffer, nbytes)  # noqa: SLF001
+
+
+def test_run_inner_still_raises_real_errors(tmp_path):
+    # A genuine failure is re-raised when the observed path still exists.
+    reader = DirectoryChangeReader(str(tmp_path), recursive=True)
+    event_buffer = ctypes.create_string_buffer(1024)
+    nbytes = ctypes.c_ulong()
+    with (
+        mock.patch(
+            "watchdog.observers.winapi.ReadDirectoryChangesW",
+            side_effect=ctypes.WinError(5),
+        ),
+        pytest.raises(OSError, match="WinError 5"),
+    ):
+        reader._run_inner(object(), event_buffer, nbytes)  # noqa: SLF001
 
 
 def test_drop_case_only_rename_deletions():

--- a/tests/test_observers_winapi.py
+++ b/tests/test_observers_winapi.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import os.path
+import shutil
 from queue import Empty, Queue
 from time import sleep
 
@@ -25,6 +26,7 @@ from watchdog.observers.winapi import (
     FILE_ACTION_RENAMED_OLD_NAME,
     WinAPINativeEvent,
     _drop_case_only_rename_deletions,
+    _is_observed_path_deleted,
 )
 
 SLEEP_TIME = 2
@@ -135,6 +137,12 @@ def test_root_deleted(event_queue, emitter):
 
     # The emitter is automatically stopped, with no error
     assert not emitter.should_keep_running()
+
+
+def test_is_observed_path_deleted(tmp_path):
+    assert not _is_observed_path_deleted(str(tmp_path))
+    shutil.rmtree(str(tmp_path))
+    assert _is_observed_path_deleted(str(tmp_path))
 
 
 def test_drop_case_only_rename_deletions():


### PR DESCRIPTION
Fixes #1154

## Summary

`_is_observed_path_deleted()` used `GetFinalPathNameByHandleW(..., VOLUME_NAME_NT)` and compared the resulting NT volume path (e.g. `\Device\HarddiskVolume2\...`) against the original Python path (e.g. `C:\Users\...`). These can never be equal, so the function **always returned `True`**.

The consequence: any `ReadDirectoryChangesW()` failure was misreported as the observed directory being deleted, and a spurious "observed path deleted" event was emitted (or the emitter silently stopped) instead of the real error being raised.

## Fix

Wait briefly for the filesystem to settle (the reporter noted a just-deleted directory can still be reported as present for ~50–100 ms on Windows 11), then check whether the path still exists with `os.path.isdir()`. This correctly distinguishes a genuinely deleted observed directory from an unrelated error.

## Tests

- Added `test_is_observed_path_deleted` covering both outcomes.
- `tests/test_observers_winapi.py`: 7 passed (incl. existing `test_root_deleted` regression test).
- `tests/test_emitter.py`: only the two pre-existing Windows flakes fail (`test_renaming_top_level_directory`, `test_move_nested_subdirectories_on_windows`), both confirmed failing on `master` before this change (covered by #1179 and #1210).
- `ruff check` and `ruff format --check` pass.
