### PR TITLE
watchmedo: fix --patterns default and docs for full_match semantics

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -29,6 +29,7 @@ Changelog
 - Thanks to our beloved contributors: @BoboTiG, @tybug, @Corentin-pro, @kirkhansen, @JoachimCoenen, @blitztide
 - [core] Call ``task_done()`` for the stop sentinel in ``dispatch_events()`` to prevent ``join()`` from hanging. (`#1159 <https://github.com/gorakhargosh/watchdog/pull/1159>`__)
 - [docs] Document that ``BaseThread`` always runs as a daemon thread, instead of inheriting ``daemon`` from the creating thread as the inherited ``threading.Thread`` documentation states. (`#1117 <https://github.com/gorakhargosh/watchdog/issues/1117>`__)
+- [watchmedo] Changed the default ``--patterns`` value from ``"*"`` to ``"**"``, so the default matches absolute paths at any depth under the ``full_match()`` semantics introduced by #1101, and updated the CLI help text and docs to the ``**/`` glob syntax. (`#1212 <https://github.com/gorakhargosh/watchdog/issues/1212>`__)
 
 6.0.0
 ~~~~~

--- a/docs/source/tricks.rst
+++ b/docs/source/tricks.rst
@@ -19,13 +19,13 @@ Without tricks, running multiple tasks requires starting several terminal proces
 .. code-block:: bash
 
     # Terminal 1
-    watchmedo log --patterns="*.py" .
+    watchmedo log --patterns="**/*.py" .
 
     # Terminal 2
-    watchmedo shell-command --patterns="*.py" --command="ruff check ." .
+    watchmedo shell-command --patterns="**/*.py" --command="ruff check ." .
 
     # Terminal 3
-    watchmedo auto-restart --patterns="*.py" --command="python app.py" .
+    watchmedo auto-restart --patterns="**/*.py" --command="python app.py" .
 
 Using tricks simplifies configuration by allowing multiple event handlers to run under a single observer:
 

--- a/docs/source/watchmedo_cli.rst
+++ b/docs/source/watchmedo_cli.rst
@@ -49,7 +49,7 @@ Logs file system events directly to the console.
 **Options:**
 
 *   ``directories``: Directories to watch (default: '.').
-*   ``--patterns="<patterns>"``:  Matches event paths with these patterns (separated by ;) (e.g., ``--patterns="*.py;*.txt"``).
+*   ``--patterns="<patterns>"``:  Matches event paths with these glob patterns (separated by ;) (e.g., ``--patterns="**/*.py;**/*.txt"``).
 *   ``--ignore-patterns="<patterns>"``: Ignores event paths with these patterns (separated by ;).
 *   ``--ignore-directories``: Ignores events for directories.
 *   ``--recursive``: Monitors the directories recursively.
@@ -61,7 +61,7 @@ Logs file system events directly to the console.
 
 .. code-block:: bash
 
-    $ watchmedo log --patterns="*.py;*.txt" --recursive .
+    $ watchmedo log --patterns="**/*.py;**/*.txt" --recursive .
 
 ---
 
@@ -79,7 +79,7 @@ Executes shell commands in response to file system events.
 
 *   ``directories``: Directories to watch (default: '.').
 *   ``-c``, ``--command="<command>"``: Shell command executed in response to matching events.
-*   ``--patterns="<patterns>"``: Matches event paths with these patterns (separated by ;).
+*   ``--patterns="<patterns>"``: Matches event paths with these glob patterns (separated by ;), e.g. ``**/*.py``.
 *   ``--ignore-patterns="<patterns>"``: Ignores event paths with these patterns (separated by ;).
 *   ``--ignore-directories``: Ignores events for directories (default: False).
 *   ``--recursive``: Monitors the directories recursively.
@@ -113,7 +113,7 @@ Within the command string, you can use the following environment variables which
 .. code-block:: bash
 
     $ watchmedo shell-command \
-        --patterns="*.py" \
+        --patterns="**/*.py" \
         --recursive \
         --command="echo 'File ${watch_src_path} was ${watch_event_type}'" \
         .
@@ -136,7 +136,7 @@ Starts a long-running subprocess (like a development server, worker, or test sui
 *   ``directories``: Directories to watch (default: '.').
 *   ``-c``, ``--command="<command>"``: The process command to run.
 *   ``-d``, ``--directory=DIRECTORY``: Directory to watch. Use another ``-d`` or ``--directory`` option for each directory.
-*   ``--patterns="<patterns>"``: Matches event paths with these patterns (separated by ;).
+*   ``--patterns="<patterns>"``: Matches event paths with these glob patterns (separated by ;), e.g. ``**/*.py``.
 *   ``--ignore-patterns="<patterns>"``: Ignores event paths with these patterns (separated by ;).
 *   ``--ignore-directories``: Ignores events for directories.
 *   ``--recursive``: Monitors the directories recursively.
@@ -152,7 +152,7 @@ Starts a long-running subprocess (like a development server, worker, or test sui
 
 .. code-block:: bash
 
-    $ watchmedo auto-restart --patterns="*.py" \
+    $ watchmedo auto-restart --patterns="**/*.py" \
         --recursive --command="python my_web_app.py" .
 
 Common Use Cases
@@ -164,7 +164,7 @@ Run your pytest test suite immediately when any Python file changes:
 
 .. code-block:: bash
 
-    $ watchmedo shell-command --patterns="*.py" \
+    $ watchmedo shell-command --patterns="**/*.py" \
         --recursive --command="pytest tests/" .
 
 
@@ -174,7 +174,7 @@ Compile Sass files to CSS automatically on edit:
 
 .. code-block:: bash
 
-    $ watchmedo shell-command --patterns="*.scss" \
+    $ watchmedo shell-command --patterns="**/*.scss" \
         --command="sass src/styles:dist/styles" .
 
 Platform Behavior & Limitations

--- a/src/watchdog/watchmedo.py
+++ b/src/watchdog/watchmedo.py
@@ -404,8 +404,8 @@ def tricks_generate_yaml(args: Namespace) -> None:
             "--pattern",
             "--patterns",
             dest="patterns",
-            default="*",
-            help="Matches event paths with these patterns (separated by ;).",
+            default="**",
+            help="Matches event paths with these glob patterns (separated by ;), e.g. **/*.py",
         ),
         argument(
             "-i",
@@ -536,8 +536,8 @@ def log(args: Namespace) -> None:
             "--pattern",
             "--patterns",
             dest="patterns",
-            default="*",
-            help="Matches event paths with these patterns (separated by ;).",
+            default="**",
+            help="Matches event paths with these glob patterns (separated by ;), e.g. **/*.py",
         ),
         argument(
             "-i",
@@ -645,8 +645,8 @@ def shell_command(args: Namespace) -> None:
             "--pattern",
             "--patterns",
             dest="patterns",
-            default="*",
-            help="Matches event paths with these patterns (separated by ;).",
+            default="**",
+            help="Matches event paths with these glob patterns (separated by ;), e.g. **/*.py",
         ),
         argument(
             "-i",

--- a/tests/test_0_watchmedo.py
+++ b/tests/test_0_watchmedo.py
@@ -55,6 +55,21 @@ def test_load_config_invalid(tmpdir):
     assert not os.path.exists(critical_dir)
 
 
+def test_watchmedo_default_patterns_match_absolute_paths(tmpdir):
+    """Regression test for #1212: the default --patterns value must match absolute
+    paths at any depth under the full_match() semantics."""
+
+    from watchdog.utils.patterns import match_any_paths
+
+    watched = os.path.join(tmpdir, "nested", "file.txt")
+    for argv in (["auto-restart", "echo", "hi"], ["shell-command"], ["log"]):
+        args = watchmedo.cli.parse_args(argv)
+        patterns, ignore_patterns = watchmedo.parse_patterns(args.patterns, args.ignore_patterns)
+        assert patterns == ["**"]
+        assert ignore_patterns == []
+        assert match_any_paths([watched], included_patterns=patterns, case_sensitive=False)
+
+
 def make_dummy_script(tmpdir, n=10):
     script = os.path.join(tmpdir, f"auto-test-{n}.py")
     with open(script, "w") as f:


### PR DESCRIPTION
Fixes #1212

### Description

Since #1101 switched the pattern matching to `pathlib.full_match()`, watchmedo's `--patterns` default of `"*"` matched nothing for absolute watch paths (and only depth-1 relative paths), so `watchmedo auto-restart` / `shell-command` / `log` were broken out of the box — the default restart/log never fired. The library default is `["**"]`, but watchmedo always passed its own `"*"` default through `parse_patterns()`.

Changes:

- Changed the `--patterns` default from `"*"` to `"**"` for the `auto-restart`, `shell-command` and `log` commands, so the default full-matches absolute paths at any depth, matching the library default `["**"]`.
- Updated the `--patterns` help text to document the `**/` glob syntax.
- Updated the CLI docs (`docs/source/watchmedo_cli.rst`, `docs/source/tricks.rst`), which still showed the old `*.py`-style patterns that match nothing under `full_match()`.
- Added a regression test asserting the default patterns match an absolute nested path for all three commands.
- Changelog entry.

I kept the library-consistent semantics rather than adding a translation layer: the changelog for #1101 documents the `full_match` change as intentional, and the README examples already use `**/*.py`, so watchmedo now follows the same `**/` glob style as the library.

### Tests

- `tests/test_0_watchmedo.py` passes locally (55 tests, including the new `test_watchmedo_default_patterns_match_absolute_paths`).
- `ruff check` and `ruff format --check` clean on the changed Python files.