### PR TITLE
fix: adapt watchmedo bare patterns after full_match change

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -14,6 +14,7 @@ Changelog
 
 **Other Changes**
 
+- [watchmedo] Bare CLI patterns such as ``*`` and ``*.py`` are prefixed with ``**/`` so they still match event paths after the ``full_match()`` change. (`#1212 <https://github.com/gorakhargosh/watchdog/issues/1212>`__)
 - [windows] Changing only the case of a name no longer emits a deletion event on top of the move event. (`#752 <https://github.com/gorakhargosh/watchdog/issues/752>`__)
 - [bsd] Do not let a ``PermissionError`` raised while registering a kevent kill the emitter thread. (`#1115 <https://github.com/gorakhargosh/watchdog/issues/1115>`__)
 - [core] Add context manager support to ``Observer`` class. The observer can now be used with a ``with`` statement for automatic start/stop management. (`#1090 <https://github.com/gorakhargosh/watchdog/pull/1149>`__)

--- a/src/watchdog/watchmedo.py
+++ b/src/watchdog/watchmedo.py
@@ -157,14 +157,30 @@ def load_config(tricks_file_pathname: str) -> dict:
         return yaml.safe_load(f.read())
 
 
+def _adapt_cli_pattern(pattern: str) -> str:
+    """Translate a bare watchmedo glob so it matches under full_match() semantics.
+
+    After #1101, matching uses ``path.full_match()`` (whole path) instead of
+    ``path.match()`` (right-anchored). A pattern such as ``*.py`` therefore
+    matches only a single path segment, while event paths are multi-segment.
+    Prepend ``**/`` to bare relative patterns so the documented CLI style
+    (``*``, ``*.py;*.txt``) keeps working.
+    """
+    if not pattern or pattern.startswith("**"):
+        return pattern
+    if "/" in pattern or "\\" in pattern:
+        return pattern
+    return f"**/{pattern}"
+
+
 def parse_patterns(
     patterns_spec: str, ignore_patterns_spec: str, *, separator: str = ";"
 ) -> tuple[list[str], list[str]]:
     """Parses pattern argument specs and returns a two-tuple of
     (patterns, ignore_patterns).
     """
-    patterns = patterns_spec.split(separator)
-    ignore_patterns = ignore_patterns_spec.split(separator)
+    patterns = [_adapt_cli_pattern(p) for p in patterns_spec.split(separator)]
+    ignore_patterns = [_adapt_cli_pattern(p) for p in ignore_patterns_spec.split(separator)]
     if ignore_patterns == [""]:
         ignore_patterns = []
     return patterns, ignore_patterns

--- a/tests/test_0_watchmedo.py
+++ b/tests/test_0_watchmedo.py
@@ -20,6 +20,7 @@ from watchdog import watchmedo  # noqa: E402
 from watchdog.events import FileModifiedEvent, FileOpenedEvent  # noqa: E402
 from watchdog.tricks import AutoRestartTrick, LoggerTrick, ShellCommandTrick  # noqa: E402
 from watchdog.utils import WatchdogShutdownError, platform  # noqa: E402
+from watchdog.utils.patterns import match_any_paths  # noqa: E402
 
 
 def test_load_config_valid(tmpdir):
@@ -339,3 +340,45 @@ tricks:
     with patch("time.sleep", mocked_sleep):
         watchmedo.tricks_from(args)
     assert checkpoint
+
+
+@pytest.mark.parametrize(
+    ("patterns_spec", "ignore_spec", "expected_patterns", "expected_ignore"),
+    [
+        ("*", "", ["**/*"], []),
+        ("*.py", "", ["**/*.py"], []),
+        ("*.py;*.txt", "", ["**/*.py", "**/*.txt"], []),
+        ("**/*.py", "", ["**/*.py"], []),
+        ("**", "", ["**"], []),
+        ("src/*.py", "", ["src/*.py"], []),
+        ("*.py", "*.pyc", ["**/*.py"], ["**/*.pyc"]),
+        ("**/*.py;**/*.txt", "**/*.pyc", ["**/*.py", "**/*.txt"], ["**/*.pyc"]),
+    ],
+)
+def test_parse_patterns_adapts_bare_globs(patterns_spec, ignore_spec, expected_patterns, expected_ignore):
+    patterns, ignore_patterns = watchmedo.parse_patterns(patterns_spec, ignore_spec)
+    assert patterns == expected_patterns
+    assert ignore_patterns == expected_ignore
+
+
+@pytest.mark.parametrize(
+    ("patterns_spec", "path", "expected"),
+    [
+        ("*", "/tmp/w/a.txt", True),
+        ("*.txt", "/tmp/w/a.txt", True),
+        ("*.py;*.txt", "/tmp/w/sub/a.py", True),
+        ("*.py;*.txt", "/tmp/w/a.md", False),
+        ("**/*.py", "/tmp/w/a.py", True),
+    ],
+)
+def test_parse_patterns_matches_absolute_event_paths(patterns_spec, path, expected):
+    patterns, ignore_patterns = watchmedo.parse_patterns(patterns_spec, "")
+    assert (
+        match_any_paths(
+            [path],
+            included_patterns=patterns,
+            excluded_patterns=ignore_patterns,
+            case_sensitive=True,
+        )
+        is expected
+    )


### PR DESCRIPTION
## Summary

- After #1101, pattern matching uses `path.full_match()` (whole path) instead of `path.match()` (right-anchored).
- `watchmedo` still defaults to `--patterns "*"` and its docs still show `--patterns="*.py;*.txt"`. Those bare globs only match a single path segment, so absolute / nested event paths never match and `log` / `shell-command` / `auto-restart` stay silent.
- `parse_patterns()` now prefixes bare relative globs (no `/` or `\`, not already starting with `**`) with `**/`. Existing `**/*.py` and path-qualified patterns are left alone.

Fixes #1212.

## Test plan

- [x] `test_parse_patterns_adapts_bare_globs` covers `*`, `*.py;*.txt`, already-qualified `**/*.py`, `src/*.py`, and ignore patterns.
- [x] `test_parse_patterns_matches_absolute_event_paths` checks that the adapted default/docs-style patterns match `/tmp/w/a.txt` and `/tmp/w/sub/a.py`, and that `*.py;*.txt` still rejects `.md`.
- [x] Existing `tests/test_patterns.py` still passes (library-level `full_match` behavior unchanged).