### PR TITLE
test: pin that the observer marks every queued item done

### DIFF
--- a/tests/test_observers_api.py
+++ b/tests/test_observers_api.py
@@ -92,3 +92,27 @@ def test_observer_basic():
     observer.unschedule_all()
     observer.stop()
     observer.join()
+
+
+def test_observer_marks_every_queued_item_done():
+    """The observer must mark both the dispatched event and the stop sentinel done.
+
+    ``BaseObserver.dispatch_events()`` calls ``event_queue.task_done()`` on the
+    stop-sentinel path as well as after dispatching. Without the sentinel call a
+    caller's ``event_queue.join()`` never returns, and nothing else here notices:
+    the other tests only join the *thread*, which stops either way.
+    """
+    observer = BaseObserver(EventEmitter)
+    handler = LoggingEventHandler()
+
+    watch = observer.schedule(handler, "/foobar", recursive=True)
+    observer.event_queue.put((FileModifiedEvent("/foobar"), watch))
+    observer.start()
+    time.sleep(1)
+    observer.unschedule_all()
+    observer.stop()
+    observer.join()
+
+    # Asserted rather than calling event_queue.join(), which would hang the run
+    # instead of failing if either task_done() goes missing.
+    assert observer.event_queue.unfinished_tasks == 0


### PR DESCRIPTION
Follow-up to #1159. That PR added `event_queue.task_done()` to the stop-sentinel branch of `BaseObserver.dispatch_events`, so a caller's `event_queue.join()` returns after stop. Nothing asserts it: the existing tests join the dispatcher *thread*, which stops either way, so removing that line leaves the whole suite green.

This puts one event, runs the observer, stops it, and asserts the queue has no unfinished tasks left, covering both `task_done()` calls.

It asserts on `unfinished_tasks` rather than calling `event_queue.join()`, which would hang the run instead of failing if either call went missing.

<details><summary>Verified by removing the sentinel call</summary>

```
assert observer.event_queue.unfinished_tasks == 0
E   assert 1 == 0
1 failed, 7 passed
```

Restored: `8 passed`. Full suite on Windows 11 / CPython 3.13.13, master `de59c86`:

```
before  2 failed, 109 passed, 14 skipped
after   2 failed, 110 passed, 14 skipped
```

Same two failures either way, both pre-existing on native Windows:
`test_renaming_top_level_directory` and `test_move_nested_subdirectories_on_windows`.

`ruff format --check` clean. `ruff check` reports only `CPY001`, which the file already had.
</details>

Test-only, no source change.
