### PR TITLE
fix(inotify): watch new directories with filtered recursive events

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -14,6 +14,7 @@ Changelog
 
 **Other Changes**
 
+- [inotify] Keep watching newly created subdirectories when recursive watches filter out creation events. (`#990 <https://github.com/gorakhargosh/watchdog/issues/990>`__)
 - Add support for Python 3.15 (`#1226 <https://github.com/gorakhargosh/watchdog/issues/1226>`__)
 - [core] ``ObservedWatch`` equality now includes ``follow_symlink``, so scheduling a path a second time with a different ``follow_symlink`` value no longer collapses onto the first watch and silently drops the request. (`#1262 <https://github.com/gorakhargosh/watchdog/pull/1262>`__)
 - [core] ``dispatch_events()`` no longer re-adds a watch that ``unschedule()`` removed, which leaked one ``_handlers`` entry per watch that had an event in flight. (`#1261 <https://github.com/gorakhargosh/watchdog/pull/1261>`__)

--- a/src/watchdog/observers/inotify.py
+++ b/src/watchdog/observers/inotify.py
@@ -506,6 +506,9 @@ class InotifyEmitter(EventEmitter):
 
         # Always listen to delete self
         event_mask = InotifyConstants.IN_DELETE_SELF
+        if self.watch.is_recursive:
+            # New directories need watches even when creation events are filtered.
+            event_mask = Mask(event_mask | InotifyConstants.IN_CREATE)
 
         for cls in self._event_filter:
             if cls in {DirMovedEvent, FileMovedEvent}:

--- a/tests/test_inotify_emitter.py
+++ b/tests/test_inotify_emitter.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from queue import Queue
+
+import pytest
+
+from watchdog.utils import platform
+
+if not platform.is_linux():
+    pytest.skip("GNU/Linux only.", allow_module_level=True)
+
+from watchdog.events import FileDeletedEvent, FileMovedEvent, FileSystemEventHandler
+from watchdog.observers.inotify import InotifyObserver
+
+
+@pytest.mark.parametrize("recursive", [True, False])
+@pytest.mark.parametrize("create_after_start", [True, False])
+def test_filtered_events_in_subdirectory(tmp_path, recursive, create_after_start):
+    events = Queue()
+
+    class Handler(FileSystemEventHandler):
+        def on_any_event(self, event):
+            events.put(event)
+
+    directory = tmp_path / "subdirectory"
+    ready = tmp_path / "ready"
+    finished = tmp_path / "finished"
+    ready.touch()
+    finished.touch()
+    if not create_after_start:
+        directory.mkdir()
+
+    observer = InotifyObserver()
+    observer.schedule(
+        Handler(),
+        str(tmp_path),
+        recursive=recursive,
+        event_filter=[FileMovedEvent, FileDeletedEvent],
+    )
+    try:
+        observer.start()
+        if create_after_start:
+            directory.mkdir()
+
+        # The root deletion follows mkdir on the same inotify descriptor, so
+        # receiving it also waits for registration of the new directory watch.
+        ready.unlink()
+        assert events.get(timeout=5) == FileDeletedEvent(str(ready))
+
+        source = directory / "source"
+        destination = directory / "destination"
+        source.touch()
+        source.rename(destination)
+        destination.unlink()
+        finished.unlink()
+
+        if recursive:
+            assert events.get(timeout=5) == FileMovedEvent(str(source), str(destination))
+            assert events.get(timeout=5) == FileDeletedEvent(str(destination))
+        # This second root event waits for the preceding operations and also
+        # checks that the filter excluded their create/modify/open/close events.
+        assert events.get(timeout=5) == FileDeletedEvent(str(finished))
+        assert events.empty()
+    finally:
+        observer.stop()
+        observer.join(timeout=5)
+        assert not observer.is_alive()


### PR DESCRIPTION
Fixes #990.

A recursive observer filtered to file moves and deletions stops tracking below directories created after the observer starts. The optimized inotify mask leaves out `IN_CREATE`, so those directories never get their own watches.

Listen for creation events internally when the watch is recursive. The existing event-class filter still controls what reaches the handler, and non-recursive watches keep their current mask.

The regression test uses one filtered observer and two root-file deletions as synchronization points. It checks the exact move/delete sequence in a subdirectory, with controls for directories that already exist and for non-recursive watches. It does not add creation events to the requested filter or rely on an unfiltered observer.

Validation:

- Original source: the new recursive-directory case fails; the other three controls pass. With the fix, all four pass on Linux / Python 3.13.15.
- Linux suite: 194 passed, 6 skipped; the sudo mount/unmount test was explicitly deselected. The container's file-descriptor limit was set to 4096 for the existing test that opens 2048 files.
- Ruff lint/format checks pass for `src`, `tests`, and examples. `mypy src` and the Linux-specific type checks pass.
- The combined source/examples type check reports the same pre-existing `bytes | str` argument error in `docs/source/examples/file_organizer.py:49` on both the original source and this branch.
