### PR TITLE
fix(inotify): watch a directory moved into a recursively watched tree

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -14,6 +14,7 @@ Changelog
 
 **Other Changes**
 
+- [inotify] A directory moved into a recursively watched tree is now watched, so events happening inside it are no longer silently lost. (`#1094 <https://github.com/gorakhargosh/watchdog/issues/1094>`__)
 - Add support for Python 3.15 (`#1226 <https://github.com/gorakhargosh/watchdog/issues/1226>`__)
 - [core] ``ObservedWatch`` equality now includes ``follow_symlink``, so scheduling a path a second time with a different ``follow_symlink`` value no longer collapses onto the first watch and silently drops the request. (`#1262 <https://github.com/gorakhargosh/watchdog/pull/1262>`__)
 - [core] ``dispatch_events()`` no longer re-adds a watch that ``unschedule()`` removed, which leaked one ``_handlers`` entry per watch that had an event in flight. (`#1261 <https://github.com/gorakhargosh/watchdog/pull/1261>`__)

--- a/src/watchdog/observers/inotify.py
+++ b/src/watchdog/observers/inotify.py
@@ -236,6 +236,11 @@ class InotifyWatchGroup(WatchCallback):
                 move_dst_path = src_path
                 if move_src_path is not None:
                     self._move_watches(move_src_path, move_dst_path)
+                elif event.is_directory and self.is_recursive:
+                    # The source is outside the watched tree, so there are no
+                    # watches to move.  The emitter reports the arrival as a
+                    # creation, so watch the new subtree like a creation would.
+                    self._add_all_callbacks(src_path)
                 # TODO: When a directory from another part of the
                 #  filesystem is moved into a watched directory, this
                 #  will not generate events for the directory tree.

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -543,6 +543,33 @@ def test_move_nested_subdirectories(
             ec.add(DirModifiedEvent, "dir2/dir3")
 
 
+@pytest.mark.skipif(not platform.is_linux(), reason="Other platforms create another set of events for this test")
+def test_move_subdirectory_into_watched_directory(
+    p: P,
+    start_watching: StartWatching,
+    events_checker: EventsChecker,
+) -> None:
+    mkdir(p("watched"))
+    mkdir(p("outside/dir1/dir2"), parents=True)
+    start_watching(path=p("watched"))
+    mv(p("outside/dir1"), p("watched/dir1"))
+
+    # Drain the events reporting the arrival of the subtree.
+    with events_checker() as ec:
+        ec.allow_extra_events()
+
+    # The subtree came from outside the watched tree, but it is inside it now,
+    # so what happens in it must still be reported.
+    mkfile(p("watched/dir1/dir2", "a"))
+
+    with events_checker() as ec:
+        ec.add(FileCreatedEvent, "watched/dir1/dir2/a")
+        ec.add(DirModifiedEvent, "watched/dir1/dir2")
+        ec.add(FileOpenedEvent, "watched/dir1/dir2/a")
+        ec.add(FileClosedEvent, "watched/dir1/dir2/a")
+        ec.add(DirModifiedEvent, "watched/dir1/dir2")
+
+
 @pytest.mark.skipif(
     not platform.is_windows(),
     reason="Non-Windows create another set of events for this test",


### PR DESCRIPTION
## What this fixes

This answers the second problem reported on #1094, in [this comment by @jake-aspect](https://github.com/gorakhargosh/watchdog/issues/1094#issuecomment-2807848822) (2025-04-16), which had not been picked up:

> There's a second related problem here that isn't fixable by enabling `generate_full_events=True`. If I'm using a recursive Observer, and move a directory into the watched folder, nothing I do inside this folder is visible to the observer after the initial move.

It does **not** touch the headline question of that issue - whether `generate_full_events` should be the default, or how the API ought to expose it. That is a design decision for the maintainers and it is left alone here.

## What a user sees

Running his reproduction script unchanged, the two actions he says are never detected are the `rm .token` and `touch .newtoken` at the end, both inside the directory that was moved in. Handler output, before and after this change:

```
--- WITHOUT the fix ---                     --- WITH the fix ---
Created file: WATCHED/file                  Created file: WATCHED/file
Modified directory: WATCHED                 Modified directory: WATCHED
Opened file: WATCHED/file                   Opened file: WATCHED/file
Closed modified file: WATCHED/file          Closed modified file: WATCHED/file
Modified directory: WATCHED                 Modified directory: WATCHED
Deleted file: WATCHED/file                  Deleted file: WATCHED/file
Modified directory: WATCHED                 Modified directory: WATCHED
Created directory: WATCHED/moved            Created directory: WATCHED/moved
Modified directory: WATCHED                 Modified directory: WATCHED
Created directory: WATCHED/moved/subdir     Created directory: WATCHED/moved/subdir
Created file: WATCHED/moved/.token          Created file: WATCHED/moved/.token
Created file: WATCHED/moved/subdir/notebook Created file: WATCHED/moved/subdir/notebook
                                            Deleted file: WATCHED/moved/.token
        (nothing further, ever)             Created file: WATCHED/moved/.newtoken
                                            Opened file: WATCHED/moved/.newtoken
                                            Closed modified file: WATCHED/moved/.newtoken
```

The two runs are identical up to the move-in, and then the unfixed build goes silent for the rest of the process's life.

What makes this easy to miss is that the arrival *is* reported: `InotifyEmitter.build_and_queue_event()` translates the event into `DirCreatedEvent` plus `generate_sub_created_events()`, so the subtree looks watched, and it is not. `PollingObserver` on the same box reports everything, which is what makes this a defect in the inotify path rather than expected behaviour:

```
===== inotify: mv subtree INTO watched dir, then edit inside it
  after touching inside moved-in subtree:
      (nothing)

===== polling: same (control)
  after touching inside moved-in subtree:
      FileCreatedEvent watched/incoming/nested/new.txt
      DirModifiedEvent watched/incoming/nested
      DirCreatedEvent  watched/incoming/nested/deeper
```

An `mv` into a watched directory is the ordinary atomic-delivery pattern - it is what the dropbox directory in #1094 does - so this loses real events rather than exotic ones.

## Why it happens

`InotifyWatchGroup.on_event()` handles `IN_MOVED_TO` by asking `_source_for_move()` for the queued `IN_MOVED_FROM` partner, then moving the existing watches to the new path. That partner exists only when the directory came from somewhere inside the watched tree. When it comes from outside, `_source_for_move()` returns `None` by design - its own docstring says so - `_move_watches()` is skipped, and nothing takes its place. No inotify watch is added for the arriving directory or for anything under it.

The branch that *would* have added them is one line below, and it is unreachable for this event because `is_moved_to` already matched:

```python
elif event.is_moved_to:
    ...
elif event.is_create and event.is_directory and self.is_recursive:
    self._add_all_callbacks(src_path)   # a directory created in place gets watches; one moved in gets none
```

## Why this fix

A directory that arrives by `mv` from outside the tree is, from the watcher's point of view, a new directory, and the emitter already reports it as one. So it gets its watches the same way a directory created in place does: `_add_all_callbacks()` on the destination, in the one case where there is no source watch to move.

That reuses the existing code path instead of adding a second one - `_add_all_callbacks()` is what `_activate()` and the in-place-create branch already call. It adds watches only and queues no events, so the events reported at move-in time are unchanged; only the silence afterwards is fixed. The before/after columns above show that: they agree line for line until the point where the old behaviour stops.

The `TODO` comment on this branch is deliberately left in place, because it is still true: this restores the watches, but it does not synthesise create events for files that already existed inside the moved-in subtree.

## What I verified

On Linux, in a clean virtualenv, Python 3.13.14, against `325508d`:

| Gate | Baseline (clean tree) | With this change |
| --- | --- | --- |
| `python -m pytest` | 190 passed, 7 skipped, exit 0 | **191 passed, 7 skipped, exit 0** |
| `python -m ruff format src tests docs/source/examples` | 61 files unchanged, exit 0 | 61 files unchanged, exit 0 |
| `python -m ruff check --fix src tests docs/source/examples` | All checks passed, exit 0 | All checks passed, exit 0 |
| `python -m mypy src docs/source/examples` | 1 error, `docs/source/examples/file_organizer.py:49` | the same 1 error, unchanged |

The mypy error is pre-existing and sits in an example file this change does not touch. It was captured on the unmodified tree first, in the same session, so the comparison is like for like.

The new test is `tests/test_emitter.py::test_move_subdirectory_into_watched_directory`. On the unmodified tree it fails with an empty event queue - watchdog reports nothing at all - and it passes with the fix. It was run 10 times in a row for stability, and it asserts the exact ordered event sequence through the file's own `events_checker`, like its neighbours.

It is marked Linux-only. The behaviour ought to hold on every platform, but the surrounding tests show each platform produces a different event set for a move, and I have no macOS, Windows or BSD machine to derive those from. I would rather skip there than guess and hand you a flaky test. Nothing else here is platform-specific: the change is inside `inotify.py`, which no other emitter imports.

Two notes for the reviewer:

- The new test omits the `event_queue` fixture parameter that its 20 sibling tests in the file carry. They do not use it either - the fixture is a pure accessor - so it is dropped rather than requested and ignored. Happy to add it back if you would rather the file stayed uniform.
- `ponytail-review` was run against `325508d` and reports `Lean already. Ship.` (exit 0). Its one finding was that unused parameter, and it was cut rather than argued with. Nothing was kept against its advice.

Fixes the second problem reported in #1094.

I am new to open source, and this pull request was made with AI assistance.
