### PR TITLE
fix(windows): decode event file names as UTF-16LE

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -14,6 +14,7 @@ Changelog
 
 **Other Changes**
 
+- [windows] Event file names are decoded as UTF-16LE, so a name starting with U+FEFF or U+FFFE no longer reports the wrong path. (`#1228 <https://github.com/gorakhargosh/watchdog/pull/1228>`__)
 - [windows] Changing only the case of a name no longer emits a deletion event on top of the move event. (`#752 <https://github.com/gorakhargosh/watchdog/issues/752>`__)
 - [bsd] Do not let a ``PermissionError`` raised while registering a kevent kill the emitter thread. (`#1115 <https://github.com/gorakhargosh/watchdog/issues/1115>`__)
 - [core] Add context manager support to ``Observer`` class. The observer can now be used with a ``with`` statement for automatic start/stop management. (`#1090 <https://github.com/gorakhargosh/watchdog/pull/1149>`__)

--- a/src/watchdog/observers/winapi.py
+++ b/src/watchdog/observers/winapi.py
@@ -269,7 +269,10 @@ def _parse_event_buffer(read_buffer: bytes) -> list[tuple[int, str]]:
         fni = ctypes.cast(read_buffer, LPFNI)[0]  # type: ignore[arg-type]
         ptr = ctypes.addressof(fni) + FileNotifyInformation.FileName.offset
         filename = ctypes.string_at(ptr, fni.FileNameLength)
-        results.append((fni.Action, filename.decode("utf-16")))
+        # ReadDirectoryChangesW writes UTF-16LE without a byte-order mark, so the
+        # "utf-16" codec would eat a leading U+FEFF and let a leading U+FFFE flip
+        # the byte order of the rest of the name.
+        results.append((fni.Action, filename.decode("utf-16-le")))
         num_to_skip = fni.NextEntryOffset
         if num_to_skip <= 0:
             break

--- a/tests/test_observers_winapi.py
+++ b/tests/test_observers_winapi.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import os.path
+import struct
 from queue import Empty, Queue
 from time import sleep
 
@@ -25,6 +26,7 @@ from watchdog.observers.winapi import (
     FILE_ACTION_RENAMED_OLD_NAME,
     WinAPINativeEvent,
     _drop_case_only_rename_deletions,
+    _parse_event_buffer,
 )
 
 SLEEP_TIME = 2
@@ -171,3 +173,22 @@ def test_drop_case_only_rename_deletions():
 )
 def test_drop_case_only_rename_deletions_keeps_real_deletions(events):
     assert _drop_case_only_rename_deletions(events) == events
+
+
+@pytest.mark.parametrize(
+    "file_name",
+    [
+        "plain.txt",
+        # U+FEFF is a legal file name character that "utf-16" eats as a byte-order
+        # mark, silently reporting the event against a different, possibly existing,
+        # file. U+FFFE flips the byte order the rest of the name is decoded with.
+        "\ufeffhello.txt",
+        "\ufffehello.txt",
+    ],
+)
+def test_parse_event_buffer_reads_the_whole_file_name(file_name):
+    """ReadDirectoryChangesW writes UTF-16LE without a byte-order mark."""
+    name = file_name.encode("utf-16-le")
+    buffer = struct.pack("<III", 0, FILE_ACTION_CREATED, len(name)) + name
+
+    assert _parse_event_buffer(buffer) == [(FILE_ACTION_CREATED, file_name)]


### PR DESCRIPTION
`_parse_event_buffer` decodes `FILE_NOTIFY_INFORMATION.FileName` with `.decode("utf-16")`. `ReadDirectoryChangesW` writes UTF-16LE with no byte-order mark, but the `"utf-16"` codec sniffs for one: a name beginning U+FEFF loses that character, and a name beginning U+FFFE decodes big-endian. Both are legal NTFS file name characters, so the emitter reports a `src_path` that is not the file that changed. In the U+FEFF case that path can name a different, existing file in the same directory.

Measured against the real filesystem on the unpatched tree, where `os.listdir` returns the correct name in both cases:

```
file created as  \ufeffhello.txt   ->  event src_path 'hello.txt'
file created as  \ufffehello.txt   ->  event src_path decoded big-endian, unusable
```

The added test builds a synthetic `FILE_NOTIFY_INFORMATION` buffer. On the unpatched source both cases fail while the `plain.txt` case passes, so the harness is sound. `tests/test_observers_winapi.py`: 9 passed.

Full suite on Windows 11, CPython 3.13.5: 2 failed, 112 passed, 14 skipped. Both failures are `test_emitter.py::test_renaming_top_level_directory` and `test_move_nested_subdirectories_on_windows`, which fail identically at `de59c86` with this change reverted.

The open draft #1156 refactors this function and carries `decode("utf-16")` to two new call sites, so if that lands first the codec change needs applying at both.
