### PR TITLE
docs: add observer context manager example

### DIFF
--- a/docs/source/api/observers_api.rst
+++ b/docs/source/api/observers_api.rst
@@ -29,4 +29,5 @@
 
     .. autoclass:: BaseObserver
        :members:
+       :special-members: __enter__, __exit__
        :show-inheritance:

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -22,6 +22,15 @@ Watchdog also includes built-in "tricks" (pre-implemented event handlers). For i
    :language: python
    :linenos:
 
+Observer Context Manager
+------------------------
+Use an observer as a context manager to start it on entry and automatically stop
+and join it on exit, including when an exception interrupts the loop:
+
+.. literalinclude:: examples/context_manager.py
+   :language: python
+   :linenos:
+
 Debouncing Events
 -----------------
 Text editors and build tools can emit several events for a single logical change. Use :class:`watchdog.utils.event_debouncer.EventDebouncer` to collect a burst of events and run an expensive action once the watched directory has been quiet for a short interval:

--- a/docs/source/examples/context_manager.py
+++ b/docs/source/examples/context_manager.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import logging
+import sys
+import time
+
+from watchdog.events import FileSystemEvent, FileSystemEventHandler
+from watchdog.observers import Observer
+
+logging.basicConfig(level=logging.INFO)
+
+
+class ChangeHandler(FileSystemEventHandler):
+    def on_any_event(self, event: FileSystemEvent) -> None:
+        logging.info("File system event: %s", event)
+
+
+path = sys.argv[1] if len(sys.argv) > 1 else "."
+
+event_handler = ChangeHandler()
+observer = Observer()
+observer.schedule(event_handler, path, recursive=True)
+
+with observer:
+    while True:
+        time.sleep(1)

--- a/src/watchdog/observers/api.py
+++ b/src/watchdog/observers/api.py
@@ -311,7 +311,10 @@ class BaseObserver(EventDispatcher):
         super().start()
 
     def __enter__(self) -> Self:
-        """Context manager entry. Starts the observer if not already running."""
+        """Context manager entry. Starts the observer if not already running.
+
+        See :ref:`examples` for a complete context manager example.
+        """
         if not self.is_alive():
             self.start()
         return self


### PR DESCRIPTION
## Summary

- add a runnable example using `Observer` as a context manager
- demonstrate automatic observer startup and cleanup when the loop exits
- include the example on the documentation Examples page

## Validation

- `python -m pytest tests/test_examples.py -q` (6 passed on Windows)
- `python -m ruff format --check docs/source/examples/context_manager.py`
- `python -m ruff check docs/source/examples/context_manager.py`
- `python -m mypy docs/source/examples/context_manager.py`
- `python -m sphinx -W --keep-going -b html docs/source docs/build/html`

Contributes to #1190 (Context Manager Example)