### PR TITLE
docs(events): note that open and close events are inotify-only

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -14,6 +14,7 @@ Changelog
 
 **Other Changes**
 
+- [docs] Note that ``FileClosedEvent``, ``FileClosedNoWriteEvent`` and ``FileOpenedEvent``, and their ``on_closed()``, ``on_closed_no_write()`` and ``on_opened()`` handlers, are emitted only by ``InotifyObserver`` on Linux. (`#1235 <https://github.com/gorakhargosh/watchdog/pull/1235>`__)
 - [windows] Event file names are decoded as UTF-16LE, so a name starting with U+FEFF or U+FFFE no longer reports the wrong path. (`#1228 <https://github.com/gorakhargosh/watchdog/pull/1228>`__)
 - [windows] Changing only the case of a name no longer emits a deletion event on top of the move event. (`#752 <https://github.com/gorakhargosh/watchdog/issues/752>`__)
 - [bsd] Do not let a ``PermissionError`` raised while registering a kevent kill the emitter thread. (`#1115 <https://github.com/gorakhargosh/watchdog/issues/1115>`__)

--- a/src/watchdog/events.py
+++ b/src/watchdog/events.py
@@ -155,19 +155,28 @@ class FileMovedEvent(FileSystemMovedEvent):
 
 
 class FileClosedEvent(FileSystemEvent):
-    """File system event representing file close on the file system."""
+    """File system event representing file close on the file system.
+
+    Emitted only by ``InotifyObserver`` on Linux.
+    """
 
     event_type = EVENT_TYPE_CLOSED
 
 
 class FileClosedNoWriteEvent(FileSystemEvent):
-    """File system event representing an unmodified file close on the file system."""
+    """File system event representing an unmodified file close on the file system.
+
+    Emitted only by ``InotifyObserver`` on Linux.
+    """
 
     event_type = EVENT_TYPE_CLOSED_NO_WRITE
 
 
 class FileOpenedEvent(FileSystemEvent):
-    """File system event representing file close on the file system."""
+    """File system event representing file open on the file system.
+
+    Emitted only by ``InotifyObserver`` on Linux.
+    """
 
     event_type = EVENT_TYPE_OPENED
 
@@ -264,6 +273,8 @@ class FileSystemEventHandler:
     def on_closed(self, event: FileClosedEvent) -> None:
         """Called when a file opened for writing is closed.
 
+        Emitted only by ``InotifyObserver`` on Linux.
+
         :param event:
             Event representing file closing.
         :type event:
@@ -273,6 +284,8 @@ class FileSystemEventHandler:
     def on_closed_no_write(self, event: FileClosedNoWriteEvent) -> None:
         """Called when a file opened for reading is closed.
 
+        Emitted only by ``InotifyObserver`` on Linux.
+
         :param event:
             Event representing file closing.
         :type event:
@@ -281,6 +294,8 @@ class FileSystemEventHandler:
 
     def on_opened(self, event: FileOpenedEvent) -> None:
         """Called when a file is opened.
+
+        Emitted only by ``InotifyObserver`` on Linux.
 
         :param event:
             Event representing file opening.


### PR DESCRIPTION
`FileClosedEvent`, `FileClosedNoWriteEvent` and `FileOpenedEvent` are constructed only in `observers/inotify.py`. No other backend emits them:

```
$ grep -rn "FileClosedEvent(\|FileOpenedEvent(\|FileClosedNoWriteEvent(" src/
src/watchdog/observers/inotify.py:491,493,496
```

Their class docstrings and the `on_closed`, `on_closed_no_write` and `on_opened` handler docstrings say so without qualification, so someone reading the API reference writes an `on_closed` handler and it silently never fires on Windows, macOS, BSD or with `PollingObserver`. Confirmed here on Windows: watching a directory through a create, write, read and close delivered only `created` and `modified`.

The changelog already scopes these correctly, tagged `[inotify]` at lines 109 and 183. This just carries that into the docstrings a user actually reads.

Also corrects `FileOpenedEvent`, whose docstring read "representing file close on the file system".

Docs only, no behaviour change. `ruff check` and `ruff format --check` clean, `tests/test_events.py` 15 passing.

I have no Linux box, so the statement that inotify does emit these rests on reading `inotify.py` and on those changelog entries rather than on a run.
