### PR TITLE
fix(windows): deliver the auto-restart stop signal to the subprocess

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -30,6 +30,7 @@ Changelog
 - [core] Call ``task_done()`` for the stop sentinel in ``dispatch_events()`` to prevent ``join()`` from hanging. (`#1159 <https://github.com/gorakhargosh/watchdog/pull/1159>`__)
 - [docs] Document that ``BaseThread`` always runs as a daemon thread, instead of inheriting ``daemon`` from the creating thread as the inherited ``threading.Thread`` documentation states. (`#1117 <https://github.com/gorakhargosh/watchdog/issues/1117>`__)
 - [core] Add ``win_arm64`` to the list of platform-specific wheels published to PyPI. (`#1137 <https://github.com/gorakhargosh/watchdog/issues/1137>`__)
+- [watchmedo] The ``AutoRestartTrick`` stop signal is now actually delivered on Windows. The subprocess is started in its own process group and signalled with ``CTRL_BREAK_EVENT``, so it can run cleanup handlers and its descendants are no longer orphaned on every restart. (`#1221 <https://github.com/gorakhargosh/watchdog/issues/1221>`__)
 
 6.0.0
 ~~~~~

--- a/src/watchdog/tricks/__init__.py
+++ b/src/watchdog/tricks/__init__.py
@@ -259,8 +259,15 @@ class AutoRestartTrick(Trick):
         if self._is_trick_stopping:
             return
 
-        # windows doesn't have setsid
-        self.process = subprocess.Popen(self.command, preexec_fn=getattr(os, "setsid", None))
+        # Put the child in its own process group so `kill_process()` can reach
+        # the whole tree. POSIX uses `setsid()`, which Windows does not have;
+        # Windows uses the `CREATE_NEW_PROCESS_GROUP` creation flag, which is
+        # `0` (i.e. no-op) elsewhere.
+        self.process = subprocess.Popen(
+            self.command,
+            preexec_fn=getattr(os, "setsid", None),
+            creationflags=getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0),
+        )
         if self.restart_on_command_exit:
             self.process_watcher = ProcessWatcher(self.process, self._restart_process)
             self.process_watcher.start()
@@ -319,7 +326,20 @@ class AutoRestartTrick(Trick):
 if platform.is_windows():
 
     def kill_process(pid: int, stop_signal: int) -> None:
-        os.kill(pid, stop_signal)
+        if stop_signal == signal.SIGINT:
+            # `os.kill()` maps every signal but the console control events to
+            # `TerminateProcess()`, which delivers nothing: the child is hard
+            # killed, so its `atexit`/`finally` cleanup never runs and anything
+            # it spawned is orphaned. `CTRL_BREAK_EVENT` is delivered to the
+            # child's whole process group (see `_start_process()`), making it
+            # the closest equivalent of `killpg()` on POSIX.
+            try:
+                os.kill(pid, getattr(signal, "CTRL_BREAK_EVENT", 1))
+            except OSError:
+                # No console to route the event through; hard kill as before.
+                os.kill(pid, stop_signal)
+        else:
+            os.kill(pid, stop_signal)
 
 else:
 

--- a/tests/test_0_watchmedo.py
+++ b/tests/test_0_watchmedo.py
@@ -75,6 +75,36 @@ def test_kill_auto_restart(tmpdir, capfd):
     # assert 'KeyboardInterrupt' in cap.err
 
 
+def test_auto_restart_stop_signal_is_delivered(tmpdir, capfd):
+    """The documented stop_signal must actually reach the subprocess.
+
+    On Windows `os.kill()` maps everything but the console control events to
+    `TerminateProcess()`, so the child used to be hard killed and no cleanup
+    handler could ever run. See #1221.
+    """
+    script = os.path.join(tmpdir, "auto-test-stop-signal.py")
+    with open(script, "w") as f:
+        f.write(
+            "import signal, sys, time\n"
+            # Windows delivers CTRL_BREAK_EVENT as SIGBREAK, not as SIGINT.
+            "if hasattr(signal, 'SIGBREAK'):\n"
+            "\tsignal.signal(signal.SIGBREAK, signal.default_int_handler)\n"
+            "try:\n"
+            "\twhile True:\n"
+            "\t\ttime.sleep(0.1)\n"
+            "except KeyboardInterrupt:\n"
+            "\tprint('+++++ stopped cleanly', flush=True)\n"
+        )
+
+    trick = AutoRestartTrick([sys.executable, script])
+    trick.start()
+    time.sleep(2)
+    trick.stop()
+
+    cap = capfd.readouterr()
+    assert "+++++ stopped cleanly" in cap.out
+
+
 def test_shell_command_wait_for_completion(tmpdir, capfd):
     script = make_dummy_script(tmpdir, n=1)
     command = f"{sys.executable} {script}"


### PR DESCRIPTION
Fixes the Windows half of #1221.

`AutoRestartTrick` documents "stop the subprocess with this signal (default SIGINT)", but on
Windows `os.kill()` maps everything except `CTRL_C_EVENT`/`CTRL_BREAK_EVENT` to
`TerminateProcess()`. The child is hard killed with the signal number as its exit code, so no
`atexit` or `finally` cleanup runs. Separately, `preexec_fn=os.setsid` is a no-op on Windows, so
the child was never in its own process group and grandchildren were orphaned on every restart.

The change starts the child with `CREATE_NEW_PROCESS_GROUP` and sends `CTRL_BREAK_EVENT`. POSIX
is untouched: both kwargs degrade to current behaviour there. `CTRL_C_EVENT` is not usable,
since a group created with `CREATE_NEW_PROCESS_GROUP` has CTRL+C disabled; measured on 3.14.7 the
call succeeds and is then silently ignored.

Measured against `eb233b8`, three identical runs, child spawning a grandchild:

| | before | after |
|---|---|---|
| child exit code | `2` (the signal number) | `0` |
| signal delivered | False | True |
| `finally` ran | False | True |
| `atexit` ran | False | True |
| grandchild leaked | True | False |

One qualification: that table is for a child that handles `SIGBREAK`, which is how Windows
surfaces `CTRL_BREAK_EVENT`. It does not arrive as `SIGINT`. A child with no handler exits via
`STATUS_CONTROL_C_EXIT` without running cleanup, so only the grandchild row holds unconditionally.

Not verified: how a console Ctrl+C now reaches the child. My interactive test was inconclusive for
both the fixed and unfixed build, so I am claiming nothing about it.

Windows 11 / 3.14.7: watchmedo 54 passed + 2 xpassed before, 55 + 2 after. Full `tests/` 163/2
before, 164/2 after, same two pre-existing failures (#1128, #1206). ruff and
`mypy --platform linux` clean.
