### PR TITLE
ci: switch PyPI publishing to Trusted Publishing

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -34,8 +34,9 @@ concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name != 'pull_request' && github.sha || '' }}
   cancel-in-progress: true
 
-# Publishing authenticates to PyPI with its own token, not the GITHUB_TOKEN, so
-# read-only is sufficient for every job here. Elevate per-job if that ever changes.
+# Publishing authenticates to PyPI through the "pypi" environment's OIDC
+# Trusted Publishing (id-token), not the GITHUB_TOKEN, so read-only is
+# sufficient for every job here. Elevate per-job if that ever changes.
 permissions:
   contents: read
 
@@ -124,6 +125,10 @@ jobs:
       - source-distribution
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Download all the dists
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -137,6 +142,4 @@ jobs:
         if: github.event.inputs.branch != ''
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: true


### PR DESCRIPTION
Fixes #1166

### Description

Switches the PyPI publish step from a stored `PYPI_API_TOKEN` secret to OIDC Trusted Publishing:

- The `publish` job now references the `pypi` GitHub environment and requests `id-token: write` (kept `contents: read` as today — `contents: write`/`packages: write` are not needed since this workflow does not create GitHub releases).
- Removed the `user: __token__` / `password: ${{ secrets.PYPI_API_TOKEN }}` arguments from the `pypa/gh-action-pypi-publish` step, which publishes via OIDC when no password is given.
- Updated the workflow comment explaining the auth model.

### Activation (maintainer, before merging or before the next publish)

Trusted Publishing must be registered on the PyPI side for the workflow to authenticate:

1. Create the `pypi` GitHub environment (or reuse an existing one) and reference it as the environment name here (currently `pypi`).
2. On PyPI, under `watchdog` → *Publishing*, add a Trusted Publisher with:
   - Workflow: `build-and-publish.yml`
   - Environment name: `pypi` (matching above)
3. The `PYPI_API_TOKEN` secret can then be removed.

Until the PyPI-side registration is done, do not run the publish workflow — the upload will be rejected by PyPI with `403: Invalid or non-existent authentication information`.

### Testing

YAML validated with PyYAML; the `publish` job now carries `environment: pypi` and `id-token: write`, and no `PYPI_API_TOKEN` reference remains in the workflow.