### PR TITLE
docs: add labeled multi-directory monitoring example

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -6,6 +6,26 @@ Examples
 ========
 This page showcases various complete, runnable examples demonstrating different features of the watchdog API.
 
+Monitoring Multiple Directories
+-------------------------------
+One :class:`watchdog.observers.Observer` can monitor several directories. Schedule
+a separate handler for each root and give it a label so events can be attributed
+to the correct watch, even when different roots contain files with the same name.
+The example logs the complete event, including the destination of a move.
+
+Pass existing directories as separate arguments, quoting paths that contain spaces.
+For example, from a checkout on Windows, macOS, or Linux::
+
+    python docs/source/examples/multiple_directories.py "input one" "input two"
+
+With no arguments, the example watches the current directory. Each watch includes
+subdirectories. Press :kbd:`Ctrl+C` to stop the observer and wait for its threads
+to finish. The example only logs events; it does not change the watched files.
+
+.. literalinclude:: examples/multiple_directories.py
+   :language: python
+   :linenos:
+
 Pattern Matching Filter
 -----------------------
 To filter file system events using glob patterns (for example, only observing changes to ``.py`` or ``.pyc`` files), you can use the :class:`watchdog.events.PatternMatchingEventHandler`:

--- a/docs/source/examples/multiple_directories.py
+++ b/docs/source/examples/multiple_directories.py
@@ -1,0 +1,45 @@
+"""Monitor several directories with one observer and a labeled handler per watch.
+
+Usage::
+
+    python multiple_directories.py "input one" "input two"
+
+Directories must already exist. With no arguments, watch the current directory.
+Press Ctrl+C to stop monitoring.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import time
+
+from watchdog.events import FileSystemEvent, FileSystemEventHandler
+from watchdog.observers import Observer
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+
+class LabeledEventHandler(FileSystemEventHandler):
+    def __init__(self, label: str) -> None:
+        self.label = label
+
+    def on_any_event(self, event: FileSystemEvent) -> None:
+        logging.info("[%s] %s", self.label, event)
+
+
+paths = sys.argv[1:] or ["."]
+observer = Observer()
+started = False
+try:
+    for path in paths:
+        observer.schedule(LabeledEventHandler(path), path, recursive=True)
+    observer.start()
+    started = True
+    while True:
+        time.sleep(1)
+finally:
+    # Also stop any emitters that started before another watch failed to start.
+    observer.stop()
+    if started:  # An observer thread cannot be joined before it has started.
+        observer.join()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
 import importlib.util
+import logging
+import runpy
 from pathlib import Path
-from unittest.mock import patch
+from queue import Queue
+from unittest.mock import call, patch
 
 import pytest
+
+from watchdog.events import FileCreatedEvent, FileMovedEvent, FileSystemEvent
+from watchdog.observers import Observer
 
 EXAMPLES_DIR = Path("docs/source/examples")
 EXAMPLES = [str(p) for p in sorted(EXAMPLES_DIR.glob("*.py")) if p.name != "__init__.py"]
@@ -23,3 +29,164 @@ def test_example(script_path: str) -> None:
         # This will run the script, trigger KeyboardInterrupt, and run the finally block
         with pytest.raises(KeyboardInterrupt):
             spec.loader.exec_module(module)
+
+
+def test_multiple_directories_schedules_both_watches() -> None:
+    script = str(EXAMPLES_DIR / "multiple_directories.py")
+    paths = ["input one", "input two"]
+    with (
+        patch("sys.argv", [script, *paths]),
+        patch("watchdog.observers.Observer") as observer_class,
+        patch("time.sleep", side_effect=KeyboardInterrupt),
+        pytest.raises(KeyboardInterrupt),
+    ):
+        runpy.run_path(script)
+
+    observer_class.assert_called_once_with()
+    observer = observer_class.return_value
+    schedules = observer.schedule.call_args_list
+    assert len(schedules) == 2
+    handlers = [scheduled.args[0] for scheduled in schedules]
+    assert handlers[0] is not handlers[1]
+    assert observer.mock_calls == [
+        call.schedule(handlers[0], paths[0], recursive=True),
+        call.schedule(handlers[1], paths[1], recursive=True),
+        call.start(),
+        call.stop(),
+        call.join(),
+    ]
+
+
+@pytest.mark.parametrize("paths", [[], ["input one"]])
+def test_multiple_directories_accepts_default_or_single_path(paths: list[str]) -> None:
+    script = str(EXAMPLES_DIR / "multiple_directories.py")
+    with (
+        patch("sys.argv", [script, *paths]),
+        patch("watchdog.observers.Observer") as observer_class,
+        patch("time.sleep", side_effect=KeyboardInterrupt),
+        pytest.raises(KeyboardInterrupt),
+    ):
+        runpy.run_path(script)
+    scheduled = observer_class.return_value.schedule.call_args_list
+    assert len(scheduled) == 1
+    assert scheduled[0].args[1] == (paths or ["."])[0]
+    assert scheduled[0].kwargs == {"recursive": True}
+
+
+def test_multiple_directories_labels_events(caplog: pytest.LogCaptureFixture) -> None:
+    script = str(EXAMPLES_DIR / "multiple_directories.py")
+    paths = ["input one", "input two"]
+    with (
+        patch("sys.argv", [script, *paths]),
+        patch("watchdog.observers.Observer") as observer_class,
+        patch("time.sleep", side_effect=KeyboardInterrupt),
+        pytest.raises(KeyboardInterrupt),
+    ):
+        runpy.run_path(script)
+
+    handlers = [scheduled.args[0] for scheduled in observer_class.return_value.schedule.call_args_list]
+    caplog.set_level(logging.INFO)
+    events = [FileCreatedEvent("same.txt"), FileMovedEvent("same.txt", "renamed.txt")]
+    for handler in handlers:
+        for event in events:
+            handler.dispatch(event)
+    assert caplog.messages == [f"[{path}] {event}" for path in paths for event in events]
+
+
+def test_multiple_directories_cleans_up_on_loop_error() -> None:
+    script = str(EXAMPLES_DIR / "multiple_directories.py")
+    error = RuntimeError("monitoring failed")
+    with (
+        patch("sys.argv", [script, "input one", "input two"]),
+        patch("watchdog.observers.Observer") as observer_class,
+        patch("time.sleep", side_effect=error),
+        pytest.raises(RuntimeError) as caught,
+    ):
+        runpy.run_path(script)
+    assert caught.value is error
+    assert observer_class.return_value.mock_calls[-2:] == [call.stop(), call.join()]
+
+
+@pytest.mark.parametrize("method", ["schedule", "start"])
+def test_multiple_directories_cleans_up_on_setup_error(method: str) -> None:
+    script = str(EXAMPLES_DIR / "multiple_directories.py")
+    error = OSError("watch setup failed")
+    with patch("sys.argv", [script, "input one", "input two"]), patch("watchdog.observers.Observer") as observer_class:
+        observer = observer_class.return_value
+        getattr(observer, method).side_effect = error
+        with pytest.raises(OSError, match="watch setup failed") as caught:
+            runpy.run_path(script)
+    assert caught.value is error
+    observer.stop.assert_called_once_with()
+    observer.join.assert_not_called()  # Thread.join cannot be called before a successful start.
+
+
+def test_multiple_directories_receives_native_events(tmp_path: Path) -> None:
+    script = str(EXAMPLES_DIR / "multiple_directories.py")
+    paths = [tmp_path / "input one", tmp_path / "input two"]
+    for path in paths:
+        path.mkdir()
+    observer = Observer()
+    received: Queue[tuple[str, FileSystemEvent]] = Queue()
+    emitters = []
+
+    def record_event(_format: str, label: str, event: FileSystemEvent) -> None:
+        received.put((label, event))
+
+    def create_files_and_wait(_seconds: float) -> None:
+        assert observer.is_alive()
+        emitters.extend(observer.emitters)
+        for path in paths:
+            (path / "same.txt").write_text("test event", encoding="utf-8")
+        pending = {str(path) for path in paths}
+        while pending:
+            label, event = received.get(timeout=5)
+            if isinstance(event, FileCreatedEvent) and Path(event.src_path).name == "same.txt":
+                pending.discard(label)
+        raise KeyboardInterrupt
+
+    try:
+        with (
+            patch("sys.argv", [script, *(str(path) for path in paths)]),
+            patch("watchdog.observers.Observer", return_value=observer),
+            patch("logging.info", side_effect=record_event),
+            patch("time.sleep", side_effect=create_files_and_wait),
+            pytest.raises(KeyboardInterrupt),
+        ):
+            runpy.run_path(script)
+        assert not observer.is_alive()
+        assert len(emitters) == 2
+        assert all(not emitter.is_alive() for emitter in emitters)
+    finally:
+        observer.stop()
+        if observer.is_alive():
+            observer.join(timeout=5)
+
+
+def test_multiple_directories_stops_a_partially_started_observer(tmp_path: Path) -> None:
+    script = str(EXAMPLES_DIR / "multiple_directories.py")
+    observer = Observer()
+    started = []
+    error = OSError("second watch could not start")
+
+    def partial_start() -> None:
+        emitter = next(iter(observer.emitters))
+        emitter.start()
+        started.append(emitter)
+        assert emitter.is_alive()
+        raise error
+
+    try:
+        with (
+            patch("sys.argv", [script, str(tmp_path)]),
+            patch("watchdog.observers.Observer", return_value=observer),
+            patch.object(observer, "start", side_effect=partial_start),
+            pytest.raises(OSError, match="second watch could not start") as caught,
+        ):
+            runpy.run_path(script)
+        assert caught.value is error
+        assert len(started) == 1
+        assert not started[0].is_alive()
+        assert not observer.is_alive()
+    finally:
+        observer.stop()


### PR DESCRIPTION
## Summary

Contributes to #1190 (Multi-Directory Monitoring Example).

Adds the approved example showing one `Observer` monitoring multiple directories, with a separate labeled handler for each watch. The complete event is logged, including move destinations. Paths with spaces work as separate quoted arguments; no arguments defaults to the current directory.

The example is linked with `literalinclude` and picked up by the existing automatic example-test discovery. Cleanup covers both normal interruption and partial startup failure. No Watchdog library source, dependency, or workflow changes.

## Tests

Acceptance tests were written before the script. The first failed because the example did not exist; all nine contract cases were then added before implementation. They cover schedules, labels, defaults, error propagation, stop/join, real events from two temporary folders, and a real emitter that starts before an injected startup failure.

Two negative controls in a separate checkout failed as intended: omit the second watch, and remove labels from the output. Restoring the script made both tests pass.

## Executed verification

Python 3.13.15, with the repository's pinned test/quality dependencies:

- `python -m pytest tests/test_examples.py -q --tb=short`: **15 passed** on native Windows.
- `python -m pytest tests -q -rs --tb=short`: **184 passed, 13 skipped, 1 xpassed** on Windows; **200 passed, 7 skipped** in a non-root Linux container on Docker Desktop's WSL 2 backend with networking disabled.
- `python -m ruff format --check docs/source/examples src tests` and `python -m ruff check src docs/source/examples tests`: passed on both.
- `python -m mypy docs/source/examples`: passed on both. The general `mypy src` and all four platform-specific checks from `tox.ini` passed in the Linux container. The prescribed Windows-backend check also passed natively.
- `python -m sphinx -aEWnb html docs/source docs/build/html`: passed on Windows; verified the new section and included script in the generated HTML.
- `python -m build --wheel`, `python -m pip check`, and `git diff --check`: passed.

The new tests are not skipped on either platform. Existing platform-specific/optional skips are unchanged from the baseline. Windows' existing non-strict xfail for subprocess termination passes unexpectedly both before and after.

Baseline caveat: blanket `mypy src` on native Windows reports the same 11 existing platform-specific errors (unused ignores in `winapi.py`, POSIX-only `os` attributes, and `select.POLLIN`). No source edits or new suppressions were made for those; the repository's Linux quality commands and prescribed Windows-backend command pass. Only Python 3.13.15 was run locally; other interpreters/macOS/BSD execution are not claimed.

AI assistance was used for implementation and verification. All results above are from executed checks.

The existing workflow skips the OS/Python test matrix for `docs:` PRs; the full-suite results above are local executions, not a claim that the hosted matrix ran. Quality/documentation CI status is reported separately by GitHub.
