### PR TITLE
docs: add asyncio event loop example

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -37,3 +37,11 @@ A common task is to keep a busy directory (such as a ``Downloads`` folder) tidy 
 .. literalinclude:: examples/file_organizer.py
    :language: python
    :linenos:
+
+Asyncio Integration
+-------------------
+Event handlers are called on the observer thread, so an asynchronous application cannot use them to drive its event loop directly. Passing each event to :meth:`asyncio.loop.call_soon_threadsafe` moves it onto the loop thread, where an :class:`asyncio.Queue` makes it available to coroutines:
+
+.. literalinclude:: examples/asyncio_integration.py
+   :language: python
+   :linenos:

--- a/docs/source/examples/asyncio_integration.py
+++ b/docs/source/examples/asyncio_integration.py
@@ -1,0 +1,57 @@
+"""Consume watched filesystem events from an asyncio event loop.
+
+The observer calls event handlers on its own thread, while an
+:class:`asyncio.Queue` may only be used from the event loop thread. Handing
+each event to the loop bridges the two, so asynchronous code can ``await``
+filesystem events like any other source of work.
+
+Usage::
+
+    python asyncio_integration.py [path]
+
+The directory to watch defaults to the current directory.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+
+from watchdog.events import FileSystemEvent, FileSystemEventHandler
+from watchdog.observers import Observer
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s", datefmt="%H:%M:%S")
+
+
+class AsyncioEventHandler(FileSystemEventHandler):
+    def __init__(self, loop: asyncio.AbstractEventLoop, queue: asyncio.Queue[FileSystemEvent]) -> None:
+        self.loop = loop
+        self.queue = queue
+
+    def on_any_event(self, event: FileSystemEvent) -> None:
+        # Runs on the observer thread, where the queue cannot be touched safely.
+        # Let the event loop perform the put on its own thread instead.
+        self.loop.call_soon_threadsafe(self.queue.put_nowait, event)
+
+
+async def watch(path: str) -> None:
+    """Log every filesystem event, awaiting them as the observer reports them."""
+    queue: asyncio.Queue[FileSystemEvent] = asyncio.Queue()
+    event_handler = AsyncioEventHandler(asyncio.get_running_loop(), queue)
+
+    observer = Observer()
+    observer.schedule(event_handler, path, recursive=True)
+    observer.start()
+    try:
+        while True:
+            event = await queue.get()
+            logging.info("Received %s", event)
+    finally:
+        observer.stop()
+        observer.join()
+
+
+path = sys.argv[1] if len(sys.argv) > 1 else "."
+
+asyncio.run(watch(path))

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -12,8 +12,11 @@ EXAMPLES = [str(p) for p in sorted(EXAMPLES_DIR.glob("*.py")) if p.name != "__in
 
 @pytest.mark.parametrize("script_path", EXAMPLES)
 def test_example(script_path: str) -> None:
-    # Mock sys.argv to supply the path parameter, and time.sleep to exit the loop
-    with patch("sys.argv", [script_path, "."]), patch("time.sleep", side_effect=KeyboardInterrupt):
+    # Mock sys.argv to supply the path parameter, and the call each example blocks
+    # on to exit the loop: time.sleep, or asyncio.Queue.get for asynchronous ones
+    argv = [script_path, "."]
+    stop = KeyboardInterrupt
+    with patch("sys.argv", argv), patch("time.sleep", side_effect=stop), patch("asyncio.Queue.get", side_effect=stop):
         # Load and execute the module dynamically
         spec = importlib.util.spec_from_file_location("example_module", script_path)
         assert spec is not None


### PR DESCRIPTION
Adds a real-world example to the [Examples page](https://python-watchdog.readthedocs.io/en/latest/examples.html): bridging watchdog events into an `asyncio` event loop so asynchronous code can consume them with `await`.
[https://github.com/gorakhargosh/watchdog/issues/1190]

Event handlers run on the observer thread, but `asyncio.Queue` may only be used from the loop thread. Filling the queue straight from a handler is unsafe and, more visibly, does not wake a sleeping loop — awaited events then arrive only when unrelated activity happens to wake it, or not at all. The example hands each event to `loop.call_soon_threadsafe()`, which both transfers it safely and wakes the loop.

- `docs/source/examples/asyncio_integration.py` — the self-contained script, named so it does not shadow the stdlib `asyncio` module when run directly.
- `docs/source/examples.rst` — new "Asyncio Integration" section with `literalinclude`.
- `tests/test_examples.py` — the harness interrupts each example at the call it blocks on. This one blocks on `await queue.get()` rather than `time.sleep()`, so `asyncio.Queue.get` is patched alongside it; without that the example would hang CI. The other examples are unaffected, as none of them use `asyncio.Queue`.

## Verification

- `pytest tests/test_examples.py` → 6 passed (includes `asyncio_integration.py`; the other 5 still pass).
- Rest of the suite → 128 passed, 10 skipped, plus `tests/test_0_watchmedo.py` 56 passed, 1 xpassed.
- `ruff format` (62 files unchanged) and `ruff check --fix --unsafe-fixes` clean; `mypy docs/source/examples` clean (ruff 0.7.1 / mypy 1.13.0, as pinned).
- `sphinx-build -aEWnb docs/source` succeeded; the `:meth:` and `:class:` references resolve to docs.python.org.
- End-to-end smoke test on a temp dir: create, modify, rename and delete each reached the async consumer, and SIGINT stopped and joined the observer without hanging.

Checks were run on macOS with Python 3.14.

Contributes to #1190 (Asyncio / Event Loop Integration Example)
