### PR TITLE
windows: fix unsynchronized access to WindowsApiEmitter._reader

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -29,6 +29,7 @@ Changelog
 - Thanks to our beloved contributors: @BoboTiG, @tybug, @Corentin-pro, @kirkhansen, @JoachimCoenen, @blitztide
 - [core] Call ``task_done()`` for the stop sentinel in ``dispatch_events()`` to prevent ``join()`` from hanging. (`#1159 <https://github.com/gorakhargosh/watchdog/pull/1159>`__)
 - [docs] Document that ``BaseThread`` always runs as a daemon thread, instead of inheriting ``daemon`` from the creating thread as the inherited ``threading.Thread`` documentation states. (`#1117 <https://github.com/gorakhargosh/watchdog/issues/1117>`__)
+- [windows] Fixed an unsynchronized access to ``WindowsApiEmitter._reader``: ``queue_events()`` now reads it under the same lock used by ``on_thread_stop()``. (`#1170 <https://github.com/gorakhargosh/watchdog/issues/1170>`__)
 
 6.0.0
 ~~~~~

--- a/changelog.rst
+++ b/changelog.rst
@@ -32,6 +32,7 @@ Changelog
 - [windows] Fixed an unsynchronized access to ``WindowsApiEmitter._reader``: ``queue_events()`` now
   reads it under the same lock used by ``on_thread_stop()``. (`#1170 <https://github.com/gorakhargosh/watchdog/issues/1170>`__)
 - [core] Add ``win_arm64`` to the list of platform-specific wheels published to PyPI. (`#1137 <https://github.com/gorakhargosh/watchdog/issues/1137>`__)
+
 6.0.0
 ~~~~~
 

--- a/src/watchdog/observers/read_directory_changes.py
+++ b/src/watchdog/observers/read_directory_changes.py
@@ -65,7 +65,8 @@ class WindowsApiEmitter(EventEmitter):
             reader.stop()
 
     def queue_events(self, timeout: float) -> None:
-        reader = self._reader
+        with self._lock:
+            reader = self._reader
         if reader is None:
             return  # reader has been stopped
         last_renamed_src_path = ""

--- a/src/watchdog/observers/read_directory_changes.py
+++ b/src/watchdog/observers/read_directory_changes.py
@@ -45,8 +45,9 @@ class WindowsApiEmitter(EventEmitter):
     def on_thread_start(self) -> None:
         with self._lock:
             assert self._reader is None
-            self._reader = DirectoryChangeReader(self.watch.path, recursive=self.watch.is_recursive)
-        self._reader.start()
+            reader = DirectoryChangeReader(self.watch.path, recursive=self.watch.is_recursive)
+            self._reader = reader
+        reader.start()
 
     if platform.python_implementation() == "PyPy":
 

--- a/tests/test_observers_winapi.py
+++ b/tests/test_observers_winapi.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import os
 import os.path
+import threading
 from queue import Empty, Queue
 from time import sleep
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -16,6 +18,9 @@ from .shell import mkdir, mkdtemp, mv, rm
 # make pytest aware this is windows only
 if not platform.is_windows():
     pytest.skip("Windows only.", allow_module_level=True)
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 from watchdog.observers.read_directory_changes import WindowsApiEmitter
 from watchdog.observers.winapi import (
@@ -135,6 +140,46 @@ def test_root_deleted(event_queue, emitter):
 
     # The emitter is automatically stopped, with no error
     assert not emitter.should_keep_running()
+
+
+def test_queue_events_locks_reader_access():
+    """Regression test for #1170.
+
+    on_thread_stop() clears _reader while holding self._lock, so queue_events()
+    must read _reader under the same lock. Otherwise a concurrent stop could
+    leave queue_events() processing events from a reader that is being stopped.
+    """
+
+    emitter = WindowsApiEmitter(Queue(), ObservedWatch(temp_dir, recursive=True), timeout=0.05)
+
+    class DummyReader:
+        def get_events(self, timeout: float) -> list:
+            return []
+
+        def stop(self) -> None:
+            pass
+
+    emitter._reader = DummyReader()  # noqa: SLF001
+
+    locked = threading.Event()
+
+    class TrackingLock:
+        def __init__(self) -> None:
+            self._lock = threading.RLock()
+
+        def __enter__(self) -> Self:
+            locked.set()
+            self._lock.acquire()
+            return self
+
+        def __exit__(self, *exc_info: object) -> None:
+            self._lock.release()
+
+    emitter._lock = TrackingLock()  # noqa: SLF001
+
+    emitter.queue_events(0)
+
+    assert locked.is_set()
 
 
 def test_drop_case_only_rename_deletions():


### PR DESCRIPTION
Fixes #1170

### Description

`on_thread_stop()` reads and clears `WindowsApiEmitter._reader` while holding `self._lock`, but `queue_events()` read `self._reader` without the lock. A concurrent stop could therefore leave `queue_events()` processing events from a reader that is being stopped. Reading under the same lock makes the read ordered with the clear in `on_thread_stop()`.

Change: `queue_events()` now snapshots `self._reader` under `self._lock` (copying it to a local and using it outside the lock, so the blocking `get_events()` call is not done while holding the lock), mirroring how `on_thread_stop()` accesses `_reader`.

Note on the regression test: on CPython the race outcome is not deterministically reproducible (the reference read is atomic under the GIL), so the test asserts the synchronization mechanism directly — `queue_events()` must acquire the lock to read `_reader`. The test fails without the fix (the lock is never acquired) and passes with it.

### Tests

- New `test_queue_events_locks_reader_access` in `tests/test_observers_winapi.py` — verified to fail on the pre-fix code and pass with the fix.
- `tests/test_observers_winapi.py` full run: 7 passed.
- `ruff check` and `ruff format --check` clean.
- `mypy --platform win32` clean on the changed source files (as run by CI).