### PR TITLE
fix(core): include follow_symlink in ObservedWatch equality

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -14,6 +14,7 @@ Changelog
 
 **Other Changes**
 
+- [core] ``ObservedWatch`` equality now includes ``follow_symlink``, so scheduling a path a second time with a different ``follow_symlink`` value no longer collapses onto the first watch and silently drops the request. (`#1262 <https://github.com/gorakhargosh/watchdog/pull/1262>`__)
 - [core] ``dispatch_events()`` no longer re-adds a watch that ``unschedule()`` removed, which leaked one ``_handlers`` entry per watch that had an event in flight. (`#1261 <https://github.com/gorakhargosh/watchdog/pull/1261>`__)
 - [docs] ``FileSystemEvent`` no longer claims to be immutable; its fields stay writable and the hash is derived from them, so mutating an event held in a dict or set strands it there. (`#1240 <https://github.com/gorakhargosh/watchdog/issues/1240>`__)
 - [docs] Note that ``FileClosedEvent``, ``FileClosedNoWriteEvent`` and ``FileOpenedEvent``, and their ``on_closed()``, ``on_closed_no_write()`` and ``on_opened()`` handlers, are emitted only by ``InotifyObserver`` on Linux. (`#1235 <https://github.com/gorakhargosh/watchdog/pull/1235>`__)

--- a/src/watchdog/observers/api.py
+++ b/src/watchdog/observers/api.py
@@ -90,9 +90,9 @@ class ObservedWatch:
         return self._event_filter
 
     @property
-    def key(self) -> tuple[str, bool, frozenset[type[FileSystemEvent]] | None]:
-        """A tuple key identifying the watch (path, recursive, event_filter)."""
-        return self.path, self.is_recursive, self.event_filter
+    def key(self) -> tuple[str, bool, frozenset[type[FileSystemEvent]] | None, bool]:
+        """A tuple key identifying the watch (path, recursive, event_filter, follow_symlink)."""
+        return self.path, self.is_recursive, self.event_filter, self.follow_symlink
 
     def __eq__(self, watch: object) -> bool:
         if not isinstance(watch, ObservedWatch):

--- a/tests/test_observers_api.py
+++ b/tests/test_observers_api.py
@@ -36,6 +36,48 @@ def test_observer__ne__():
     assert watch1.__ne__(watch_ne2)
 
 
+def test_observer__eq__ignores_follow_symlink():
+    """Two watches that differ only in ``follow_symlink`` must not compare equal.
+
+    ``ObservedWatch.key`` builds its tuple from ``path``, ``is_recursive`` and
+    ``event_filter`` only, omitting ``follow_symlink`` even though the latter is a
+    real constructor parameter stored on the instance. ``event_filter`` was
+    deliberately added to the key so that two watches on the same path with
+    different filters stay independent; ``follow_symlink`` should get the same
+    treatment, otherwise scheduling the same path twice with different
+    ``follow_symlink`` values collapses onto a single watch (see
+    ``test_observer_schedule_respects_second_follow_symlink`` below for the
+    resulting observer-level bug).
+    """
+    watch_no_follow = ObservedWatch("/foobar", recursive=True, follow_symlink=False)
+    watch_follow = ObservedWatch("/foobar", recursive=True, follow_symlink=True)
+
+    assert watch_no_follow != watch_follow
+    assert hash(watch_no_follow) != hash(watch_follow)
+
+
+def test_observer_schedule_respects_second_follow_symlink():
+    """A second ``schedule()`` call for the same path must honor its own follow_symlink.
+
+    Because ``ObservedWatch`` equality ignores ``follow_symlink``, scheduling
+    "/foobar" with ``follow_symlink=False`` and then again with
+    ``follow_symlink=True`` makes the second watch compare equal to the first.
+    ``BaseObserver.schedule()`` then treats an emitter as already existing for it
+    and never creates one for the ``follow_symlink=True`` request: the emitter
+    actually reachable from the returned watch still reports
+    ``follow_symlink=False``, silently dropping the caller's request.
+    """
+    observer = BaseObserver(EventEmitter)
+    handler = LoggingEventHandler()
+
+    watch_no_follow = observer.schedule(handler, "/foobar", recursive=True, follow_symlink=False)
+    watch_follow = observer.schedule(handler, "/foobar", recursive=True, follow_symlink=True)
+
+    assert len(observer.emitters) == 2
+    assert observer._emitter_for_watch[watch_no_follow].watch.follow_symlink is False  # noqa: SLF001
+    assert observer._emitter_for_watch[watch_follow].watch.follow_symlink is True  # noqa: SLF001
+
+
 def test_observer__repr__():
     observed_watch = ObservedWatch("/foobar", recursive=True)
     repr_str = "<ObservedWatch: path='/foobar', is_recursive=True>"

--- a/tests/test_observers_api.py
+++ b/tests/test_observers_api.py
@@ -39,7 +39,7 @@ def test_observer__ne__():
 def test_observer__eq__ignores_follow_symlink():
     """Two watches that differ only in ``follow_symlink`` must not compare equal.
 
-    ``ObservedWatch.key`` builds its tuple from ``path``, ``is_recursive`` and
+    ``ObservedWatch.key`` used to build its tuple from ``path``, ``is_recursive`` and
     ``event_filter`` only, omitting ``follow_symlink`` even though the latter is a
     real constructor parameter stored on the instance. ``event_filter`` was
     deliberately added to the key so that two watches on the same path with
@@ -59,7 +59,7 @@ def test_observer__eq__ignores_follow_symlink():
 def test_observer_schedule_respects_second_follow_symlink():
     """A second ``schedule()`` call for the same path must honor its own follow_symlink.
 
-    Because ``ObservedWatch`` equality ignores ``follow_symlink``, scheduling
+    Because ``ObservedWatch`` equality used to ignore ``follow_symlink``, scheduling
     "/foobar" with ``follow_symlink=False`` and then again with
     ``follow_symlink=True`` makes the second watch compare equal to the first.
     ``BaseObserver.schedule()`` then treats an emitter as already existing for it
@@ -74,8 +74,8 @@ def test_observer_schedule_respects_second_follow_symlink():
     watch_follow = observer.schedule(handler, "/foobar", recursive=True, follow_symlink=True)
 
     assert len(observer.emitters) == 2
-    assert observer._emitter_for_watch[watch_no_follow].watch.follow_symlink is False  # noqa: SLF001
-    assert observer._emitter_for_watch[watch_follow].watch.follow_symlink is True  # noqa: SLF001
+    assert not observer._emitter_for_watch[watch_no_follow].watch.follow_symlink  # noqa: SLF001
+    assert observer._emitter_for_watch[watch_follow].watch.follow_symlink  # noqa: SLF001
 
 
 def test_observer__repr__():


### PR DESCRIPTION
`ObservedWatch.key` builds its tuple from `path`, `is_recursive` and `event_filter`, omitting `follow_symlink` even though it is a constructor parameter stored on the instance. `event_filter` is in the key so two watches on one path with different filters stay independent; `follow_symlink` needs the same treatment.

Scheduling a path with `follow_symlink=False` and then again with `follow_symlink=True` makes the second watch compare equal to the first, so `schedule()` finds an emitter already present and never creates one for the second request. The emitter reachable from the returned watch still runs with `follow_symlink=False`, and nothing reports that the request was dropped.

Reverting only `api.py` and keeping the two new tests:

```
test_observer__eq__ignores_follow_symlink - AssertionError: assert <ObservedWatch: path='/foobar', is_recursive=True> != <ObservedWatch: path='/foobar', is_recursive=True>
test_observer_schedule_respects_second_follow_symlink - assert 1 == 2
```

Suite on this branch: 2 failed, 172 passed. Both failures are `test_emitter.py::test_renaming_top_level_directory` and `::test_move_nested_subdirectories_on_windows`, which also fail on clean master on this machine. `ruff check`, `ruff format --check` and `mypy src/watchdog/observers/api.py` are clean.
