### PR TITLE
docs: add shell command trick example

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -22,6 +22,14 @@ Watchdog also includes built-in "tricks" (pre-implemented event handlers). For i
    :language: python
    :linenos:
 
+Shell Command Trick
+-------------------
+The :class:`watchdog.tricks.ShellCommandTrick` can execute a shell command when matching file system events occur. The command supports template variables such as the event type, object type, and source path:
+
+.. literalinclude:: examples/shell_command.py
+   :language: python
+   :linenos:
+
 Debouncing Events
 -----------------
 Text editors and build tools can emit several events for a single logical change. Use :class:`watchdog.utils.event_debouncer.EventDebouncer` to collect a burst of events and run an expensive action once the watched directory has been quiet for a short interval:

--- a/docs/source/examples/shell_command.py
+++ b/docs/source/examples/shell_command.py
@@ -1,0 +1,35 @@
+"""Execute a shell command when matching file system events occur.
+
+Usage::
+
+    python shell_command.py [path]
+
+The directory to watch defaults to the current directory.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+
+from watchdog.observers import Observer
+from watchdog.tricks import ShellCommandTrick
+
+path = sys.argv[1] if len(sys.argv) > 1 else "."
+
+event_handler = ShellCommandTrick(
+    "echo 'Event: ${watch_event_type} ${watch_object}: ${watch_src_path}'",
+    patterns=["*.py"],
+    ignore_directories=True,
+    wait_for_process=True,
+)
+
+observer = Observer()
+observer.schedule(event_handler, path, recursive=True)
+observer.start()
+try:
+    while True:
+        time.sleep(1)
+finally:
+    observer.stop()
+    observer.join()


### PR DESCRIPTION
Adds a runnable ShellCommandTrick example to the examples documentation.

The example demonstrates:
- Executing a shell command on file system events
- Template variables such as event type, object type, and source path
- Pattern matching for Python files
- Ignoring directory events
- Waiting for the command to finish

Tests:
- python3 -m pytest tests/test_examples.py
- 6 passed
- git diff --check passed