### PR TITLE
polling: use os.lstat so symlinks are not mistaken for moves

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -26,9 +26,10 @@ Changelog
 - [utils] Fixed ``repr(EmptyDirectorySnapshot)``, before that it was throwing an ``AttributeError: 'EmptyDirectorySnapshot' object has no attribute '_stat_info'``.
 - [utils] Implemented ``len(DirectorySnapshotDiff)`` to return the total number of changes.
 - [core] Fixed ``generate_sub_moved_events()`` corrupting paths when the directory name appears multiple times in the path. (`#1158 <https://github.com/gorakhargosh/watchdog/pull/1158>`__)
-- Thanks to our beloved contributors: @BoboTiG, @tybug, @Corentin-pro, @kirkhansen, @JoachimCoenen, @blitztide
+- Thanks to our beloved contributors: @BoboTiG, @tybug, @Corentin-pro, @kirkhansen, @JoachimCoenen, @blitztide, @Skeletor-Pirate
 - [core] Call ``task_done()`` for the stop sentinel in ``dispatch_events()`` to prevent ``join()`` from hanging. (`#1159 <https://github.com/gorakhargosh/watchdog/pull/1159>`__)
 - [docs] Document that ``BaseThread`` always runs as a daemon thread, instead of inheriting ``daemon`` from the creating thread as the inherited ``threading.Thread`` documentation states. (`#1117 <https://github.com/gorakhargosh/watchdog/issues/1117>`__)
+- [polling] ``PollingEmitter`` now uses ``os.lstat`` instead of ``os.stat`` by default so that a symlink pointing to an existing file is reported as created rather than as a phantom move of its target. (`#1110 <https://github.com/gorakhargosh/watchdog/issues/1110>`__)
 
 6.0.0
 ~~~~~

--- a/src/watchdog/observers/polling.py
+++ b/src/watchdog/observers/polling.py
@@ -59,7 +59,7 @@ class PollingEmitter(EventEmitter):
         *,
         timeout: float = DEFAULT_EMITTER_TIMEOUT,
         event_filter: list[type[FileSystemEvent]] | None = None,
-        stat: Callable[[str], os.stat_result] = os.stat,
+        stat: Callable[[str], os.stat_result] = os.lstat,
         listdir: Callable[[str | None], Iterator[os.DirEntry]] = os.scandir,
     ) -> None:
         super().__init__(event_queue, watch, timeout=timeout, event_filter=event_filter)

--- a/tests/test_observers_polling.py
+++ b/tests/test_observers_polling.py
@@ -130,6 +130,46 @@ def test___init__(event_queue, emitter):
     assert expected == got
 
 
+def test_symlink_to_file_reported_as_created_not_moved(event_queue):
+    """Regression test for #1110.
+
+    Creating a symlink to an existing file inside a watched directory must be
+    reported as a ``FileCreatedEvent`` and not as a phantom ``FileMovedEvent``
+    where the target file is reported as the source of the move.
+    """
+    watched = os.path.join(mkdtemp(), "watched")
+    os.makedirs(watched)
+
+    watch = ObservedWatch(watched, recursive=True)
+    em = Emitter(event_queue, watch, timeout=0.2)
+    em.start()
+    try:
+        sleep(SLEEP_TIME)
+        touch(os.path.join(watched, "source"))
+        sleep(SLEEP_TIME)
+
+        try:
+            os.symlink(os.path.join(watched, "source"), os.path.join(watched, "link"))
+        except OSError:
+            pytest.skip("Creating symlinks is not supported in this environment.")
+
+        sleep(SLEEP_TIME)
+    finally:
+        em.stop()
+        em.join(5)
+
+    got = set()
+    while True:
+        try:
+            event, _ = event_queue.get_nowait()
+            got.add(event)
+        except Empty:
+            break
+
+    assert FileCreatedEvent(os.path.join(watched, "link")) in got
+    assert FileMovedEvent(os.path.join(watched, "source"), os.path.join(watched, "link")) not in got
+
+
 def test_delete_watched_dir(event_queue, emitter):
     rm(p(""), recursive=True)
 


### PR DESCRIPTION
Fix #1110.

Creating a symlink to an existing file inside a watched directory was reported as a phantom `FileMovedEvent` from the target to the symlink, instead of a `FileCreatedEvent`.

**Root cause**: `PollingEmitter` builds its `DirectorySnapshot` with the default `stat=os.stat`, which follows symlinks. A symlink to an existing file therefore shares the target's `(st_ino, st_dev)`, and `DirectorySnapshotDiff` reads that inode's new path as the symlink → a phantom move.

**Fix**: change the `PollingEmitter` default to `os.lstat` so each symlink is identified by its own inode and correctly reported as created. As a bonus, `DirectorySnapshot.walk()` will no longer recurse into symlinked directories, which avoids potential infinite loops through symlink cycles.

**Regression test**: `test_symlink_to_file_reported_as_created_not_moved` creates a symlink to a watched file and asserts a `FileCreatedEvent` is emitted and no `FileMovedEvent` is. Verified it fails without the fix (reproduces the reported phantom move) and passes with it. On environments where symlink creation is unsupported (e.g. Windows without Developer Mode) the test is skipped.