### PR TITLE
docs: add custom Trick subclass example

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -37,3 +37,13 @@ A common task is to keep a busy directory (such as a ``Downloads`` folder) tidy 
 .. literalinclude:: examples/file_organizer.py
    :language: python
    :linenos:
+
+Custom Trick Subclass
+----------------------
+
+You can build your own long-running handler by subclassing :class:`watchdog.tricks.Trick` (rather than :class:`watchdog.events.FileSystemEventHandler` directly). Since ``Trick`` already extends ``PatternMatchingEventHandler`` and exposes ``generate_yaml()`` for scaffolding, this approach also allows the handler to be declared in a ``watchmedo`` tricks YAML file. Here is an example that tallies filesystem events by type:
+
+.. literalinclude:: examples/custom_trick.py
+    :language: python
+    :linenos:
+

--- a/docs/source/examples/custom_trick.py
+++ b/docs/source/examples/custom_trick.py
@@ -1,0 +1,47 @@
+import logging
+import sys
+import time
+
+from watchdog.events import FileSystemEvent
+from watchdog.observers import Observer
+from watchdog.tricks import Trick
+
+logging.basicConfig(level=logging.INFO)
+
+
+class FileCountTrick(Trick):
+    """A custom Trick subclass that keeps a running tally of filesystem
+    events by type (created, deleted, modified, moved) and logs the
+    counters every time a new event is observed.
+
+    Subclassing Trick (rather than FileSystemEventHandler directly) means
+    this handler can also be declared in a watchmedo tricks YAML file,
+    since Trick already extends PatternMatchingEventHandler and exposes
+    generate_yaml() for scaffolding that config.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.counters = {
+            "created": 0,
+            "deleted": 0,
+            "modified": 0,
+            "moved": 0,
+            "other": 0,
+        }
+
+    def on_any_event(self, event: FileSystemEvent) -> None:
+        self.counters[event.event_type] = self.counters.get(event.event_type, 0) + 1
+        logging.info("Event counters: %s", self.counters)
+
+
+event_handler = FileCountTrick(ignore_directories=True)
+observer = Observer()
+observer.schedule(event_handler, sys.argv[1], recursive=True)
+observer.start()
+try:
+    while True:
+        time.sleep(1)
+finally:
+    observer.stop()
+    observer.join()


### PR DESCRIPTION
Adds a new documentation example demonstrating how to build a custom event handler by subclassing `watchdog.tricks.Trick` instead of `FileSystemEventHandler` directly.

Since `Trick` already extends `PatternMatchingEventHandler` and exposes `generate_yaml()`, subclassing it (rather than `FileSystemEventHandler`) means the resulting handler can also be declared in a `watchmedo` tricks YAML file. The example (`FileCountTrick`) keeps a running tally of filesystem events by type (created, deleted, modified, moved) and logs the counters whenever a new event is observed.

Changes:
- Add `docs/source/examples/custom_trick.py` with the `FileCountTrick` example.
- Add a "Custom Trick Subclass" section to `docs/source/examples.rst` documenting the new example.

Related to #1190.