### PR TITLE
Resolve "Drop the versionless License :: classifier now that license is a valid SPDX expression"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,6 @@ setup(
         "Environment :: Console",
         "Intended Audience :: Developers",
         "Intended Audience :: System Administrators",
-        "License :: OSI Approved :: Apache Software License",
         "Natural Language :: English",
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS :: MacOS X",


### PR DESCRIPTION
Dropping the deprecated classifier.

Tested the change using by creating the SBOM as demonstrated in the issue and observing the absence of the legacy classifier.

Closes #1224 